### PR TITLE
Added plugin registration after loading

### DIFF
--- a/tests/PluginTestCase.php
+++ b/tests/PluginTestCase.php
@@ -157,6 +157,7 @@ abstract class PluginTestCase extends TestCase
             }
 
             $plugin = $manager->loadPlugin($namespace, $path);
+            $manager->registerPlugin($plugin);
         }
 
         /*


### PR DESCRIPTION
There is an issue running tests in plugins where a plugin can be loaded but `PluginManager::registerPlugin()` isn't called which causes issues when the plugin is using an `init.php` as the files isn't required.

This patch just adds plugin registration after loading to the `PluginTestCase`.