### PR TITLE
Add dynamic option creation to dropdown

### DIFF
--- a/modules/backend/widgets/form/partials/_field_dropdown.htm
+++ b/modules/backend/widgets/form/partials/_field_dropdown.htm
@@ -1,7 +1,7 @@
 <?php
     $fieldOptions = $field->options();
     $useSearch = $field->getConfig('showSearch', true);
-    $acceptNewOptions = $field->getConfig('acceptNewOptions', false);
+    $allowCustom = $field->getConfig('allowCustom', false);
     $emptyOption = $field->getConfig('emptyOption', $field->placeholder);
 ?>
 <!-- Dropdown -->
@@ -19,7 +19,7 @@
     <select
         id="<?= $field->getId() ?>"
         name="<?= $field->getName() ?>"
-        class="form-control custom-select <?= $useSearch ? '' : 'select-no-search' ?> <?= $acceptNewOptions ? 'select-modifiable' : '' ?>"
+        class="form-control custom-select <?= $useSearch ? '' : 'select-no-search' ?> <?= $allowCustom ? 'select-modifiable' : '' ?>"
         <?= $field->getAttributes() ?>
         <?= $field->placeholder ? 'data-placeholder="'.e(trans($field->placeholder)).'"' : '' ?>
         >

--- a/modules/backend/widgets/form/partials/_field_dropdown.htm
+++ b/modules/backend/widgets/form/partials/_field_dropdown.htm
@@ -1,6 +1,7 @@
 <?php
     $fieldOptions = $field->options();
     $useSearch = $field->getConfig('showSearch', true);
+    $acceptNewOptions = $field->getConfig('acceptNewOptions', false);
     $emptyOption = $field->getConfig('emptyOption', $field->placeholder);
 ?>
 <!-- Dropdown -->
@@ -18,7 +19,7 @@
     <select
         id="<?= $field->getId() ?>"
         name="<?= $field->getName() ?>"
-        class="form-control custom-select <?= $useSearch ? '' : 'select-no-search' ?>"
+        class="form-control custom-select <?= $useSearch ? '' : 'select-no-search' ?> <?= $acceptNewOptions ? 'select-modifiable' : '' ?>"
         <?= $field->getAttributes() ?>
         <?= $field->placeholder ? 'data-placeholder="'.e(trans($field->placeholder)).'"' : '' ?>
         >

--- a/modules/system/assets/ui/js/select.js
+++ b/modules/system/assets/ui/js/select.js
@@ -67,7 +67,7 @@
                 extraOptions.minimumResultsForSearch = Infinity
             }
             if ($element.hasClass('select-modifiable')) {
-                extraOptions.tags = true
+                extraOptions.tags = true;
 
                 extraOptions.createTag = function (params) {
                     var term = $.trim(params.term);
@@ -80,7 +80,7 @@
                         id: term,
                         text: term,
                         newTag: true
-                    }
+                    };
                 }
 
                 extraOptions.templateResult = function (state) {

--- a/modules/system/assets/ui/js/select.js
+++ b/modules/system/assets/ui/js/select.js
@@ -66,6 +66,9 @@
             if ($element.hasClass('select-no-search')) {
                 extraOptions.minimumResultsForSearch = Infinity
             }
+            if ($element.hasClass('select-modifiable')) {
+                extraOptions.tags = true
+            }
             if ($element.hasClass('select-no-dropdown')) {
                 extraOptions.dropdownCssClass += ' select-no-dropdown'
                 extraOptions.containerCssClass += ' select-no-dropdown'

--- a/modules/system/assets/ui/js/select.js
+++ b/modules/system/assets/ui/js/select.js
@@ -68,6 +68,31 @@
             }
             if ($element.hasClass('select-modifiable')) {
                 extraOptions.tags = true
+
+                extraOptions.createTag = function (params) {
+                    var term = $.trim(params.term);
+
+                    if (term === '') {
+                        return null;
+                    }
+
+                    return {
+                        id: term,
+                        text: term,
+                        newTag: true
+                    }
+                }
+
+                extraOptions.templateResult = function (state) {
+                    if (!state.id) {
+                        return state.text;
+                    }
+                    var icon = state.newTag ? '<i class="icon-plus"></i> ' : '';
+
+                    return $(
+                        '<span>' + icon + state.text + '</span>'
+                    );
+                }
             }
             if ($element.hasClass('select-no-dropdown')) {
                 extraOptions.dropdownCssClass += ' select-no-dropdown'

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3552,7 +3552,11 @@ if($element.data('select2')!=null){return true;}
 $element.attr('data-disposable','data-disposable')
 $element.one('dispose-control',function(){if($element.data('select2')){$element.select2('destroy')}})
 if($element.hasClass('select-no-search')){extraOptions.minimumResultsForSearch=Infinity}
-if($element.hasClass('select-modifiable')){extraOptions.tags=true}
+if($element.hasClass('select-modifiable')){extraOptions.tags=true
+extraOptions.createTag=function(params){var term=$.trim(params.term);if(term===''){return null;}
+return{id:term,text:term,newTag:true}}
+extraOptions.templateResult=function(state){if(!state.id){return state.text;}
+var icon=state.newTag?'<i class="icon-plus"></i> ':'';return $('<span>'+icon+state.text+'</span>');}}
 if($element.hasClass('select-no-dropdown')){extraOptions.dropdownCssClass+=' select-no-dropdown'
 extraOptions.containerCssClass+=' select-no-dropdown'}
 if($element.hasClass('select-hide-selected')){extraOptions.dropdownCssClass+=' select-hide-selected'}

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3552,6 +3552,7 @@ if($element.data('select2')!=null){return true;}
 $element.attr('data-disposable','data-disposable')
 $element.one('dispose-control',function(){if($element.data('select2')){$element.select2('destroy')}})
 if($element.hasClass('select-no-search')){extraOptions.minimumResultsForSearch=Infinity}
+if($element.hasClass('select-modifiable')){extraOptions.tags=true}
 if($element.hasClass('select-no-dropdown')){extraOptions.dropdownCssClass+=' select-no-dropdown'
 extraOptions.containerCssClass+=' select-no-dropdown'}
 if($element.hasClass('select-hide-selected')){extraOptions.dropdownCssClass+=' select-hide-selected'}


### PR DESCRIPTION
This allows the user to accept new options to be set on the dropdown field:
![easy-bizi](https://user-images.githubusercontent.com/53976837/117063021-806d3280-ad24-11eb-9b0b-95b02d7242bc.gif)

It's natively handled by Select2 as you can see [into the documentation](https://select2.org/tagging).

To active the option, we just need to set `acceptNewOptions` to `true`:
```yaml
my_field:
    label: my_label
    type: dropdown
    acceptNewOptions: true
```