### PR TITLE
Constrain project's support PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "source": "https://github.com/wintercms/winter"
     },
     "require": {
-        "php": ">=7.2.9",
+        "php": "^7.2.9|^8.0",
         "winter/storm": "dev-develop as 1.1.999",
         "winter/wn-system-module": "dev-develop as 1.1.999",
         "winter/wn-backend-module": "dev-develop as 1.1.999",


### PR DESCRIPTION
Setting this PHP version constraint should make it more obvious to other developers PHP 8.1 is not supported and will not work.

This might also prevent developers from creating a new project using `composer create-project` on PHP 8.1, although I haven't personally tested this. But, this would be the desired outcome and hopefully composer notifies them the PHP version they are using is not supported.

<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/361"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

