### PR TITLE
Fix/ux messages when smtp is not configured in backend

### DIFF
--- a/modules/backend/controllers/Auth.php
+++ b/modules/backend/controllers/Auth.php
@@ -2,18 +2,21 @@
 
 use Mail;
 use Flash;
+use Config;
 use Backend;
 use Request;
+use Exception;
 use Validator;
 use BackendAuth;
+use ValidationException;
+use ApplicationException;
 use Backend\Models\AccessLog;
+use Swift_TransportException;
 use Backend\Classes\Controller;
 use System\Classes\UpdateManager;
-use ApplicationException;
-use ValidationException;
-use Exception;
-use Config;
+use Illuminate\Support\Facades\Lang;
 use Winter\Storm\Foundation\Http\Middleware\CheckForTrustedHost;
+use Winter\Storm\Exception\ApplicationException as ExceptionApplicationException;
 
 /**
  * Authentication controller
@@ -140,6 +143,8 @@ class Auth extends Controller
             if (post('postback')) {
                 return $this->restore_onSubmit();
             }
+        } catch (Swift_TransportException $e) {
+            Flash::error(Lang::get('backend::lang.auth.error_recover_smtp'));
         } catch (Exception $ex) {
             Flash::error($ex->getMessage());
         }

--- a/modules/backend/controllers/Auth.php
+++ b/modules/backend/controllers/Auth.php
@@ -1,5 +1,6 @@
 <?php namespace Backend\Controllers;
 
+use Log;
 use Mail;
 use Flash;
 use Config;
@@ -11,12 +12,10 @@ use BackendAuth;
 use ValidationException;
 use ApplicationException;
 use Backend\Models\AccessLog;
-use Swift_TransportException;
 use Backend\Classes\Controller;
 use System\Classes\UpdateManager;
 use Illuminate\Support\Facades\Lang;
 use Winter\Storm\Foundation\Http\Middleware\CheckForTrustedHost;
-use Winter\Storm\Exception\ApplicationException as ExceptionApplicationException;
 
 /**
  * Authentication controller
@@ -143,7 +142,8 @@ class Auth extends Controller
             if (post('postback')) {
                 return $this->restore_onSubmit();
             }
-        } catch (Swift_TransportException $e) {
+        } catch (\Swift_TransportException $ex) {
+            Log::error($ex);
             Flash::error(Lang::get('backend::lang.auth.error_recover_smtp'));
         } catch (Exception $ex) {
             Flash::error($ex->getMessage());

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -75,6 +75,7 @@ return [
         'cancel' => 'Cancel',
         'delete' => 'Delete',
         'ok' => 'OK',
+        'send_invitation_error' => "There seems to be an error with your SMTP configuration. Please check it and try again.\n\n If you don't want to configure it right now, please uncheck the 'Send invitation by email' checkbox."
     ],
     'dashboard' => [
         'menu_label' => 'Dashboard',

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -4,6 +4,7 @@ return [
     'auth' => [
         'title' => 'Administration Area',
         'invalid_login' => 'The details you entered did not match our records. Please double-check and try again.',
+        'error_recover_smtp' => "There seems to be an error with your SMTP configuration. Please check it before trying to use the 'recover password' feature."
     ],
     'field' => [
         'invalid_type' => 'Invalid field type used :type.',

--- a/modules/backend/models/User.php
+++ b/modules/backend/models/User.php
@@ -1,13 +1,12 @@
 <?php namespace Backend\Models;
 
+use Log;
 use Mail;
 use Event;
 use Backend;
 use BackendAuth;
 use Illuminate\Support\Facades\Lang;
-use Swift_TransportException;
 use Winter\Storm\Auth\Models\User as UserBase;
-use Winter\Storm\Exception\AjaxException;
 use Winter\Storm\Exception\ApplicationException;
 
 /**
@@ -131,7 +130,8 @@ class User extends UserBase
         if ($this->send_invite) {
             try {
                 $this->sendInvitation();
-            } catch (Swift_TransportException $e) {
+            } catch (\Swift_TransportException $ex) {
+                Log::error($ex);
                 throw new ApplicationException(Lang::get('backend::lang.account.send_invitation_error'));
             }
         }

--- a/modules/backend/models/User.php
+++ b/modules/backend/models/User.php
@@ -4,7 +4,11 @@ use Mail;
 use Event;
 use Backend;
 use BackendAuth;
+use Illuminate\Support\Facades\Lang;
+use Swift_TransportException;
 use Winter\Storm\Auth\Models\User as UserBase;
+use Winter\Storm\Exception\AjaxException;
+use Winter\Storm\Exception\ApplicationException;
 
 /**
  * Administrator user model
@@ -99,8 +103,7 @@ class User extends UserBase
     {
         if (is_string($options)) {
             $options = ['default' => $options];
-        }
-        elseif (!is_array($options)) {
+        } elseif (!is_array($options)) {
             $options = [];
         }
 
@@ -126,7 +129,11 @@ class User extends UserBase
         $this->restorePurgedValues();
 
         if ($this->send_invite) {
-            $this->sendInvitation();
+            try {
+                $this->sendInvitation();
+            } catch (Swift_TransportException $e) {
+                throw new ApplicationException(Lang::get('backend::lang.account.send_invitation_error'));
+            }
         }
     }
 


### PR DESCRIPTION
# Problem
- The errors thrown by Swift SMTP class were very cryptic to non-developers using backend features that require sending e-mails.

# Solution
- Following the philosophy of Winter CMS to be an user-friendly, out-of-the-box working for non-tech users, now there are try-catch blocks to be able to capture the Swift exceptions and then have the opportunity to show a more user-friendly oriented message, that also provides how to solve the SMTP issue at hand.

# Sreenshots

## before
![error-winter-create-user-notify](https://user-images.githubusercontent.com/9614642/140570723-09157b83-cc5f-49d8-97aa-8a0eeb3c98aa.png)

![error-backend-winter](https://user-images.githubusercontent.com/9614642/140570741-ef377b9c-1e13-4adc-a78f-e53b702120b6.jpg)

## after
![fix-ux-create-user-notify](https://user-images.githubusercontent.com/9614642/140570764-1fc42959-edf8-4912-aaa3-083fa2b03e50.png)

![fix-ux-recover-password-backend](https://user-images.githubusercontent.com/9614642/140570778-071a77c5-a87d-478e-a2f5-399d1fe120a1.png)


# Final considerations
- Other language files must be updated to reflect the new strings
- It should be able to manipulate the modal, to add buttons, for instance, to redirect to the SMTP configuration page. That would provide a better user flow from exceptions and error messages


<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/346"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

