### PR TITLE
trigger a new ajaxRedirect event and handle it in the loading indicator

### DIFF
--- a/modules/system/assets/js/framework-min.js
+++ b/modules/system/assets/js/framework-min.js
@@ -69,8 +69,8 @@ var fieldElement=$form.find('[name="'+fieldName+'"], [name="'+fieldName+'[]"], [
 if(fieldElement.length>0){var _event=jQuery.Event('ajaxInvalidField')
 $(window).trigger(_event,[fieldElement.get(0),fieldName,fieldMessages,isFirstInvalidField])
 if(isFirstInvalidField){if(!_event.isDefaultPrevented())fieldElement.focus()
-isFirstInvalidField=false}}})},handleFlashMessage:function(message,type){},handleRedirectResponse:function(url){window.location.assign(url)
-$el.trigger('ajaxRedirected')},handleUpdateResponse:function(data,textStatus,jqXHR){var updatePromise=$.Deferred().done(function(){for(var partial in data){var selector=(options.update[partial])?options.update[partial]:partial
+isFirstInvalidField=false}}})},handleFlashMessage:function(message,type){},handleRedirectResponse:function(url){$(window).one('popstate',function(){$el.trigger('ajaxRedirected')})
+window.location.assign(url)},handleUpdateResponse:function(data,textStatus,jqXHR){var updatePromise=$.Deferred().done(function(){for(var partial in data){var selector=(options.update[partial])?options.update[partial]:partial
 if($.type(selector)=='string'&&selector.charAt(0)=='@'){$(selector.substring(1)).append(data[partial]).trigger('ajaxUpdate',[context,data,textStatus,jqXHR])}
 else if($.type(selector)=='string'&&selector.charAt(0)=='^'){$(selector.substring(1)).prepend(data[partial]).trigger('ajaxUpdate',[context,data,textStatus,jqXHR])}
 else{$(selector).trigger('ajaxBeforeReplace')

--- a/modules/system/assets/js/framework-min.js
+++ b/modules/system/assets/js/framework-min.js
@@ -70,7 +70,7 @@ if(fieldElement.length>0){var _event=jQuery.Event('ajaxInvalidField')
 $(window).trigger(_event,[fieldElement.get(0),fieldName,fieldMessages,isFirstInvalidField])
 if(isFirstInvalidField){if(!_event.isDefaultPrevented())fieldElement.focus()
 isFirstInvalidField=false}}})},handleFlashMessage:function(message,type){},handleRedirectResponse:function(url){window.location.assign(url)
-$el.trigger('ajaxRedirect')},handleUpdateResponse:function(data,textStatus,jqXHR){var updatePromise=$.Deferred().done(function(){for(var partial in data){var selector=(options.update[partial])?options.update[partial]:partial
+$el.trigger('ajaxRedirected')},handleUpdateResponse:function(data,textStatus,jqXHR){var updatePromise=$.Deferred().done(function(){for(var partial in data){var selector=(options.update[partial])?options.update[partial]:partial
 if($.type(selector)=='string'&&selector.charAt(0)=='@'){$(selector.substring(1)).append(data[partial]).trigger('ajaxUpdate',[context,data,textStatus,jqXHR])}
 else if($.type(selector)=='string'&&selector.charAt(0)=='^'){$(selector.substring(1)).prepend(data[partial]).trigger('ajaxUpdate',[context,data,textStatus,jqXHR])}
 else{$(selector).trigger('ajaxBeforeReplace')

--- a/modules/system/assets/js/framework-min.js
+++ b/modules/system/assets/js/framework-min.js
@@ -70,7 +70,7 @@ if(fieldElement.length>0){var _event=jQuery.Event('ajaxInvalidField')
 $(window).trigger(_event,[fieldElement.get(0),fieldName,fieldMessages,isFirstInvalidField])
 if(isFirstInvalidField){if(!_event.isDefaultPrevented())fieldElement.focus()
 isFirstInvalidField=false}}})},handleFlashMessage:function(message,type){},handleRedirectResponse:function(url){window.location.assign(url)
-$el.trigger('ajaxDone')},handleUpdateResponse:function(data,textStatus,jqXHR){var updatePromise=$.Deferred().done(function(){for(var partial in data){var selector=(options.update[partial])?options.update[partial]:partial
+$el.trigger('ajaxRedirect')},handleUpdateResponse:function(data,textStatus,jqXHR){var updatePromise=$.Deferred().done(function(){for(var partial in data){var selector=(options.update[partial])?options.update[partial]:partial
 if($.type(selector)=='string'&&selector.charAt(0)=='@'){$(selector.substring(1)).append(data[partial]).trigger('ajaxUpdate',[context,data,textStatus,jqXHR])}
 else if($.type(selector)=='string'&&selector.charAt(0)=='^'){$(selector.substring(1)).prepend(data[partial]).trigger('ajaxUpdate',[context,data,textStatus,jqXHR])}
 else{$(selector).trigger('ajaxBeforeReplace')

--- a/modules/system/assets/js/framework.combined-min.js
+++ b/modules/system/assets/js/framework.combined-min.js
@@ -69,8 +69,8 @@ var fieldElement=$form.find('[name="'+fieldName+'"], [name="'+fieldName+'[]"], [
 if(fieldElement.length>0){var _event=jQuery.Event('ajaxInvalidField')
 $(window).trigger(_event,[fieldElement.get(0),fieldName,fieldMessages,isFirstInvalidField])
 if(isFirstInvalidField){if(!_event.isDefaultPrevented())fieldElement.focus()
-isFirstInvalidField=false}}})},handleFlashMessage:function(message,type){},handleRedirectResponse:function(url){window.location.assign(url)
-$el.trigger('ajaxRedirected')},handleUpdateResponse:function(data,textStatus,jqXHR){var updatePromise=$.Deferred().done(function(){for(var partial in data){var selector=(options.update[partial])?options.update[partial]:partial
+isFirstInvalidField=false}}})},handleFlashMessage:function(message,type){},handleRedirectResponse:function(url){$(window).one('popstate',function(){$el.trigger('ajaxRedirected')})
+window.location.assign(url)},handleUpdateResponse:function(data,textStatus,jqXHR){var updatePromise=$.Deferred().done(function(){for(var partial in data){var selector=(options.update[partial])?options.update[partial]:partial
 if($.type(selector)=='string'&&selector.charAt(0)=='@'){$(selector.substring(1)).append(data[partial]).trigger('ajaxUpdate',[context,data,textStatus,jqXHR])}
 else if($.type(selector)=='string'&&selector.charAt(0)=='^'){$(selector.substring(1)).prepend(data[partial]).trigger('ajaxUpdate',[context,data,textStatus,jqXHR])}
 else{$(selector).trigger('ajaxBeforeReplace')

--- a/modules/system/assets/js/framework.combined-min.js
+++ b/modules/system/assets/js/framework.combined-min.js
@@ -70,7 +70,7 @@ if(fieldElement.length>0){var _event=jQuery.Event('ajaxInvalidField')
 $(window).trigger(_event,[fieldElement.get(0),fieldName,fieldMessages,isFirstInvalidField])
 if(isFirstInvalidField){if(!_event.isDefaultPrevented())fieldElement.focus()
 isFirstInvalidField=false}}})},handleFlashMessage:function(message,type){},handleRedirectResponse:function(url){window.location.assign(url)
-$el.trigger('ajaxDone')},handleUpdateResponse:function(data,textStatus,jqXHR){var updatePromise=$.Deferred().done(function(){for(var partial in data){var selector=(options.update[partial])?options.update[partial]:partial
+$el.trigger('ajaxRedirect')},handleUpdateResponse:function(data,textStatus,jqXHR){var updatePromise=$.Deferred().done(function(){for(var partial in data){var selector=(options.update[partial])?options.update[partial]:partial
 if($.type(selector)=='string'&&selector.charAt(0)=='@'){$(selector.substring(1)).append(data[partial]).trigger('ajaxUpdate',[context,data,textStatus,jqXHR])}
 else if($.type(selector)=='string'&&selector.charAt(0)=='^'){$(selector.substring(1)).prepend(data[partial]).trigger('ajaxUpdate',[context,data,textStatus,jqXHR])}
 else{$(selector).trigger('ajaxBeforeReplace')
@@ -212,7 +212,7 @@ $('[data-validate-for]',$this).removeClass('visible')
 $('[data-validate-error]',$this).removeClass('visible')})
 $(document).on('ajaxPromise','[data-request]',function(){var $target=$(this)
 if($target.data('attach-loading')!==undefined){$target.addClass(LOADER_CLASS).prop('disabled',true)}
-if($target.is('form')){$('[data-attach-loading]',$target).addClass(LOADER_CLASS).prop('disabled',true)}}).on('ajaxFail ajaxDone','[data-request]',function(){var $target=$(this)
+if($target.is('form')){$('[data-attach-loading]',$target).addClass(LOADER_CLASS).prop('disabled',true)}}).on('ajaxFail ajaxDone ajaxRedirect','[data-request]',function(){var $target=$(this)
 if($target.data('attach-loading')!==undefined){$target.removeClass(LOADER_CLASS).prop('disabled',false)}
 if($target.is('form')){$('[data-attach-loading]',$target).removeClass(LOADER_CLASS).prop('disabled',false)}})
 var StripeLoadIndicator=function(){var self=this
@@ -234,7 +234,7 @@ $(document).on('ajaxPromise','[data-request]',function(event){event.stopPropagat
 $.wn.stripeLoadIndicator.show()
 var $el=$(this)
 $(window).one('ajaxUpdateComplete',function(){if($el.closest('html').length===0)
-$.wn.stripeLoadIndicator.hide()})}).on('ajaxFail ajaxDone','[data-request]',function(event){event.stopPropagation()
+$.wn.stripeLoadIndicator.hide()})}).on('ajaxFail ajaxDone ajaxRedirect','[data-request]',function(event){event.stopPropagation()
 $.wn.stripeLoadIndicator.hide()})
 var FlashMessage=function(options,el){var
 options=$.extend({},FlashMessage.DEFAULTS,options),$element=$(el)

--- a/modules/system/assets/js/framework.combined-min.js
+++ b/modules/system/assets/js/framework.combined-min.js
@@ -70,7 +70,7 @@ if(fieldElement.length>0){var _event=jQuery.Event('ajaxInvalidField')
 $(window).trigger(_event,[fieldElement.get(0),fieldName,fieldMessages,isFirstInvalidField])
 if(isFirstInvalidField){if(!_event.isDefaultPrevented())fieldElement.focus()
 isFirstInvalidField=false}}})},handleFlashMessage:function(message,type){},handleRedirectResponse:function(url){window.location.assign(url)
-$el.trigger('ajaxRedirect')},handleUpdateResponse:function(data,textStatus,jqXHR){var updatePromise=$.Deferred().done(function(){for(var partial in data){var selector=(options.update[partial])?options.update[partial]:partial
+$el.trigger('ajaxRedirected')},handleUpdateResponse:function(data,textStatus,jqXHR){var updatePromise=$.Deferred().done(function(){for(var partial in data){var selector=(options.update[partial])?options.update[partial]:partial
 if($.type(selector)=='string'&&selector.charAt(0)=='@'){$(selector.substring(1)).append(data[partial]).trigger('ajaxUpdate',[context,data,textStatus,jqXHR])}
 else if($.type(selector)=='string'&&selector.charAt(0)=='^'){$(selector.substring(1)).prepend(data[partial]).trigger('ajaxUpdate',[context,data,textStatus,jqXHR])}
 else{$(selector).trigger('ajaxBeforeReplace')
@@ -212,7 +212,7 @@ $('[data-validate-for]',$this).removeClass('visible')
 $('[data-validate-error]',$this).removeClass('visible')})
 $(document).on('ajaxPromise','[data-request]',function(){var $target=$(this)
 if($target.data('attach-loading')!==undefined){$target.addClass(LOADER_CLASS).prop('disabled',true)}
-if($target.is('form')){$('[data-attach-loading]',$target).addClass(LOADER_CLASS).prop('disabled',true)}}).on('ajaxFail ajaxDone ajaxRedirect','[data-request]',function(){var $target=$(this)
+if($target.is('form')){$('[data-attach-loading]',$target).addClass(LOADER_CLASS).prop('disabled',true)}}).on('ajaxFail ajaxDone ajaxRedirected','[data-request]',function(){var $target=$(this)
 if($target.data('attach-loading')!==undefined){$target.removeClass(LOADER_CLASS).prop('disabled',false)}
 if($target.is('form')){$('[data-attach-loading]',$target).removeClass(LOADER_CLASS).prop('disabled',false)}})
 var StripeLoadIndicator=function(){var self=this
@@ -234,7 +234,7 @@ $(document).on('ajaxPromise','[data-request]',function(event){event.stopPropagat
 $.wn.stripeLoadIndicator.show()
 var $el=$(this)
 $(window).one('ajaxUpdateComplete',function(){if($el.closest('html').length===0)
-$.wn.stripeLoadIndicator.hide()})}).on('ajaxFail ajaxDone ajaxRedirect','[data-request]',function(event){event.stopPropagation()
+$.wn.stripeLoadIndicator.hide()})}).on('ajaxFail ajaxDone ajaxRedirected','[data-request]',function(event){event.stopPropagation()
 $.wn.stripeLoadIndicator.hide()})
 var FlashMessage=function(options,el){var
 options=$.extend({},FlashMessage.DEFAULTS,options),$element=$(el)

--- a/modules/system/assets/js/framework.extras.js
+++ b/modules/system/assets/js/framework.extras.js
@@ -105,7 +105,7 @@
                     .prop('disabled', true)
             }
         })
-        .on('ajaxFail ajaxDone ajaxRedirect', '[data-request]', function() {
+        .on('ajaxFail ajaxDone ajaxRedirected', '[data-request]', function() {
             var $target = $(this)
 
             if ($target.data('attach-loading') !== undefined) {
@@ -185,7 +185,7 @@
                     $.wn.stripeLoadIndicator.hide()
              })
         })
-        .on('ajaxFail ajaxDone ajaxRedirect', '[data-request]', function(event) {
+        .on('ajaxFail ajaxDone ajaxRedirected', '[data-request]', function(event) {
             event.stopPropagation()
             $.wn.stripeLoadIndicator.hide()
         })

--- a/modules/system/assets/js/framework.extras.js
+++ b/modules/system/assets/js/framework.extras.js
@@ -105,7 +105,7 @@
                     .prop('disabled', true)
             }
         })
-        .on('ajaxFail ajaxDone', '[data-request]', function() {
+        .on('ajaxFail ajaxDone ajaxRedirect', '[data-request]', function() {
             var $target = $(this)
 
             if ($target.data('attach-loading') !== undefined) {
@@ -185,7 +185,7 @@
                     $.wn.stripeLoadIndicator.hide()
              })
         })
-        .on('ajaxFail ajaxDone', '[data-request]', function(event) {
+        .on('ajaxFail ajaxDone ajaxRedirect', '[data-request]', function(event) {
             event.stopPropagation()
             $.wn.stripeLoadIndicator.hide()
         })

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -292,7 +292,7 @@ if (window.jQuery.request !== undefined) {
                 // so that the loading indicator for redirects that cause a browser to download 
                 // a file instead of leave the page will properly stop.
                 // @see https://github.com/octobercms/october/issues/5055
-                $el.trigger('ajaxDone')
+                $el.trigger('ajaxRedirect')
             },
 
             /*

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -292,7 +292,7 @@ if (window.jQuery.request !== undefined) {
                 // so that the loading indicator for redirects that cause a browser to download 
                 // a file instead of leave the page will properly stop.
                 // @see https://github.com/octobercms/october/issues/5055
-                $el.trigger('ajaxRedirect')
+                $el.trigger('ajaxRedirected')
             },
 
             /*

--- a/modules/system/assets/js/framework.js
+++ b/modules/system/assets/js/framework.js
@@ -287,12 +287,15 @@ if (window.jQuery.request !== undefined) {
              * Custom function, redirect the browser to another location
              */
             handleRedirectResponse: function(url) {
-                window.location.assign(url)
                 // Indicate that the AJAX request is finished if we're still on the current page
-                // so that the loading indicator for redirects that cause a browser to download 
-                // a file instead of leave the page will properly stop.
-                // @see https://github.com/octobercms/october/issues/5055
-                $el.trigger('ajaxRedirected')
+                // so that the loading indicator for redirects that just change the hash value of
+                // the URL instead of leaving the page will properly stop.
+                // @see https://github.com/octobercms/october/issues/2780
+                $(window).one('popstate', function () {
+                    $el.trigger('ajaxRedirected')
+                })
+
+                window.location.assign(url)
             },
 
             /*

--- a/modules/system/assets/ui/js/loader.base.js
+++ b/modules/system/assets/ui/js/loader.base.js
@@ -132,7 +132,7 @@
 
             indicatorContainer.loadIndicator(options)
         })
-        .on('ajaxFail ajaxDone ajaxRedirect', '[data-load-indicator]', function() {
+        .on('ajaxFail ajaxDone ajaxRedirected', '[data-load-indicator]', function() {
             $(this).closest('.loading-indicator-container').loadIndicator('hide')
         })
 

--- a/modules/system/assets/ui/js/loader.base.js
+++ b/modules/system/assets/ui/js/loader.base.js
@@ -132,7 +132,7 @@
 
             indicatorContainer.loadIndicator(options)
         })
-        .on('ajaxFail ajaxDone', '[data-load-indicator]', function() {
+        .on('ajaxFail ajaxDone ajaxRedirect', '[data-load-indicator]', function() {
             $(this).closest('.loading-indicator-container').loadIndicator('hide')
         })
 

--- a/modules/system/assets/ui/js/loader.cursor.js
+++ b/modules/system/assets/ui/js/loader.cursor.js
@@ -83,7 +83,7 @@
     $(document)
         .on('ajaxPromise', '[data-cursor-load-indicator]', function() {
             $.wn.cursorLoadIndicator.show()
-        }).on('ajaxFail ajaxDone ajaxRedirect', '[data-cursor-load-indicator]', function() {
+        }).on('ajaxFail ajaxDone ajaxRedirected', '[data-cursor-load-indicator]', function() {
             $.wn.cursorLoadIndicator.hide()
         })
 

--- a/modules/system/assets/ui/js/loader.cursor.js
+++ b/modules/system/assets/ui/js/loader.cursor.js
@@ -83,7 +83,7 @@
     $(document)
         .on('ajaxPromise', '[data-cursor-load-indicator]', function() {
             $.wn.cursorLoadIndicator.show()
-        }).on('ajaxFail ajaxDone', '[data-cursor-load-indicator]', function() {
+        }).on('ajaxFail ajaxDone ajaxRedirect', '[data-cursor-load-indicator]', function() {
             $.wn.cursorLoadIndicator.hide()
         })
 

--- a/modules/system/assets/ui/js/loader.stripe.js
+++ b/modules/system/assets/ui/js/loader.stripe.js
@@ -92,7 +92,7 @@
                 if ($el.closest('html').length === 0)
                     $.wn.stripeLoadIndicator.hide()
              })
-        }).on('ajaxFail ajaxDone ajaxRedirect', '[data-stripe-load-indicator]', function(event) {
+        }).on('ajaxFail ajaxDone ajaxRedirected', '[data-stripe-load-indicator]', function(event) {
             event.stopPropagation()
             $.wn.stripeLoadIndicator.hide()
         })

--- a/modules/system/assets/ui/js/loader.stripe.js
+++ b/modules/system/assets/ui/js/loader.stripe.js
@@ -92,7 +92,7 @@
                 if ($el.closest('html').length === 0)
                     $.wn.stripeLoadIndicator.hide()
              })
-        }).on('ajaxFail ajaxDone', '[data-stripe-load-indicator]', function(event) {
+        }).on('ajaxFail ajaxDone ajaxRedirect', '[data-stripe-load-indicator]', function(event) {
             event.stopPropagation()
             $.wn.stripeLoadIndicator.hide()
         })

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3614,7 +3614,7 @@ $(document).on('ajaxPromise','[data-load-indicator]',function(){var
 indicatorContainer=$(this).closest('.loading-indicator-container'),loadingText=$(this).data('load-indicator'),options={opaque:$(this).data('load-indicator-opaque'),centered:$(this).data('load-indicator-centered'),size:$(this).data('load-indicator-size')}
 if(loadingText)
 options.text=loadingText
-indicatorContainer.loadIndicator(options)}).on('ajaxFail ajaxDone','[data-load-indicator]',function(){$(this).closest('.loading-indicator-container').loadIndicator('hide')})}(window.jQuery);+function($){"use strict";if($.wn===undefined)
+indicatorContainer.loadIndicator(options)}).on('ajaxFail ajaxDone ajaxRedirect','[data-load-indicator]',function(){$(this).closest('.loading-indicator-container').loadIndicator('hide')})}(window.jQuery);+function($){"use strict";if($.wn===undefined)
 $.wn={}
 if($.oc===undefined)
 $.oc=$.wn
@@ -3639,7 +3639,7 @@ this.counter=0
 if(this.counter<=0){this.indicator.addClass('hide')
 $(window).off('.cursorLoadIndicator');}}
 $(document).ready(function(){$.wn.cursorLoadIndicator=new CursorLoadIndicator();})
-$(document).on('ajaxPromise','[data-cursor-load-indicator]',function(){$.wn.cursorLoadIndicator.show()}).on('ajaxFail ajaxDone','[data-cursor-load-indicator]',function(){$.wn.cursorLoadIndicator.hide()})}(window.jQuery);+function($){"use strict";if($.wn===undefined)
+$(document).on('ajaxPromise','[data-cursor-load-indicator]',function(){$.wn.cursorLoadIndicator.show()}).on('ajaxFail ajaxDone ajaxRedirect','[data-cursor-load-indicator]',function(){$.wn.cursorLoadIndicator.hide()})}(window.jQuery);+function($){"use strict";if($.wn===undefined)
 $.wn={}
 if($.oc===undefined)
 $.oc=$.wn
@@ -3668,7 +3668,7 @@ $(document).on('ajaxPromise','[data-stripe-load-indicator]',function(event){even
 $.wn.stripeLoadIndicator.show()
 var $el=$(this)
 $(window).one('ajaxUpdateComplete',function(){if($el.closest('html').length===0)
-$.wn.stripeLoadIndicator.hide()})}).on('ajaxFail ajaxDone','[data-stripe-load-indicator]',function(event){event.stopPropagation()
+$.wn.stripeLoadIndicator.hide()})}).on('ajaxFail ajaxDone ajaxRedirect','[data-stripe-load-indicator]',function(event){event.stopPropagation()
 $.wn.stripeLoadIndicator.hide()})}(window.jQuery);+function($){"use strict";var Popover=function(element,options){var $el=this.$el=$(element);this.options=options||{};this.arrowSize=15
 this.docClickHandler=null
 this.show()}

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3614,7 +3614,7 @@ $(document).on('ajaxPromise','[data-load-indicator]',function(){var
 indicatorContainer=$(this).closest('.loading-indicator-container'),loadingText=$(this).data('load-indicator'),options={opaque:$(this).data('load-indicator-opaque'),centered:$(this).data('load-indicator-centered'),size:$(this).data('load-indicator-size')}
 if(loadingText)
 options.text=loadingText
-indicatorContainer.loadIndicator(options)}).on('ajaxFail ajaxDone ajaxRedirect','[data-load-indicator]',function(){$(this).closest('.loading-indicator-container').loadIndicator('hide')})}(window.jQuery);+function($){"use strict";if($.wn===undefined)
+indicatorContainer.loadIndicator(options)}).on('ajaxFail ajaxDone ajaxRedirected','[data-load-indicator]',function(){$(this).closest('.loading-indicator-container').loadIndicator('hide')})}(window.jQuery);+function($){"use strict";if($.wn===undefined)
 $.wn={}
 if($.oc===undefined)
 $.oc=$.wn
@@ -3639,7 +3639,7 @@ this.counter=0
 if(this.counter<=0){this.indicator.addClass('hide')
 $(window).off('.cursorLoadIndicator');}}
 $(document).ready(function(){$.wn.cursorLoadIndicator=new CursorLoadIndicator();})
-$(document).on('ajaxPromise','[data-cursor-load-indicator]',function(){$.wn.cursorLoadIndicator.show()}).on('ajaxFail ajaxDone ajaxRedirect','[data-cursor-load-indicator]',function(){$.wn.cursorLoadIndicator.hide()})}(window.jQuery);+function($){"use strict";if($.wn===undefined)
+$(document).on('ajaxPromise','[data-cursor-load-indicator]',function(){$.wn.cursorLoadIndicator.show()}).on('ajaxFail ajaxDone ajaxRedirected','[data-cursor-load-indicator]',function(){$.wn.cursorLoadIndicator.hide()})}(window.jQuery);+function($){"use strict";if($.wn===undefined)
 $.wn={}
 if($.oc===undefined)
 $.oc=$.wn
@@ -3668,7 +3668,7 @@ $(document).on('ajaxPromise','[data-stripe-load-indicator]',function(event){even
 $.wn.stripeLoadIndicator.show()
 var $el=$(this)
 $(window).one('ajaxUpdateComplete',function(){if($el.closest('html').length===0)
-$.wn.stripeLoadIndicator.hide()})}).on('ajaxFail ajaxDone ajaxRedirect','[data-stripe-load-indicator]',function(event){event.stopPropagation()
+$.wn.stripeLoadIndicator.hide()})}).on('ajaxFail ajaxDone ajaxRedirected','[data-stripe-load-indicator]',function(event){event.stopPropagation()
 $.wn.stripeLoadIndicator.hide()})}(window.jQuery);+function($){"use strict";var Popover=function(element,options){var $el=this.$el=$(element);this.options=options||{};this.arrowSize=15
 this.docClickHandler=null
 this.show()}


### PR DESCRIPTION
Cleaner way to disable loading indicator when an AJAX handler returns a redirect reponse.

ref. https://github.com/octobercms/october/commit/99a08616bb649af7bf442fa1d01b7ce70dc6a939
ref. https://github.com/octobercms/october/issues/5555
ref. https://github.com/octobercms/october/issues/5055

replaces https://github.com/octobercms/october/pull/5321