### PR TITLE
Fix null saving in relation widgets when hidden/disabled from model

### DIFF
--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -173,6 +173,8 @@ class FormController extends ControllerBehavior
 
         $this->formWidget->bindToController();
 
+        $this->formWidget->applyFiltersFromModel();
+
         /*
          * Detected Relation controller behavior
          */

--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -1,5 +1,6 @@
 <?php namespace Backend\FormWidgets;
 
+use Backend\Classes\FormField;
 use Lang;
 use ApplicationException;
 use Backend\Classes\FormWidgetBase;
@@ -241,6 +242,10 @@ class RecordFinder extends FormWidgetBase
      */
     public function getSaveValue($value)
     {
+        if ($this->formField->disabled || $this->formField->hidden) {
+            return FormField::NO_SAVE_DATA;
+        }
+
         return strlen($value) ? $value : null;
     }
 

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1235,7 +1235,7 @@ class Form extends WidgetBase
     /*
      * Allow the model to filter fields.
      */
-    protected function applyFiltersFromModel()
+    public function applyFiltersFromModel()
     {
         /*
          * Standard usage


### PR DESCRIPTION
This fix https://github.com/wintercms/winter/issues/15 :
`filterFields` method is called through the rendering process to hide/disable the form fields, but is never called during the post saving process.

This does not cause any issue into basic form fields because hiding/disabling a basic input field simply remove the data from the post() and so is not saved, but concerning the relation: the field keep "being here" (because it's not hidden into the fields.yaml) and so is saved with null (since it's not present into the post data).