### PR TITLE
Fixing styles for custom checkbox

### DIFF
--- a/modules/system/assets/ui/less/checkbox.less
+++ b/modules/system/assets/ui/less/checkbox.less
@@ -46,7 +46,9 @@
     input[type=radio],
     input[type=checkbox] {
         display: block;
-        opacity: 0;
+        visibility: hidden;
+        height: 0;
+        margin-top: 0;
     }
 
     label {

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -5956,7 +5956,7 @@ html.cssanimations .cursor-loading-indicator.hide {display:none}
 .custom-checkbox input[type=radio],
 .custom-radio input[type=radio],
 .custom-checkbox input[type=checkbox],
-.custom-radio input[type=checkbox] {display:block;opacity:0}
+.custom-radio input[type=checkbox] {display:block;visibility:hidden;height:0;margin-top:0}
 .custom-checkbox label,
 .custom-radio label {display:inline-block;cursor:pointer;position:relative;padding-left:25px;margin-right:15px;margin-left:-20px;font-size:13px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
 .custom-checkbox label:before,


### PR DESCRIPTION
The custom checkbox has the wrong styles.
Now there is an empty space in front of the custom checkbox:

![2021-05-01_111248_2](https://user-images.githubusercontent.com/61043464/116776474-458fa400-aa71-11eb-8719-476633b41d0c.jpg)

Instead of full transparency, there is a `visibility` property. Then the element is on the page, but it is not visually visible.
Due to the `height: 0` we remove the space that the element occupies.

![2021-05-01_111414](https://user-images.githubusercontent.com/61043464/116776596-d4042580-aa71-11eb-82d5-c9eb539e5ee0.jpg)

![2021-05-01_111638](https://user-images.githubusercontent.com/61043464/116776601-d9fa0680-aa71-11eb-8d22-7f7c373abd64.jpg)
