### PR TITLE
 Fixed tooltip in first column of Lists widget not working

### DIFF
--- a/modules/system/assets/ui/js/list.rowlink.js
+++ b/modules/system/assets/ui/js/list.rowlink.js
@@ -78,7 +78,7 @@
             })
 
             $(this).addClass(options.linkedClass)
-            link.hide().after(link.html())
+            link.after(link.contents()).hide()
         })
 
         // Add Keyboard Navigation to list rows

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -4125,7 +4125,7 @@ $(this).not('.'+options.excludeClass).find('td').not('.'+options.excludeClass).c
 $(this).not('.'+options.excludeClass).on('keypress',function(e){if(e.key==='(Space character)'||e.key==='Spacebar'||e.key===' '){handleClick(e)
 return false}})
 $(this).addClass(options.linkedClass)
-link.hide().after(link.html())})
+link.after(link.contents()).hide()})
 $('tr.rowlink').attr('tabindex',0)}
 RowLink.DEFAULTS={target:'a',excludeClass:'nolink',linkedClass:'rowlink'}
 var old=$.fn.rowLink


### PR DESCRIPTION
Ref: https://github.com/wintercms/winter/commit/9866f5ce4fac514f5e95ad1e935dc8858863dc94

The fix that was reverted in the commit above created problems because `.children()` does not return text nodes. [jQuery docs](https://api.jquery.com/children/) suggest using [`.contents()`](https://api.jquery.com/contents/) to get all children including text and comment nodes.

cc @daftspunk you may have the [problem](https://github.com/wintercms/winter/commit/9866f5ce4fac514f5e95ad1e935dc8858863dc94#commitcomment-48182809) in your private development branch of October that I cannot check/fix