### PR TITLE
PluginManager disable / enable plugin fix

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -803,8 +803,8 @@ class PluginManager
         unset($this->disabledPlugins[$code]);
         $this->writeDisabled();
 
-        if ($pluginObj = $this->findByIdentifier($code)) {
-            $pluginObj->disabled = false;
+        if (isset($this->plugins[$code])) {
+            $this->plugins[$code]->disabled = false;
         }
 
         return true;

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -773,8 +773,8 @@ class PluginManager
         $this->disabledPlugins[$code] = $isUser;
         $this->writeDisabled();
 
-        if ($pluginObj = $this->findByIdentifier($code)) {
-            $pluginObj->disabled = true;
+        if (isset($this->plugins[$code])) {
+            $this->plugins[$code]->disabled = true;
         }
 
         return true;


### PR DESCRIPTION
There is a bug where a plugin object wont be marked disabled/enabled after calling `PluginManager::disablePlugin()` or `PluginManager::enablePlugin()`. It should treat the plugin object as a reference but for some reason it doesn't and the disabled property doesn't get updated.

As we've already processed what the code should be we can simply look in the `$this->plugins` array and find the object directly and update it.