### PR TITLE
Optimize system_files table performance

### DIFF
--- a/modules/system/database/migrations/2021_06_25_143510_Db_Attachment_ID_To_int.php
+++ b/modules/system/database/migrations/2021_06_25_143510_Db_Attachment_ID_To_int.php
@@ -30,7 +30,7 @@ class DbAttachmentIdToInt extends Migration
         // Convert attachment_id to bigint if the attachment_id column only contains integer values.
         $convert = true;
         DB::table('system_files')
-            ->select(['attachment_id'])
+            ->select(['id', 'attachment_id'])
             ->chunkById(1000, function ($attachmentIds) use (&$convert) {
                 $files = $attachmentIds->filter(function ($file) {
                     return ! is_numeric($file->attachment_id);

--- a/modules/system/database/migrations/2021_06_25_143510_Db_Attachment_ID_To_int.php
+++ b/modules/system/database/migrations/2021_06_25_143510_Db_Attachment_ID_To_int.php
@@ -33,7 +33,7 @@ class DbAttachmentIdToInt extends Migration
             ->select(['id', 'attachment_id'])
             ->chunkById(1000, function ($attachmentIds) use (&$convert) {
                 $files = $attachmentIds->filter(function ($file) {
-                    return ! is_numeric($file->attachment_id);
+                    return ((string) $file->attachment_id === (string) intval($file->attachment_id));
                 });
 
                 if ($files->isNotEmpty()) {

--- a/modules/system/database/migrations/2021_06_25_143510_Db_Attachment_ID_To_int.php
+++ b/modules/system/database/migrations/2021_06_25_143510_Db_Attachment_ID_To_int.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Winter\Storm\Database\Schema\Blueprint;
+use Winter\Storm\Database\Updates\Migration;
+use Winter\Storm\Support\Facades\Schema;
+
+class DbAttachmentIdToInt extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('system_files', function (Blueprint $table) {
+            // Drop old indexes
+            $table->dropIndex(['attachment_id']);
+            $table->dropIndex(['attachment_type']);
+            $table->dropIndex(['field']);
+
+            $table->index([
+                'field',
+                'attachment_type',
+                'attachment_id',
+            ]);
+        });
+
+        // Convert attachment_id to bigint if the attachment_id column only contains integer values.
+        $convert = true;
+        DB::table('system_files')
+            ->select(['attachment_id'])
+            ->chunkById(1000, function ($attachmentIds) use (&$convert) {
+                $files = $attachmentIds->filter(function ($file) {
+                    return ! is_numeric($file->attachment_id);
+                });
+
+                if ($files->isNotEmpty()) {
+                    return $convert = false;
+                }
+            });
+
+        if ($convert) {
+            Schema::table('system_files', function (Blueprint $table) {
+                $table->unsignedBigInteger('attachment_id')->change();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('system_files', function (Blueprint $table) {
+            $table->index('attachment_id');
+            $table->index('attachment_type');
+            $table->index('field');
+        });
+    }
+}

--- a/modules/system/database/migrations/2021_06_25_143510_Db_Attachment_ID_To_int.php
+++ b/modules/system/database/migrations/2021_06_25_143510_Db_Attachment_ID_To_int.php
@@ -56,6 +56,14 @@ class DbAttachmentIdToInt extends Migration
     public function down()
     {
         Schema::table('system_files', function (Blueprint $table) {
+            $table->string('attachment_id')->change();
+
+            $table->dropIndex([
+                'field',
+                'attachment_type',
+                'attachment_id',
+            ]);
+
             $table->index('attachment_id');
             $table->index('attachment_type');
             $table->index('field');

--- a/tests/unit/system/database/migrations/TestConvertingSystemFilesAttachmentIdToInt.php
+++ b/tests/unit/system/database/migrations/TestConvertingSystemFilesAttachmentIdToInt.php
@@ -1,0 +1,173 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Winter\Storm\Database\Schema\Blueprint;
+use Winter\Storm\Support\Facades\Schema;
+
+class TestConvertingSystemFilesAttachmentIdToInt extends TestCase
+{
+    public static $tempMigrationsPath = '';
+
+    protected $migrationFileName = '2021_06_25_143510_Db_Attachment_ID_To_int.php';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setupTestFixtures();
+
+        if (Schema::hasTable('migrations')) {
+            // Clean database starting point
+            $this->artisan('winter:down --force');
+        }
+
+        $this->artisan('winter:up');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownTestFixtures();
+
+        $this->artisan('winter:down --force');
+
+        parent::tearDown();
+    }
+
+    public function test_it_can_change_attachment_id_column_to_int()
+    {
+        $faker = \Faker\Factory::create();
+
+        $data = [];
+
+        foreach (range(1, 100) as $i) {
+            $data[] = [
+                'disk_name' => str_random().'.jpg',
+                'file_name' => str_random().'.jpg',
+                'file_size' => mt_rand(),
+                'content_type' => 'image/jpeg',
+                'title' => $faker->title,
+                'description' => $faker->text,
+                'field' => 'files',
+                'attachment_id' => mt_rand(1, 10000),
+                'attachment_type' => 'System\Models\File',
+                'sort_order' => mt_rand(0, 100),
+                'created_at' => now()->toDateTimeString(),
+                'updated_at' => now()->toDateTimeString(),
+            ];
+        }
+
+        DB::table('system_files')->insert($data);
+
+        $this->enableMigration();
+
+        $this->artisan('winter:up');
+
+        $this->assertEquals('bigint', DB::getSchemaBuilder()->getColumnType('system_files', 'attachment_id'));
+
+        $files = DB::table('system_files')->get();
+
+        foreach ($files as $file) {
+            $this->assertIsInt($file->attachment_id);
+            $this->assertNotEmpty($file->attachment_id);
+            $this->assertTrue($file->attachment_id !== 0);
+        }
+    }
+
+    public function test_it_will_not_change_attachment_id_column_to_int()
+    {
+        $faker = \Faker\Factory::create();
+
+        $data = [];
+
+        foreach (range(1, 100) as $i) {
+            $data[] = [
+                'disk_name' => str_random().'.jpg',
+                'file_name' => str_random().'.jpg',
+                'file_size' => mt_rand(),
+                'content_type' => 'image/jpeg',
+                'title' => $faker->title,
+                'description' => $faker->text,
+                'field' => 'files',
+                'attachment_id' => str_random(10),
+                'attachment_type' => 'System\Models\File',
+                'sort_order' => mt_rand(0, 100),
+                'created_at' => now()->toDateTimeString(),
+                'updated_at' => now()->toDateTimeString(),
+            ];
+        }
+
+        DB::table('system_files')->insert($data);
+
+        $this->enableMigration();
+
+        $this->artisan('winter:up');
+
+        $this->assertEquals('string', DB::getSchemaBuilder()->getColumnType('system_files', 'attachment_id'));
+    }
+
+    public function test_it_will_not_change_attachment_id_column_to_int_when_column_contains_both_strings_and_integers()
+    {
+        $faker = \Faker\Factory::create();
+
+        $data = [];
+
+        foreach (range(1, 100) as $i) {
+            $data[] = [
+                'disk_name' => str_random().'.jpg',
+                'file_name' => str_random().'.jpg',
+                'file_size' => mt_rand(),
+                'content_type' => 'image/jpeg',
+                'title' => $faker->title,
+                'description' => $faker->text,
+                'field' => 'files',
+                'attachment_id' => mt_rand(0, 1) ? str_random(10) : mt_rand(),
+                'attachment_type' => 'System\Models\File',
+                'sort_order' => mt_rand(0, 100),
+                'created_at' => now()->toDateTimeString(),
+                'updated_at' => now()->toDateTimeString(),
+            ];
+        }
+
+        DB::table('system_files')->insert($data);
+
+        $this->enableMigration();
+
+        $this->artisan('winter:up');
+
+        $this->assertEquals('string', DB::getSchemaBuilder()->getColumnType('system_files', 'attachment_id'));
+    }
+
+    protected function setupTestFixtures()
+    {
+        static::$tempMigrationsPath = storage_path('temp/tests/database/migrations');
+
+        $this->disableMigration();
+    }
+
+    protected function tearDownTestFixtures()
+    {
+        $this->enableMigration();
+    }
+
+    protected function enableMigration()
+    {
+        if (! is_dir(static::$tempMigrationsPath)) {
+            mkdir(static::$tempMigrationsPath, 0777, true);
+        }
+
+        if (! file_exists(static::$tempMigrationsPath.'/'.$this->migrationFileName)) {
+            return;
+        }
+
+        rename(static::$tempMigrationsPath.'/'.$this->migrationFileName, base_path('modules/system/database/migrations/'.$this->migrationFileName));
+    }
+
+    protected function disableMigration()
+    {
+        if (! file_exists(base_path('modules/system/database/migrations/'.$this->migrationFileName))) {
+            return;
+        }
+
+        rename(base_path('modules/system/database/migrations/'.$this->migrationFileName), static::$tempMigrationsPath.'/'.$this->migrationFileName);
+    }
+}

--- a/tests/unit/system/database/migrations/TestConvertingSystemFilesAttachmentIdToInt.php
+++ b/tests/unit/system/database/migrations/TestConvertingSystemFilesAttachmentIdToInt.php
@@ -137,6 +137,38 @@ class TestConvertingSystemFilesAttachmentIdToInt extends TestCase
         $this->assertEquals('string', DB::getSchemaBuilder()->getColumnType('system_files', 'attachment_id'));
     }
 
+    public function test_it_will_not_convert_attachment_id_column_when_it_contains_a_float()
+    {
+        $faker = \Faker\Factory::create();
+
+        $data = [];
+
+        foreach (range(1, 100) as $i) {
+            $data[] = [
+                'disk_name' => str_random().'.jpg',
+                'file_name' => str_random().'.jpg',
+                'file_size' => mt_rand(),
+                'content_type' => 'image/jpeg',
+                'title' => $faker->title,
+                'description' => $faker->text,
+                'field' => 'files',
+                'attachment_id' => $faker->randomFloat(2, 1),
+                'attachment_type' => 'System\Models\File',
+                'sort_order' => mt_rand(0, 100),
+                'created_at' => now()->toDateTimeString(),
+                'updated_at' => now()->toDateTimeString(),
+            ];
+        }
+
+        DB::table('system_files')->insert($data);
+
+        $this->enableMigration();
+
+        $this->artisan('winter:up');
+
+        $this->assertEquals('string', DB::getSchemaBuilder()->getColumnType('system_files', 'attachment_id'));
+    }
+
     protected function setupTestFixtures()
     {
         static::$tempMigrationsPath = storage_path('temp/tests/database/migrations');


### PR DESCRIPTION
This is in reference to this discussion: https://github.com/wintercms/winter/discussions/208

This PR will drop the single column indexes and convert them into a composite index for improved performance and convert the `attachment_id` column to bigint if the database column only contains numeric values.

Feel free to suggest any changes/improvements because this is my first attempt at this type of a change and want this change to be as safe as possible.