### PR TITLE
Fix return type hints for CMS Page and Controller.

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -1336,7 +1336,7 @@ class Controller
      * @param mixed $name Specifies the Cms Page file name.
      * @param array $parameters Route parameters to consider in the URL.
      * @param bool $routePersistence By default the existing routing parameters will be included
-     * @return string
+     * @return string|null
      */
     public function pageUrl($name, $parameters = [], $routePersistence = true)
     {
@@ -1519,7 +1519,7 @@ class Controller
     /**
      * Searches the layout and page components by a partial file
      * @param string $partial
-     * @return ComponentBase The component object, if found
+     * @return ComponentBase|null The component object, if found
      */
     public function findComponentByPartial($partial)
     {

--- a/modules/cms/classes/Page.php
+++ b/modules/cms/classes/Page.php
@@ -117,7 +117,7 @@ class Page extends CmsCompoundObject
      * Helper that makes a URL for a page in the active theme.
      * @param mixed $page Specifies the Cms Page file name.
      * @param array $params Route parameters to consider in the URL.
-     * @return string
+     * @return string|null
      */
     public static function url($page, array $params = [])
     {


### PR DESCRIPTION
Fixed a couple of type hints I came across which didn't include null as a possible return type.

<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/362"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

