### PR TITLE
Added asset filter

### DIFF
--- a/modules/system/twig/Extension.php
+++ b/modules/system/twig/Extension.php
@@ -1,11 +1,11 @@
 <?php namespace System\Twig;
 
-use Twig\TwigFunction as TwigSimpleFunction;
 use Url;
 use System\Classes\ImageResizer;
 use System\Classes\MediaLibrary;
 use System\Classes\MarkupManager;
 use Twig\TwigFilter as TwigSimpleFilter;
+use Twig\TwigFunction as TwigSimpleFunction;
 use Twig\Extension\AbstractExtension as TwigExtension;
 
 /**

--- a/modules/system/twig/Extension.php
+++ b/modules/system/twig/Extension.php
@@ -61,12 +61,12 @@ class Extension extends TwigExtension
     public function getFilters()
     {
         $filters = [
-            new TwigSimpleFilter('app', [$this, 'appFilter'], ['is_safe' => ['html']]),
-            new TwigSimpleFilter('media', [$this, 'mediaFilter'], ['is_safe' => ['html']]),
-            new TwigSimpleFilter('asset', [$this, 'assetFilter'], ['is_safe' => ['html']]),
-            new TwigSimpleFilter('resize', [$this, 'resizeFilter'], ['is_safe' => ['html']]),
-            new TwigSimpleFilter('imageWidth', [$this, 'imageWidthFilter'], ['is_safe' => ['html']]),
-            new TwigSimpleFilter('imageHeight', [$this, 'imageHeightFilter'], ['is_safe' => ['html']]),
+            new TwigSimpleFilter('app', [$this, 'appFilter']),
+            new TwigSimpleFilter('media', [$this, 'mediaFilter']),
+            new TwigSimpleFilter('asset', [$this, 'assetFilter']),
+            new TwigSimpleFilter('resize', [$this, 'resizeFilter']),
+            new TwigSimpleFilter('imageWidth', [$this, 'imageWidthFilter']),
+            new TwigSimpleFilter('imageHeight', [$this, 'imageHeightFilter']),
         ];
 
         /*

--- a/modules/system/twig/Extension.php
+++ b/modules/system/twig/Extension.php
@@ -55,6 +55,7 @@ class Extension extends TwigExtension
         $filters = [
             new TwigSimpleFilter('app', [$this, 'appFilter'], ['is_safe' => ['html']]),
             new TwigSimpleFilter('media', [$this, 'mediaFilter'], ['is_safe' => ['html']]),
+            new TwigSimpleFilter('asset', [$this, 'assetFilter'], ['is_safe' => ['html']]),
             new TwigSimpleFilter('resize', [$this, 'resizeFilter'], ['is_safe' => ['html']]),
             new TwigSimpleFilter('imageWidth', [$this, 'imageWidthFilter'], ['is_safe' => ['html']]),
             new TwigSimpleFilter('imageHeight', [$this, 'imageHeightFilter'], ['is_safe' => ['html']]),
@@ -103,6 +104,16 @@ class Extension extends TwigExtension
     public function mediaFilter($file)
     {
         return MediaLibrary::url($file);
+    }
+
+    /**
+     * Converts supplied file to a URL relative to the `app.asset_url` config.
+     * @param string $file Specifies the asset-relative file
+     * @return string
+     */
+    public function assetFilter($file)
+    {
+        return Url::asset($file);
     }
 
     /**

--- a/modules/system/twig/Extension.php
+++ b/modules/system/twig/Extension.php
@@ -1,5 +1,6 @@
 <?php namespace System\Twig;
 
+use Twig\TwigFunction as TwigSimpleFunction;
 use Url;
 use System\Classes\ImageResizer;
 use System\Classes\MediaLibrary;
@@ -35,7 +36,14 @@ class Extension extends TwigExtension
      */
     public function getFunctions()
     {
-        $functions = [];
+        $functions = [
+            new TwigSimpleFunction('app', [$this, 'appFilter']),
+            new TwigSimpleFunction('media', [$this, 'mediaFilter']),
+            new TwigSimpleFunction('asset', [$this, 'assetFilter']),
+            new TwigSimpleFunction('resize', [$this, 'resizeFilter']),
+            new TwigSimpleFunction('imageWidth', [$this, 'imageWidthFilter']),
+            new TwigSimpleFunction('imageHeight', [$this, 'imageHeightFilter']),
+        ];
 
         /*
          * Include extensions provided by plugins


### PR DESCRIPTION
This PR adds an asset filter to twig.

```twig
{{ 'path/to/asset.png' | asset }}
// this is the equivilant to the blade
{{ asset('path/to/asset.png') }}
```

<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/428"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

