### PR TITLE
switch to actively maintained faker repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require-dev": {
         "phpunit/phpunit": "^8.4|^9.3.3",
         "mockery/mockery": "~1.3.3|^1.4.2",
-        "fzaninotto/faker": "~1.9",
+        "fakerphp/faker": "~1.9",
         "squizlabs/php_codesniffer": "3.*",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "dms/phpunit-arraysubset-asserts": "^0.1.0|^0.2.1"


### PR DESCRIPTION
Fixes an unmaintained repository warning when running composer updates/install

- I chose the repository version which is equal to the previous repository, tested on a live instance of Winter and saw no issues. The warning can be alarming to new users when performing an install of Winter and can prompt them to attempt to fix the issue themselves, potentially breaking their new install while test driving Winter.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->