### PR TITLE
Fix response code when not found assets

### DIFF
--- a/modules/system/classes/SystemController.php
+++ b/modules/system/classes/SystemController.php
@@ -38,7 +38,7 @@ class SystemController extends ControllerBase
 
             return $combiner->getContents($cacheId);
         } catch (Exception $ex) {
-            return Response::make('/* '.e($ex->getMessage()).' */', 500);
+            return Response::make('/* '.e($ex->getMessage()).' */', 404);
         }
     }
 


### PR DESCRIPTION
Previously Winter returns 500 error code in response when not found assets during combining JavaScript and CSS. It would make sense but caught exception uses `system::lang.combiner.not_found` text suggesting it should returns 404 code.