### PR TITLE
Add class alias registration method to ServiceProvider

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -182,7 +182,9 @@ class ServiceProvider extends ModuleServiceProvider
                 continue;
             }
             foreach ($aliases as $real => $alias) {
-                class_alias($real, $alias);
+                if (!class_exists($alias)) {
+                    class_alias($real, $alias);
+                }
             }
         }
     }

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -52,6 +52,7 @@ class ServiceProvider extends ModuleServiceProvider
          */
         PluginManager::instance()->registerAll();
 
+        $this->registerAliases();
         $this->registerConsole();
         $this->registerErrorHandler();
         $this->registerLogging();
@@ -167,6 +168,22 @@ class ServiceProvider extends ModuleServiceProvider
          */
         if (App::runningInConsole() && count(array_intersect($commands, Request::server('argv', []))) > 0) {
             PluginManager::$noInit = true;
+        }
+    }
+
+    /*
+     * Register class aliases for the plugins.
+     */
+    protected function registerAliases()
+    {
+        $plugins = PluginManager::instance()->getRegistrationMethodValues('registerAliases');
+        foreach ($plugins as $plugin => $aliases) {
+            if (!is_array($aliases)  || empty($aliases)) {
+                continue;
+            }
+            foreach ($aliases as $real => $alias) {
+                class_alias($real, $alias);
+            }
         }
     }
 

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -178,7 +178,7 @@ class ServiceProvider extends ModuleServiceProvider
     {
         $plugins = PluginManager::instance()->getRegistrationMethodValues('registerClassAliases');
         foreach ($plugins as $plugin => $aliases) {
-            if (!is_array($aliases)  || empty($aliases)) {
+            if (!is_array($aliases) || empty($aliases)) {
                 continue;
             }
             foreach ($aliases as $real => $alias) {

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -171,8 +171,10 @@ class ServiceProvider extends ModuleServiceProvider
         }
     }
 
-    /*
+    /**
      * Register class aliases for the plugins.
+     *
+     * @return void
      */
     protected function registerClassAliases()
     {

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -52,7 +52,7 @@ class ServiceProvider extends ModuleServiceProvider
          */
         PluginManager::instance()->registerAll();
 
-        $this->registerAliases();
+        $this->registerClassAliases();
         $this->registerConsole();
         $this->registerErrorHandler();
         $this->registerLogging();
@@ -174,9 +174,9 @@ class ServiceProvider extends ModuleServiceProvider
     /*
      * Register class aliases for the plugins.
      */
-    protected function registerAliases()
+    protected function registerClassAliases()
     {
-        $plugins = PluginManager::instance()->getRegistrationMethodValues('registerAliases');
+        $plugins = PluginManager::instance()->getRegistrationMethodValues('registerClassAliases');
         foreach ($plugins as $plugin => $aliases) {
             if (!is_array($aliases)  || empty($aliases)) {
                 continue;

--- a/modules/system/classes/PluginBase.php
+++ b/modules/system/classes/PluginBase.php
@@ -105,7 +105,7 @@ class PluginBase extends ServiceProviderBase
      *
      * @return array
      */
-    public function registerAliases()
+    public function registerClassAliases()
     {
         return [];
     }

--- a/modules/system/classes/PluginBase.php
+++ b/modules/system/classes/PluginBase.php
@@ -101,6 +101,16 @@ class PluginBase extends ServiceProviderBase
     }
 
     /**
+     * Registers class aliases needed for this plugin.
+     *
+     * @return array
+     */
+    public function registerAliases()
+    {
+        return [];
+    }
+
+    /**
      * Registers any front-end components implemented in this plugin.
      *
      * @return array

--- a/tests/fixtures/plugins/winter/tester/Plugin.php
+++ b/tests/fixtures/plugins/winter/tester/Plugin.php
@@ -71,4 +71,11 @@ class Plugin extends PluginBase
             'be_like_bob' => \Winter\Tester\Rules\BeLikeBobRule::class,
         ];
     }
+
+    public function registerClassAliases()
+    {
+        return [
+            '\Winter\Tester\Plugin' => 'My\Aliased\Class',
+        ];
+    }
 }

--- a/tests/fixtures/plugins/winter/tester/Plugin.php
+++ b/tests/fixtures/plugins/winter/tester/Plugin.php
@@ -75,7 +75,7 @@ class Plugin extends PluginBase
     public function registerClassAliases()
     {
         return [
-            '\Winter\Tester\Plugin' => 'My\Aliased\Class',
+            '\Winter\Tester\Plugin' => '\My\Aliased\Class',
         ];
     }
 }

--- a/tests/unit/plugins/system/PluginRegisterClassAliasesTest.php
+++ b/tests/unit/plugins/system/PluginRegisterClassAliasesTest.php
@@ -11,7 +11,7 @@ class PluginRegisterClassAliasesTest extends PluginTestCase
         $this->runPluginRefreshCommand('Winter.Tester');
     }
 
-    public function testValidationUsingClosure()
+    public function testClassAliases()
     {
         $this->assertFalse(class_exists('\My\NonExistent\Class'));
         $this->assertTrue(class_exists('\Winter\Tester\Plugin'));

--- a/tests/unit/plugins/system/PluginRegisterClassAliasesTest.php
+++ b/tests/unit/plugins/system/PluginRegisterClassAliasesTest.php
@@ -13,8 +13,8 @@ class PluginRegisterClassAliasesTest extends PluginTestCase
 
     public function testValidationUsingClosure()
     {
-        $this->assertFalse(class_exists('My\NonExistent\Class'));
-        $this->assertTrue(class_exists('Winter\Tester\Plugin'));
-        $this->assertTrue(class_exists('My\Aliased\Class'));
+        $this->assertFalse(class_exists('\My\NonExistent\Class'));
+        $this->assertTrue(class_exists('\Winter\Tester\Plugin'));
+        $this->assertTrue(class_exists('\My\Aliased\Class'));
     }
 }

--- a/tests/unit/plugins/system/PluginRegisterClassAliasesTest.php
+++ b/tests/unit/plugins/system/PluginRegisterClassAliasesTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class PluginRegisterClassAliasesTest extends PluginTestCase
+{
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        include_once base_path() . '/tests/fixtures/plugins/winter/tester/Plugin.php';
+
+        $this->runPluginRefreshCommand('Winter.Tester');
+    }
+
+    public function testValidationUsingClosure()
+    {
+        $this->assertFalse(class_exists('My\NonExistent\Class'));
+        $this->assertTrue(class_exists('Winter\Tester\Plugin'));
+        $this->assertTrue(class_exists('My\Aliased\Class'));
+    }
+}


### PR DESCRIPTION
Setup class aliases registered in plugin's registerAliases() method.

This can be tested with the Winter.Blog plugin adding this method:
```
    public function registerAliases()
    {   
        /**
         * To allow compatibility with plugins that extend the original RainLab.Blog plugin, 
         * this will alias those classes to use the new Winter.Blog classes.
         */
        return [
            Winter\Blog\Plugin::class                     => RainLab\Blog\Plugin::class,
            Winter\Blog\Components\Categories::class      => RainLab\Blog\Components\Categories::class,
            Winter\Blog\Classes\TagProcessor::class       => RainLab\Blog\Classes\TagProcessor::class,
            Winter\Blog\Components\Posts::class           => RainLab\Blog\Components\Posts::class,
            Winter\Blog\Components\Post::class            => RainLab\Blog\Components\Post::class,
            Winter\Blog\Components\RssFeed::class         => RainLab\Blog\Components\RssFeed::class,
            Winter\Blog\Controllers\Categories::class     => RainLab\Blog\Controllers\Categories::class,
            Winter\Blog\Controllers\Posts::class          => RainLab\Blog\Controllers\Posts::class,
            Winter\Blog\FormWidgets\BlogMarkdown::class   => RainLab\Blog\FormWidgets\BlogMarkdown::class,
            Winter\Blog\FormWidgets\MLBlogMarkdown::class => RainLab\Blog\FormWidgets\MLBlogMarkdown::class,
            Winter\Blog\Models\Settings::class            => RainLab\Blog\Models\Settings::class,
            Winter\Blog\Models\PostImport::class          => RainLab\Blog\Models\PostImport::class,
            Winter\Blog\Models\Post::class                => RainLab\Blog\Models\Post::class,
            Winter\Blog\Models\Category::class            => RainLab\Blog\Models\Category::class,
            Winter\Blog\Models\PostExport::class          => RainLab\Blog\Models\PostExport::class,
        ];
    }   
```
