### PR TITLE
Update queue connection wording.

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -4,12 +4,12 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Default Queue Driver
+    | Default Queue Connection Name
     |--------------------------------------------------------------------------
     |
     | The Laravel queue API supports a variety of back-ends via an unified
     | API, giving you convenient access to each back-end using the same
-    | syntax for each one. Here you may set the default queue driver.
+    | syntax for each one. Here you may define a default connection.
     |
     | Supported: "null", "sync", "database", "beanstalkd",
     |            "sqs", "iron", "redis"


### PR DESCRIPTION
Update wording to be more inline with what is actually being set, since these are actually a list of connections and are not actually queue drivers. The env variable is also defined as `QUEUE_CONNECTION` so it makes more sense to title this as a queue connection.