### PR TITLE
Fix to uninstall to include disabled plugins

### DIFF
--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -347,7 +347,7 @@ class UpdateManager
         /*
          * Rollback plugins
          */
-        $plugins = array_reverse($this->pluginManager->getPlugins());
+        $plugins = array_reverse($this->pluginManager->getAllPlugins());
         foreach ($plugins as $name => $plugin) {
             $this->rollbackPlugin($name);
         }


### PR DESCRIPTION
Disabled plugins are not returned by `getPlugins()`, this means that when `winter:down` is ran if plugins are disabled then their tables remain in the DB.

Steps to reporduce are:

- `./artisan winter:up`
- disable any plugin with tables
- `./artisan winter:down`

Result: the disabled plugin's tables are left over.

This patch switches `getPlugins()` for `getAllPlugins()` which includes disabled plugins.