### PR TITLE
Fixing datepicker readOnly property

### DIFF
--- a/modules/backend/formwidgets/datepicker/partials/_picker_date.htm
+++ b/modules/backend/formwidgets/datepicker/partials/_picker_date.htm
@@ -7,6 +7,5 @@
         class="form-control align-right"
         autocomplete="off"
         <?= $field->getAttributes() ?>
-        <?= ($field->readOnly && !$field->disabled) ? 'disabled="disabled"' : '' ?>
         data-datepicker />
 </div>

--- a/modules/backend/formwidgets/datepicker/partials/_picker_date.htm
+++ b/modules/backend/formwidgets/datepicker/partials/_picker_date.htm
@@ -6,6 +6,7 @@
         id="<?= $this->getId('date') ?>"
         class="form-control align-right"
         autocomplete="off"
+        <?= $field->readOnly ? $field->disabled = true : '' ?>
         <?= $field->getAttributes() ?>
         data-datepicker />
 </div>

--- a/modules/backend/formwidgets/datepicker/partials/_picker_date.htm
+++ b/modules/backend/formwidgets/datepicker/partials/_picker_date.htm
@@ -7,5 +7,6 @@
         class="form-control align-right"
         autocomplete="off"
         <?= $field->getAttributes() ?>
+        <?= ($field->readOnly && !$field->disabled) ? 'disabled="disabled"' : '' ?>
         data-datepicker />
 </div>

--- a/modules/backend/formwidgets/datepicker/partials/_picker_time.htm
+++ b/modules/backend/formwidgets/datepicker/partials/_picker_time.htm
@@ -7,6 +7,5 @@
         class="form-control align-right"
         autocomplete="off"
         <?= $field->getAttributes() ?>
-        <?= ($field->readOnly && !$field->disabled) ? 'disabled="disabled"' : '' ?>
         data-timepicker />
 </div>

--- a/modules/backend/formwidgets/datepicker/partials/_picker_time.htm
+++ b/modules/backend/formwidgets/datepicker/partials/_picker_time.htm
@@ -6,6 +6,7 @@
         id="<?= $this->getId('time') ?>"
         class="form-control align-right"
         autocomplete="off"
+        <?= $field->readOnly ? $field->disabled = true : '' ?>
         <?= $field->getAttributes() ?>
         data-timepicker />
 </div>

--- a/modules/backend/formwidgets/datepicker/partials/_picker_time.htm
+++ b/modules/backend/formwidgets/datepicker/partials/_picker_time.htm
@@ -7,5 +7,6 @@
         class="form-control align-right"
         autocomplete="off"
         <?= $field->getAttributes() ?>
+        <?= ($field->readOnly && !$field->disabled) ? 'disabled="disabled"' : '' ?>
         data-timepicker />
 </div>

--- a/modules/system/assets/ui/js/datepicker.js
+++ b/modules/system/assets/ui/js/datepicker.js
@@ -58,6 +58,14 @@
             this.initTimePicker()
         }
 
+        if (this.$datePicker.prop('readonly')) {
+            this.$datePicker.prop('disabled', true)
+        }
+
+        if (this.$timePicker.prop('readonly')) {
+            this.$timePicker.prop('disabled', true)
+        }
+
         if (changeMonitor !== undefined) {
             changeMonitor.resume()
         }

--- a/modules/system/assets/ui/js/datepicker.js
+++ b/modules/system/assets/ui/js/datepicker.js
@@ -58,14 +58,6 @@
             this.initTimePicker()
         }
 
-        if (this.$datePicker.prop('readonly')) {
-            this.$datePicker.prop('disabled', true)
-        }
-
-        if (this.$timePicker.prop('readonly')) {
-            this.$timePicker.prop('disabled', true)
-        }
-
         if (changeMonitor !== undefined) {
             changeMonitor.resume()
         }


### PR DESCRIPTION
Fixes https://github.com/wintercms/winter/issues/363

`&& !$field->disabled` check is used so `diabled` attribute doesn't get added the second time if also used in `<?= $field->getAttributes() ?>` (if `disabled: true` also is specified).

<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/367"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

