### PR TITLE
Added settings for VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,29 @@
 {
     "files.associations": {
+        "**/modules/*/behaviors/*/partials/*.htm": "php",
+        "**/modules/*/controllers/*.htm": "php",
+        "**/modules/*/formwidgets/*/partials/*.htm": "php",
+        "**/modules/*/layouts/*.htm": "php",
+        "**/modules/*/models/*/*.htm": "php",
+        "**/modules/*/partials/*.htm": "php",
+        "**/modules/*/reportwidgets/*/partials/*.htm": "php",
+        "**/modules/*/views/mail/*.htm": "wintercms",
+        "**/modules/*/widgets/*/partials/*.htm": "php",
+        
+        "**/plugins/*/*/behaviors/*/partials/*.htm": "php",
         "**/plugins/*/*/components/*/*.htm": "twig",
-        "**/plugins/*/*/controllers/*/*.htm": "php",
+        "**/plugins/*/*/controllers/*.htm": "php",
+        "**/plugins/*/*/formwidgets/*/partials/*.htm": "php",
+        "**/plugins/*/*/layouts/*.htm": "php",
         "**/plugins/*/*/models/*/*.htm": "php",
+        "**/plugins/*/*/partials/*.htm": "php",
         "**/plugins/*/*/reportwidgets/*/partials/*.htm": "php",
+        "**/plugins/*/*/views/mail/*.htm": "wintercms",
         "**/plugins/*/*/widgets/*/partials/*.htm": "php",
+        
+        "**/themes/*/content/**/*.htm": "wintercms",
         "**/themes/*/layouts/*.htm": "wintercms",
+        "**/themes/*/pages/**/*.htm": "wintercms",
         "**/themes/*/partials/**/*.htm": "wintercms"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "files.associations": {
+        "**/plugins/*/*/components/*/*.htm": "twig",
+        "**/plugins/*/*/controllers/*/*.htm": "php",
+        "**/plugins/*/*/models/*/*.htm": "php",
+        "**/plugins/*/*/reportwidgets/*/partials/*.htm": "php",
+        "**/plugins/*/*/widgets/*/partials/*.htm": "php",
+        "**/themes/*/layouts/*.htm": "wintercms",
+        "**/themes/*/partials/**/*.htm": "wintercms"
+	}
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,5 @@
         "**/plugins/*/*/widgets/*/partials/*.htm": "php",
         "**/themes/*/layouts/*.htm": "wintercms",
         "**/themes/*/partials/**/*.htm": "wintercms"
-	}
+    }
 }


### PR DESCRIPTION
This pull request adds a setting for the VSCode editor.
This will ensure that files with the `.htm` extension have the correct code highlighting and functionality for the corresponding programming language.

<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/414"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

