### PR TITLE
Docs UI - fix link fontawesome

### DIFF
--- a/modules/system/assets/ui/docs/icon.md
+++ b/modules/system/assets/ui/docs/icon.md
@@ -1,6 +1,6 @@
 # Icon library
 
-Winter provides an icon library with icons of various descriptions, based on the popular [Font Awesome collection](http://fortawesome.github.io/Font-Awesome/).
+Winter provides an icon library with icons of various descriptions, based on the popular [Font Awesome collection](https://fontawesome.com/v4.7).
 
 ### Inline icons
 


### PR DESCRIPTION
Are there any plans to replace the icon library from FontAwesome 4.x to FontAwesome 6.x ?

https://github.com/FortAwesome/Font-Awesome/releases
https://packagist.org/packages/fortawesome/font-awesome

https://fontawesome.com/v6.0/icons?m=free

<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/441"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

