### PR TITLE
check overrides for parent locale when compiling language files

### DIFF
--- a/modules/system/console/WinterUtil.php
+++ b/modules/system/console/WinterUtil.php
@@ -191,7 +191,6 @@ class WinterUtil extends Command
              * Generate messages
              */
             $fallbackPath = base_path() . '/modules/system/lang/en/client.php';
-
             $srcPath = base_path() . '/modules/system/lang/'.$locale.'/client.php';
 
             $messages = require $fallbackPath;

--- a/modules/system/console/WinterUtil.php
+++ b/modules/system/console/WinterUtil.php
@@ -191,9 +191,11 @@ class WinterUtil extends Command
              * Generate messages
              */
             $fallbackPath = base_path() . '/modules/system/lang/en/client.php';
+
             $srcPath = base_path() . '/modules/system/lang/'.$locale.'/client.php';
 
             $messages = require $fallbackPath;
+
             if (File::isFile($srcPath) && $fallbackPath != $srcPath) {
                 $messages = array_replace_recursive($messages, require $srcPath);
             }
@@ -201,16 +203,24 @@ class WinterUtil extends Command
             /*
              * Load possible replacements from /lang
              */
+            $overrides = [];
+            $parentOverrides = [];
+
             $overridePath = base_path() . '/lang/'.$locale.'/system/client.php';
             if (File::isFile($overridePath)) {
-                $messages = array_replace_recursive($messages, require $overridePath);
-            } elseif (str_contains($locale, '-')) {
+                $overrides = require $overridePath;
+            }
+
+            if (str_contains($locale, '-')) {
                 list($parentLocale, $country) = explode('-', $locale);
-                $overridePath = base_path() . '/lang/'.$parentLocale.'/system/client.php';
-                if (File::isFile($overridePath)) {
-                    $messages = array_replace_recursive($messages, require $overridePath);
+
+                $parentOverridePath = base_path() . '/lang/'.$parentLocale.'/system/client.php';
+                if (File::isFile($parentOverridePath)) {
+                    $parentOverrides = require $parentOverridePath;
                 }
             }
+
+            $messages = array_replace_recursive($messages, $parentOverrides, $overrides);
 
             /*
              * Compile from stub and save file

--- a/modules/system/console/WinterUtil.php
+++ b/modules/system/console/WinterUtil.php
@@ -190,10 +190,21 @@ class WinterUtil extends Command
             /*
              * Generate messages
              */
-            $fallbackPath = base_path() . '/modules/system/lang/en/client.php';
+            $fallbackLocale = Config::get('app.fallback_locale', 'en');
+            $fallbackPath = base_path() . '/modules/system/lang/'.$fallbackLocale.'/client.php';
+
             $srcPath = base_path() . '/modules/system/lang/'.$locale.'/client.php';
 
+
+            if (!File::isFile($fallbackPath) && str_contains($fallbackLocale, '-')) {
+                $this->warn('Warning: fallback path not found for country-specific locale: reverting to parent locale');
+                list ($parentFallbackLocale, $country) = explode('-', $fallbackLocale);
+                $fallbackPath = base_path() . '/modules/system/lang/'.$parentFallbackLocale.'/client.php';
+            } else {
+                $fallbackPath = base_path() . '/modules/system/lang/en/client.php';
+            }
             $messages = require $fallbackPath;
+
             if (File::isFile($srcPath) && $fallbackPath != $srcPath) {
                 $messages = array_replace_recursive($messages, require $srcPath);
             }
@@ -204,6 +215,12 @@ class WinterUtil extends Command
             $overridePath = base_path() . '/lang/'.$locale.'/system/client.php';
             if (File::isFile($overridePath)) {
                 $messages = array_replace_recursive($messages, require $overridePath);
+            } else if (str_contains($locale, '-')) {
+                list ($parentLocale, $country) = explode('-', $locale);
+                $overridePath = base_path() . '/lang/'.$parentLocale.'/system/client.php';
+                if (File::isFile($overridePath)) {
+                    $messages = array_replace_recursive($messages, require $overridePath);
+                }
             }
 
             /*

--- a/modules/system/console/WinterUtil.php
+++ b/modules/system/console/WinterUtil.php
@@ -190,19 +190,11 @@ class WinterUtil extends Command
             /*
              * Generate messages
              */
-            $fallbackLocale = Config::get('app.fallback_locale', 'en');
-            $fallbackPath = base_path() . '/modules/system/lang/'.$fallbackLocale.'/client.php';
+            $fallbackPath = base_path() . '/modules/system/lang/en/client.php';
 
             $srcPath = base_path() . '/modules/system/lang/'.$locale.'/client.php';
 
 
-            if (!File::isFile($fallbackPath) && str_contains($fallbackLocale, '-')) {
-                $this->warn('Warning: fallback path not found for country-specific locale: reverting to parent locale');
-                list ($parentFallbackLocale, $country) = explode('-', $fallbackLocale);
-                $fallbackPath = base_path() . '/modules/system/lang/'.$parentFallbackLocale.'/client.php';
-            } else {
-                $fallbackPath = base_path() . '/modules/system/lang/en/client.php';
-            }
             $messages = require $fallbackPath;
 
             if (File::isFile($srcPath) && $fallbackPath != $srcPath) {

--- a/modules/system/console/WinterUtil.php
+++ b/modules/system/console/WinterUtil.php
@@ -191,12 +191,9 @@ class WinterUtil extends Command
              * Generate messages
              */
             $fallbackPath = base_path() . '/modules/system/lang/en/client.php';
-
             $srcPath = base_path() . '/modules/system/lang/'.$locale.'/client.php';
 
-
             $messages = require $fallbackPath;
-
             if (File::isFile($srcPath) && $fallbackPath != $srcPath) {
                 $messages = array_replace_recursive($messages, require $srcPath);
             }

--- a/modules/system/console/WinterUtil.php
+++ b/modules/system/console/WinterUtil.php
@@ -204,7 +204,7 @@ class WinterUtil extends Command
             $overridePath = base_path() . '/lang/'.$locale.'/system/client.php';
             if (File::isFile($overridePath)) {
                 $messages = array_replace_recursive($messages, require $overridePath);
-            } else if (str_contains($locale, '-')) {
+            } elseif (str_contains($locale, '-')) {
                 list ($parentLocale, $country) = explode('-', $locale);
                 $overridePath = base_path() . '/lang/'.$parentLocale.'/system/client.php';
                 if (File::isFile($overridePath)) {

--- a/modules/system/console/WinterUtil.php
+++ b/modules/system/console/WinterUtil.php
@@ -205,7 +205,7 @@ class WinterUtil extends Command
             if (File::isFile($overridePath)) {
                 $messages = array_replace_recursive($messages, require $overridePath);
             } elseif (str_contains($locale, '-')) {
-                list ($parentLocale, $country) = explode('-', $locale);
+                list($parentLocale, $country) = explode('-', $locale);
                 $overridePath = base_path() . '/lang/'.$parentLocale.'/system/client.php';
                 if (File::isFile($overridePath)) {
                     $messages = array_replace_recursive($messages, require $overridePath);

--- a/tests/unit/system/console/WinterUtilTest.php
+++ b/tests/unit/system/console/WinterUtilTest.php
@@ -1,17 +1,19 @@
 <?php
 
-use Winter\Storm\Foundation\Bootstrap\LoadConfiguration;
-
 class WinterUtilTest extends TestCase
 {
     public function testCompileLang()
     {
+        $defaultClient = base_path('/modules/system/lang/en/client.php');
+
         // mv file so we can inject a test
-        $target = base_path('/modules/system/lang/en/client.php');
-        rename($target, $target . '.backup');
-        file_put_contents($target, '<?php return [\'winter\' => \'is coming\'];');
+        rename($defaultClient, $defaultClient . '.backup');
+
+        file_put_contents($defaultClient, '<?php return [\'winter\' => \'is coming\'];');
+
         // execute compile
         $this->artisan('winter:util compile lang')->execute();
+
         // validate default lang handling
         $lang = file_get_contents(base_path('modules/system/assets/js/lang/lang.en.js'));
         $this->assertStringContainsString('winter', $lang);
@@ -31,16 +33,16 @@ class WinterUtilTest extends TestCase
             }
         }
 
-        // handle existing file
         $langClient = base_path('lang/en/system/client.php');
+        // handle existing file
         if (file_exists($langClient)) {
             rename($langClient, $langClient . '.backup');
         }
 
         file_put_contents($langClient, '<?php return [\'winter\' => \'is epic\'];');
 
-        // handle existing file
         $langCountryClient = base_path('lang/en-gb/system/client.php');
+        // handle existing file
         if (file_exists($langCountryClient)) {
             rename($langCountryClient, $langCountryClient . '.backup');
         }
@@ -49,6 +51,7 @@ class WinterUtilTest extends TestCase
 
         // execute compile
         $this->artisan('winter:util compile lang')->execute();
+
         // validate override handling
         $lang = file_get_contents(base_path('modules/system/assets/js/lang/lang.en.js'));
         $this->assertStringContainsString('winter', $lang);
@@ -62,8 +65,8 @@ class WinterUtilTest extends TestCase
         $this->assertStringContainsString('winter', $lang);
 
         // restore
-        unlink($target);
-        rename($target . '.backup', $target);
+        unlink($defaultClient);
+        rename($defaultClient . '.backup', $defaultClient);
 
         foreach ([$langClient, $langCountryClient] as $client) {
             unlink($client);
@@ -76,7 +79,7 @@ class WinterUtilTest extends TestCase
             rmdir($dir);
         }
 
-        // regenerate compiled lang
+        // regenerate original compiled lang
         $this->artisan('winter:util compile lang')->execute();
     }
 }

--- a/tests/unit/system/console/WinterUtilTest.php
+++ b/tests/unit/system/console/WinterUtilTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Winter\Storm\Foundation\Bootstrap\LoadConfiguration;
+
+class WinterUtilTest extends TestCase
+{
+    public function testCompileLang()
+    {
+        // mv file so we can inject a test
+        $target = base_path('/modules/system/lang/en/client.php');
+        rename($target, $target . '.backup');
+        file_put_contents($target, '<?php return [\'winter\' => \'is coming\'];');
+        // execute compile
+        $this->artisan('winter:util compile lang')->execute();
+        // validate default lang handling
+        $lang = file_get_contents(base_path('modules/system/assets/js/lang/lang.en.js'));
+        $this->assertStringContainsString('winter', $lang);
+        $this->assertStringContainsString('is coming', $lang);
+
+        // simulate override
+        $created = [];
+
+        foreach (['lang/en/system', 'lang/en-gb/system'] as $slug) {
+            $path = rtrim(base_path(), '/');
+            foreach (explode('/', $slug) as $dir) {
+                $path = $path . '/' . $dir;
+                if (!is_dir($path)) {
+                    mkdir($path, 0755);
+                    $created[] = $path;
+                }
+            }
+        }
+
+        // handle existing file
+        $langClient = base_path('lang/en/system/client.php');
+        if (file_exists($langClient)) {
+            rename($langClient, $langClient . '.backup');
+        }
+
+        file_put_contents($langClient, '<?php return [\'winter\' => \'is epic\'];');
+
+        // handle existing file
+        $langCountryClient = base_path('lang/en-gb/system/client.php');
+        if (file_exists($langCountryClient)) {
+            rename($langCountryClient, $langCountryClient . '.backup');
+        }
+
+        file_put_contents($langCountryClient, '<?php return [\'whats_epic\' => \'winter\'];');
+
+        // execute compile
+        $this->artisan('winter:util compile lang')->execute();
+        // validate override handling
+        $lang = file_get_contents(base_path('modules/system/assets/js/lang/lang.en.js'));
+        $this->assertStringContainsString('winter', $lang);
+        $this->assertStringContainsString('is epic', $lang);
+
+        // check that lang subset has included parent overrides
+        $lang = file_get_contents(base_path('modules/system/assets/js/lang/lang.en-gb.js'));
+        $this->assertStringContainsString('winter', $lang);
+        $this->assertStringContainsString('is epic', $lang);
+        $this->assertStringContainsString('whats_epic', $lang);
+        $this->assertStringContainsString('winter', $lang);
+
+        // restore
+        unlink($target);
+        rename($target . '.backup', $target);
+
+        foreach ([$langClient, $langCountryClient] as $client) {
+            unlink($client);
+            if (file_exists($client . '.backup')) {
+                rename($client . '.backup', $client);
+            }
+        }
+
+        foreach (array_reverse($created) as $dir) {
+            rmdir($dir);
+        }
+
+        // regenerate compiled lang
+        $this->artisan('winter:util compile lang')->execute();
+    }
+}


### PR DESCRIPTION
- fallback to parent locale for client localization strings overrides

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->