### PR TITLE
Added fix to ensure removed plugins show no warnings

### DIFF
--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -186,9 +186,11 @@ class UpdateManager
 
         // Set replacement warning messages
         foreach ($this->pluginManager->getReplacementMap() as $alias => $plugin) {
-            $this->addMessage($plugin, Lang::get('system::lang.updates.update_warnings_plugin_replace_cli', [
+            if (File::exists(PluginManager::instance()->getPluginPath($alias))) {
+                $this->addMessage($plugin, Lang::get('system::lang.updates.update_warnings_plugin_replace_cli', [
                     'alias' => '<info>' . $alias . '</info>'
-            ]));
+                ]));
+            }
         }
 
         // Print messages returned by migrations / seeders

--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -247,10 +247,12 @@ class Updates extends Controller
         $replacementMap = PluginManager::instance()->getReplacementMap();
 
         foreach ($replacementMap as $alias => $plugin) {
-            $warnings[] = Lang::get('system::lang.updates.update_warnings_plugin_replace', [
-                'plugin' => '<strong>' . $plugin . '</strong>',
-                'alias' => '<strong>' . $alias . '</strong>'
-            ]);
+            if (File::exists(PluginManager::instance()->getPluginPath($alias))) {
+                $warnings[] = Lang::get('system::lang.updates.update_warnings_plugin_replace', [
+                    'plugin' => '<strong>' . $plugin . '</strong>',
+                    'alias' => '<strong>' . $alias . '</strong>'
+                ]);
+            }
         }
 
         return $warnings;


### PR DESCRIPTION
Because the `PluginManager`'s `replacementMap` isn't cleared when an original plugin is not installed the warnings were still being shown.

This patch checks if the original plugin has been removed before displaying warnings.