### PR TITLE
Force resized images to be regenerated when the source image changes

### DIFF
--- a/modules/system/classes/ImageResizer.php
+++ b/modules/system/classes/ImageResizer.php
@@ -230,6 +230,9 @@ class ImageResizer
                 $disk->getAdapter()->setPathPrefix($realPath);
             }
         }
+        
+        // Include last modified time to tie generated images to the source image
+        $mtime = $disk->lastModified($this->image['path']);
 
         // Handle disks that can't be serialized by referencing them by their
         // filesystems.php config name
@@ -243,6 +246,7 @@ class ImageResizer
             'image' => [
                 'disk' => $disk,
                 'path' => $this->image['path'],
+                'mtime' => $mtime,
                 'source' => $this->image['source'],
             ],
             'width' => $this->width,


### PR DESCRIPTION
This should fix https://github.com/wintercms/winter/issues/177, but it will cause all existing installations to resize all of their already resized images. 

Another alternative could have been to include the hash of the source image; but it would have been at the expense of more work every time this function is called, which could potentially include generating hashes of multiple extremely large (10+ MB) images on every page load if the page includes such images that need to be resized since the filter needs to identify the configuration in order to identify the path to the resized image to check if it needs to return a resizer/ URL or a /resized one.

Further improvements could potentially be made in the isResized() / getPathToResized() methods to cache the results to avoid doing all the work involved with the getConfig() method while still allowing people to run a command to trigger a refresh.