### PR TITLE
Altered order of operations to ensure modules are seeded before plugins

### DIFF
--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -165,16 +165,6 @@ class UpdateManager
         }
 
         /*
-         * Update plugins
-         */
-        foreach ($plugins as $code => $plugin) {
-            $this->updatePlugin($code);
-        }
-
-        Parameter::set('system::update.count', 0);
-        CacheHelper::clear();
-
-        /*
          * Seed modules
          */
         if ($firstUp) {
@@ -183,6 +173,16 @@ class UpdateManager
                 $this->seedModule($module);
             }
         }
+
+        /*
+         * Update plugins
+         */
+        foreach ($plugins as $code => $plugin) {
+            $this->updatePlugin($code);
+        }
+
+        Parameter::set('system::update.count', 0);
+        CacheHelper::clear();
 
         // Set replacement warning messages
         foreach ($this->pluginManager->getReplacementMap() as $alias => $plugin) {


### PR DESCRIPTION
If a plugin has seeds that interacts with module tables, this can cause issues as currently the module seeders will be ran after the plugin seeders.

This PR is a simple change that alters the `UpdateManager` to run module seeders before updating plugins.


<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/419"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

