### PR TITLE
Return 404 for asset combiner resources that don't exist

### DIFF
--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -234,7 +234,7 @@ class CombineAssets
     /**
      * Returns the combined contents from a prepared cache identifier.
      * @param string $cacheKey Cache identifier.
-     * @return string Combined file contents.
+     * @return Response Combined file contents.
      */
     public function getContents($cacheKey)
     {

--- a/modules/system/classes/CombineAssets.php
+++ b/modules/system/classes/CombineAssets.php
@@ -240,7 +240,7 @@ class CombineAssets
     {
         $cacheInfo = $this->getCache($cacheKey);
         if (!$cacheInfo) {
-            throw new ApplicationException(Lang::get('system::lang.combiner.not_found', ['name'=>$cacheKey]));
+            return Response::make('/* '.e(Lang::get('system::lang.combiner.not_found', ['name' => $cacheKey])).' */', 404);
         }
 
         $this->localPath = $cacheInfo['path'];

--- a/modules/system/classes/SystemController.php
+++ b/modules/system/classes/SystemController.php
@@ -27,7 +27,7 @@ class SystemController extends ControllerBase
     {
         try {
             if (!strpos($name, '-')) {
-                throw new ApplicationException(Lang::get('system::lang.combiner.not_found', ['name' => $name]));
+                return Response::make('/* '.e(Lang::get('system::lang.combiner.not_found', ['name' => $name])).' */', 404);
             }
 
             $parts = explode('-', $name);
@@ -38,7 +38,7 @@ class SystemController extends ControllerBase
 
             return $combiner->getContents($cacheId);
         } catch (Exception $ex) {
-            return Response::make('/* '.e($ex->getMessage()).' */', 404);
+            return Response::make('/* '.e($ex->getMessage()).' */', 500);
         }
     }
 

--- a/modules/system/classes/SystemController.php
+++ b/modules/system/classes/SystemController.php
@@ -38,7 +38,7 @@ class SystemController extends ControllerBase
 
             return $combiner->getContents($cacheId);
         } catch (Exception $ex) {
-            return Response::make('/* '.e($ex->getMessage()).' */', 500);
+            return Response::make('/* '.e($ex->getMessage()).' */', 404);
         }
     }
 

--- a/modules/system/classes/SystemController.php
+++ b/modules/system/classes/SystemController.php
@@ -21,7 +21,7 @@ class SystemController extends ControllerBase
     /**
      * Combines JavaScript and StyleSheet assets.
      * @param string $name Combined file code
-     * @return string Combined content.
+     * @return Response Combined content.
      */
     public function combine($name)
     {


### PR DESCRIPTION
Returning a 500 error (server error) for a error which should be a 404.

