### PR TITLE
Fix yaml parser

### DIFF
--- a/modules/system/classes/VersionYamlProcessor.php
+++ b/modules/system/classes/VersionYamlProcessor.php
@@ -28,7 +28,12 @@ class VersionYamlProcessor extends YamlProcessor
 
             // Add quotes around any unquoted text following an array key
             // specifically to ensure usage of !!! in unquoted comments does not fail
-            $line = preg_replace('/^\s*([^\n\r\-:]+)\s*: +(?![\'"\s])(.*)/m', '$1: "$2"', $line);
+            // Also replace quotes with single quotes within the value
+            $line = preg_replace_callback('/^\s*([^\n\r\-:]+)\s*: +(?![\'"\s])(.*)/m', function ($matches) {
+                $key = $matches[1];
+                $value = str_replace('"', "'", $matches[2]);
+                return "$key: \"$value\"";
+            }, rtrim($line));
 
             // If this line is the continuance of a multi-line string, remove the quote from the previous line and
             // continue the quote
@@ -40,8 +45,12 @@ class VersionYamlProcessor extends YamlProcessor
                 $line .= '"';
             }
 
-            // Add quotes around any unquoted array items
-            $line = preg_replace('/^(\s*-\s*)(?![\'" ])(.*)/m', '$1"$2"', $line);
+            // Add quotes around any unquoted array items and replace quotes with single quotes within the item
+            $line = preg_replace_callback('/^(\s*-\s*)(?![\'" ])(.*)/m', function ($matches) {
+                $key = $matches[1];
+                $value = str_replace('"', "'", $matches[2]);
+                return "$key \"$value\"";
+            }, $line);
         }
 
         return implode("\n", $lines);


### PR DESCRIPTION
This fixes Yaml file parsing (e.g. version.yaml files) like so:
```
1.1.1: this is a "new" release
1.1.2: !!! warning this is a "new" release
1.1.3:
  - my "new" item
  - my "other" item
```

gets replaced with:
```
1.1.1: "this is a 'new' release"
1.1.2: "!!! warning this is a 'new' release"
1.1.3:
  - "my 'new' item"
  - "my 'other' item"
```


<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/460"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

