### PR TITLE
[FIX] Plugin warnings only shown for active replacements

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -51,6 +51,11 @@ class PluginManager
     protected $replacementMap = [];
 
     /**
+     * @var array A map of plugins that are currently replaced [Original.Plugin => Replacement.Plugin]
+     */
+    protected $activeReplacementMap = [];
+
+    /**
      * @var bool Flag to indicate that all plugins have had the register() method called by registerAll() being called on this class.
      */
     protected $registered = false;
@@ -687,6 +692,19 @@ class PluginManager
     }
 
     /**
+     * Returns the actively replaced plugins defined in $this->activeReplacementMap
+     * @param string $pluginIdentifier Plugin code/namespace
+     * @return array|null
+     */
+    public function getActiveReplacementMap(string $pluginIdentifier = null)
+    {
+        if (!$pluginIdentifier) {
+            return $this->activeReplacementMap;
+        }
+        return $this->activeReplacementMap[$pluginIdentifier] ?? null;
+    }
+
+    /**
      * Evaluates and initializes the plugin replacements defined in $this->replacementMap
      *
      * @return void
@@ -710,6 +728,8 @@ class PluginManager
                 $this->aliasPluginAs($replacement, $target);
                 $this->disablePlugin($target);
                 $this->enablePlugin($replacement);
+                // Register this plugin as actively replaced
+                $this->activeReplacementMap[$target] = $replacement;
             } else {
                 $this->disablePlugin($replacement);
                 $this->enablePlugin($target);

--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -186,9 +186,11 @@ class UpdateManager
 
         // Set replacement warning messages
         foreach ($this->pluginManager->getReplacementMap() as $alias => $plugin) {
-            $this->addMessage($plugin, Lang::get('system::lang.updates.update_warnings_plugin_replace_cli', [
+            if ($this->pluginManager->getActiveReplacementMap($alias)) {
+                $this->addMessage($plugin, Lang::get('system::lang.updates.update_warnings_plugin_replace_cli', [
                     'alias' => '<info>' . $alias . '</info>'
-            ]));
+                ]));
+            }
         }
 
         // Print messages returned by migrations / seeders

--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -247,10 +247,12 @@ class Updates extends Controller
         $replacementMap = PluginManager::instance()->getReplacementMap();
 
         foreach ($replacementMap as $alias => $plugin) {
-            $warnings[] = Lang::get('system::lang.updates.update_warnings_plugin_replace', [
-                'plugin' => '<strong>' . $plugin . '</strong>',
-                'alias' => '<strong>' . $alias . '</strong>'
-            ]);
+            if (PluginManager::instance()->getActiveReplacementMap($alias)) {
+                $warnings[] = Lang::get('system::lang.updates.update_warnings_plugin_replace', [
+                    'plugin' => '<strong>' . $plugin . '</strong>',
+                    'alias' => '<strong>' . $alias . '</strong>'
+                ]);
+            }
         }
 
         return $warnings;

--- a/tests/unit/system/classes/PluginManagerTest.php
+++ b/tests/unit/system/classes/PluginManagerTest.php
@@ -280,4 +280,14 @@ class PluginManagerTest extends TestCase
         $this->assertTrue($replacementPlugin->canReplacePlugin('Winter.Original', '1.0'));
         $this->assertFalse($replacementPlugin->canReplacePlugin('Winter.Original', '2.0.1'));
     }
+
+    public function testActiveReplacementMap()
+    {
+        $map = $this->manager->getActiveReplacementMap();
+        $this->assertArrayHasKey('Winter.Original', $map);
+        $this->assertEquals('Winter.Replacement', $map['Winter.Original']);
+
+        $this->assertEquals('Winter.Replacement', $this->manager->getActiveReplacementMap('Winter.Original'));
+        $this->assertNull($this->manager->getActiveReplacementMap('Winter.InvalidReplacement'));
+    }
 }


### PR DESCRIPTION
Because the `PluginManager`'s `replacementMap` isn't cleared when an original plugin is not installed the warnings were still being shown.

This patch adds support for tracking active replacements within the `PluginManager` and uses that data to check if the original plugin has been removed before displaying warnings.

Fixes #123 