### PR TITLE
Fix plugin status update issue

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -773,7 +773,7 @@ class PluginManager
         $this->disabledPlugins[$code] = $isUser;
         $this->writeDisabled();
 
-        if ($pluginObj = $this->findByIdentifier($code)) {
+        if ($pluginObj = $this->findByIdentifier($code, true)) {
             $pluginObj->disabled = true;
         }
 
@@ -803,7 +803,7 @@ class PluginManager
         unset($this->disabledPlugins[$code]);
         $this->writeDisabled();
 
-        if ($pluginObj = $this->findByIdentifier($code)) {
+        if ($pluginObj = $this->findByIdentifier($code, true)) {
             $pluginObj->disabled = false;
         }
 


### PR DESCRIPTION
Added fix when setting plugin status, replacements were overriding originals that would cause issues on requests with no cache.