### PR TITLE
avoid translation error

### DIFF
--- a/modules/backend/widgets/form/partials/_field_dropdown.htm
+++ b/modules/backend/widgets/form/partials/_field_dropdown.htm
@@ -27,13 +27,17 @@
         <?php endif ?>
         <?php foreach ($fieldOptions as $value => $option): ?>
             <?php
-                if (!is_array($option)) $option = [$option];
+                if (!is_array($option) )  $option = [$option];
             ?>
-            <option
-                <?= $field->isSelected($value) ? 'selected="selected"' : '' ?>
-                <?php if (isset($option[1])): ?>data-<?=strpos($option[1],'.')?'image':'icon'?>="<?= $option[1] ?>"<?php endif ?>
-                value="<?= e($value) ?>"
-            ><?= e(trans($option[0])) ?></option>
+            <?php if (!is_array( trans($option[0]) )): ?>
+                <option
+                    <?= $field->isSelected($value) ? 'selected="selected"' : '' ?>
+                    <?php if (isset($option[1])): ?>data-<?=strpos($option[1],'.')?'image':'icon'?>="<?= $option[1] ?>"<?php endif ?>
+                    value="<?= e($value) ?>"
+                ><?= e(trans($option[0])) ?>
+            
+                </option>
+            <?php endif; ?>
         <?php endforeach ?>
     </select>
 <?php endif ?>


### PR DESCRIPTION
If we use Renatio.Builder and Offline.Mall plugin, an error can show up because template `code` is an array

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->