### PR TITLE
Move scaffold commands

### DIFF
--- a/modules/backend/ServiceProvider.php
+++ b/modules/backend/ServiceProvider.php
@@ -20,6 +20,7 @@ class ServiceProvider extends ModuleServiceProvider
      */
     public function register()
     {
+        $this->registerConsole();
         $this->registerMailer();
         $this->registerAssetBundles();
 
@@ -43,6 +44,16 @@ class ServiceProvider extends ModuleServiceProvider
     public function boot()
     {
         parent::boot('backend');
+    }
+
+    /**
+     * Register console commands
+     */
+    protected function registerConsole()
+    {
+        $this->registerConsoleCommand('create.controller', \Backend\Console\CreateController::class);
+        $this->registerConsoleCommand('create.formwidget', \Backend\Console\CreateFormWidget::class);
+        $this->registerConsoleCommand('create.reportwidget', \Backend\Console\CreateReportWidget::class);
     }
 
     /**

--- a/modules/backend/console/CreateController.php
+++ b/modules/backend/console/CreateController.php
@@ -1,0 +1,87 @@
+<?php namespace Backend\Console;
+
+use Winter\Storm\Scaffold\GeneratorCommand;
+use Winter\Storm\Support\Str;
+
+class CreateController extends GeneratorCommand
+{
+    /**
+     * The default command name for lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'create:controller';
+
+    /**
+     * The name and signature of this command.
+     *
+     * @var string
+     */
+    protected $signature = 'create:controller
+        {plugin : The name of the plugin. <info>(eg: Winter.Blog)</info>}
+        {controller : The name of the controller to generate. <info>(eg: Posts)</info>}
+        {--force : Overwrite existing files with generated files.}
+        {--model= : Defines the model name to use. If not provided, the singular name of the controller is used.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new controller.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Controller';
+
+    /**
+     * A mapping of stub to generated file.
+     *
+     * @var array
+     */
+    protected $stubs = [
+        'scaffold/controller/_list_toolbar.stub' => 'controllers/{{lower_name}}/_list_toolbar.htm',
+        'scaffold/controller/config_form.stub'   => 'controllers/{{lower_name}}/config_form.yaml',
+        'scaffold/controller/config_list.stub'   => 'controllers/{{lower_name}}/config_list.yaml',
+        'scaffold/controller/create.stub'        => 'controllers/{{lower_name}}/create.htm',
+        'scaffold/controller/index.stub'         => 'controllers/{{lower_name}}/index.htm',
+        'scaffold/controller/preview.stub'       => 'controllers/{{lower_name}}/preview.htm',
+        'scaffold/controller/update.stub'        => 'controllers/{{lower_name}}/update.htm',
+        'scaffold/controller/controller.stub'    => 'controllers/{{studly_name}}.php',
+    ];
+
+    /**
+     * Prepare variables for stubs.
+     *
+     * return @array
+     */
+    protected function prepareVars()
+    {
+        $pluginCode = $this->argument('plugin');
+
+        $parts = explode('.', $pluginCode);
+        $plugin = array_pop($parts);
+        $author = array_pop($parts);
+
+        $controller = $this->argument('controller');
+
+        /*
+         * Determine the model name to use,
+         * either supplied or singular from the controller name.
+         */
+        $model = $this->option('model');
+        if (!$model) {
+            $model = Str::singular($controller);
+        }
+
+        return [
+            'name' => $controller,
+            'model' => $model,
+            'author' => $author,
+            'plugin' => $plugin
+        ];
+    }
+}

--- a/modules/backend/console/CreateFormWidget.php
+++ b/modules/backend/console/CreateFormWidget.php
@@ -1,0 +1,71 @@
+<?php namespace Backend\Console;
+
+use Winter\Storm\Scaffold\GeneratorCommand;
+
+class CreateFormWidget extends GeneratorCommand
+{
+    /**
+     * The default command name for lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'create:formwidget';
+
+    /**
+     * The name and signature of this command.
+     *
+     * @var string
+     */
+    protected $signature = 'create:formwidget
+        {plugin : The name of the plugin. <info>(eg: Winter.Blog)</info>}
+        {widget : The name of the form widget to generate. <info>(eg: PostList)</info>}
+        {--force : Overwrite existing files with generated files.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new form widget.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'FormWidget';
+
+    /**
+     * A mapping of stub to generated file.
+     *
+     * @var array
+     */
+    protected $stubs = [
+        'scaffold/formwidget/formwidget.stub'      => 'formwidgets/{{studly_name}}.php',
+        'scaffold/formwidget/partial.stub'         => 'formwidgets/{{lower_name}}/partials/_{{lower_name}}.htm',
+        'scaffold/formwidget/stylesheet.stub'      => 'formwidgets/{{lower_name}}/assets/css/{{lower_name}}.css',
+        'scaffold/formwidget/javascript.stub'      => 'formwidgets/{{lower_name}}/assets/js/{{lower_name}}.js',
+    ];
+
+    /**
+     * Prepare variables for stubs.
+     *
+     * return @array
+     */
+    protected function prepareVars()
+    {
+        $pluginCode = $this->argument('plugin');
+
+        $parts = explode('.', $pluginCode);
+        $plugin = array_pop($parts);
+        $author = array_pop($parts);
+
+        $widget = $this->argument('widget');
+
+        return [
+            'name' => $widget,
+            'author' => $author,
+            'plugin' => $plugin
+        ];
+    }
+}

--- a/modules/backend/console/CreateReportWidget.php
+++ b/modules/backend/console/CreateReportWidget.php
@@ -1,0 +1,69 @@
+<?php namespace Backend\Console;
+
+use Winter\Storm\Scaffold\GeneratorCommand;
+
+class CreateReportWidget extends GeneratorCommand
+{
+    /**
+     * The default command name for lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'create:reportwidget';
+
+    /**
+     * The name and signature of this command.
+     *
+     * @var string
+     */
+    protected $signature = 'create:reportwidget
+        {plugin : The name of the plugin. <info>(eg: Winter.Blog)</info>}
+        {widget : The name of the report widget to generate. <info>(eg: PostViews)</info>}
+        {--force : Overwrite existing files with generated files.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new report widget.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'ReportWidget';
+
+    /**
+     * A mapping of stub to generated file.
+     *
+     * @var array
+     */
+    protected $stubs = [
+        'scaffold/reportwidget/reportwidget.stub' => 'reportwidgets/{{studly_name}}.php',
+        'scaffold/reportwidget/widget.stub'       => 'reportwidgets/{{lower_name}}/partials/_{{lower_name}}.htm',
+    ];
+
+    /**
+     * Prepare variables for stubs.
+     *
+     * return @array
+     */
+    protected function prepareVars()
+    {
+        $pluginCode = $this->argument('plugin');
+
+        $parts = explode('.', $pluginCode);
+        $plugin = array_pop($parts);
+        $author = array_pop($parts);
+
+        $widget = $this->argument('widget');
+
+        return [
+            'name' => $widget,
+            'author' => $author,
+            'plugin' => $plugin
+        ];
+    }
+}

--- a/modules/backend/console/scaffold/controller/_list_toolbar.stub
+++ b/modules/backend/console/scaffold/controller/_list_toolbar.stub
@@ -1,0 +1,21 @@
+<div data-control="toolbar">
+    <a
+        href="<?= Backend::url('{{lower_author}}/{{lower_plugin}}/{{lower_name}}/create') ?>"
+        class="btn btn-primary wn-icon-plus">
+        New {{title_singular_name}}
+    </a>
+
+    <button
+        class="btn btn-danger wn-icon-trash-o"
+        disabled="disabled"
+        onclick="$(this).data('request-data', { checked: $('.control-list').listWidget('getChecked') })"
+        data-request="onDelete"
+        data-request-confirm="Are you sure you want to delete the selected {{title_plural_name}}?"
+        data-trigger-action="enable"
+        data-trigger=".control-list input[type=checkbox]"
+        data-trigger-condition="checked"
+        data-request-success="$(this).prop('disabled', 'disabled')"
+        data-stripe-load-indicator>
+        Delete selected
+    </button>
+</div>

--- a/modules/backend/console/scaffold/controller/config_form.stub
+++ b/modules/backend/console/scaffold/controller/config_form.stub
@@ -1,0 +1,31 @@
+# ===================================
+#  Form Behavior Config
+# ===================================
+
+# Record name
+name: {{title_singular_name}}
+
+# Model Form Field configuration
+form: $/{{lower_author}}/{{lower_plugin}}/models/{{lower_model}}/fields.yaml
+
+# Model Class name
+modelClass: {{studly_author}}\{{studly_plugin}}\Models\{{studly_model}}
+
+# Default redirect location
+defaultRedirect: {{lower_author}}/{{lower_plugin}}/{{lower_name}}
+
+# Create page
+create:
+    title: backend::lang.form.create_title
+    redirect: {{lower_author}}/{{lower_plugin}}/{{lower_name}}/update/:id
+    redirectClose: {{lower_author}}/{{lower_plugin}}/{{lower_name}}
+
+# Update page
+update:
+    title: backend::lang.form.update_title
+    redirect: {{lower_author}}/{{lower_plugin}}/{{lower_name}}
+    redirectClose: {{lower_author}}/{{lower_plugin}}/{{lower_name}}
+
+# Preview page
+preview:
+    title: backend::lang.form.preview_title

--- a/modules/backend/console/scaffold/controller/config_list.stub
+++ b/modules/backend/console/scaffold/controller/config_list.stub
@@ -1,0 +1,50 @@
+# ===================================
+#  List Behavior Config
+# ===================================
+
+# Model List Column configuration
+list: $/{{lower_author}}/{{lower_plugin}}/models/{{lower_model}}/columns.yaml
+
+# Model Class name
+modelClass: {{studly_author}}\{{studly_plugin}}\Models\{{studly_model}}
+
+# List Title
+title: Manage {{title_plural_name}}
+
+# Link URL for each record
+recordUrl: {{lower_author}}/{{lower_plugin}}/{{lower_name}}/update/:id
+
+# Message to display if the list is empty
+noRecordsMessage: backend::lang.list.no_records
+
+# Records to display per page
+recordsPerPage: 20
+
+# Options to provide the user when selecting how many records to display per page
+perPageOptions: [20, 40, 80, 100, 120]
+
+# Display page numbers with pagination, disable to improve performance
+showPageNumbers: true
+
+# Displays the list column set up button
+showSetup: true
+
+# Displays the sorting link on each column
+showSorting: true
+
+# Default sorting column
+# defaultSort:
+#     column: created_at
+#     direction: desc
+
+# Display checkboxes next to each record
+showCheckboxes: true
+
+# Toolbar widget configuration
+toolbar:
+    # Partial for toolbar buttons
+    buttons: list_toolbar
+
+    # Search widget configuration
+    search:
+        prompt: backend::lang.list.search_prompt

--- a/modules/backend/console/scaffold/controller/controller.stub
+++ b/modules/backend/console/scaffold/controller/controller.stub
@@ -1,0 +1,25 @@
+<?php namespace {{studly_author}}\{{studly_plugin}}\Controllers;
+
+use BackendMenu;
+use Backend\Classes\Controller;
+
+/**
+ * {{title_name}} Back-end Controller
+ */
+class {{studly_name}} extends Controller
+{
+    /**
+     * @var array Behaviors that are implemented by this controller.
+     */
+    public $implement = [
+        \Backend\Behaviors\FormController::class,
+        \Backend\Behaviors\ListController::class,
+    ];
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        BackendMenu::setContext('{{studly_author}}.{{studly_plugin}}', '{{lower_plugin}}', '{{lower_name}}');
+    }
+}

--- a/modules/backend/console/scaffold/controller/create.stub
+++ b/modules/backend/console/scaffold/controller/create.stub
@@ -1,0 +1,48 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('{{lower_author}}/{{lower_plugin}}/{{lower_name}}') ?>">{{title_name}}</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <?= Form::open(['class' => 'layout']) ?>
+
+        <div class="layout-row">
+            <?= $this->formRender() ?>
+        </div>
+
+        <div class="form-buttons">
+            <div class="loading-indicator-container">
+                <button
+                    type="submit"
+                    data-request="onSave"
+                    data-hotkey="ctrl+s, cmd+s"
+                    data-load-indicator="Creating {{singular_name}}..."
+                    class="btn btn-primary">
+                    Create
+                </button>
+                <button
+                    type="button"
+                    data-request="onSave"
+                    data-request-data="close:1"
+                    data-hotkey="ctrl+enter, cmd+enter"
+                    data-load-indicator="Creating {{singular_name}}..."
+                    class="btn btn-default">
+                    Create and Close
+                </button>
+                <span class="btn-text">
+                    or <a href="<?= Backend::url('{{lower_author}}/{{lower_plugin}}/{{lower_name}}') ?>">Cancel</a>
+                </span>
+            </div>
+        </div>
+
+    <?= Form::close() ?>
+
+<?php else: ?>
+
+    <p class="flash-message static error"><?= e($this->fatalError) ?></p>
+    <p><a href="<?= Backend::url('{{lower_author}}/{{lower_plugin}}/{{lower_name}}') ?>" class="btn btn-default">Return to {{lower_title_name}} list</a></p>
+
+<?php endif ?>

--- a/modules/backend/console/scaffold/controller/index.stub
+++ b/modules/backend/console/scaffold/controller/index.stub
@@ -1,0 +1,2 @@
+
+<?= $this->listRender() ?>

--- a/modules/backend/console/scaffold/controller/preview.stub
+++ b/modules/backend/console/scaffold/controller/preview.stub
@@ -1,0 +1,19 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('{{lower_author}}/{{lower_plugin}}/{{lower_name}}') ?>">{{title_name}}</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <div class="form-preview">
+        <?= $this->formRenderPreview() ?>
+    </div>
+
+<?php else: ?>
+
+    <p class="flash-message static error"><?= e($this->fatalError) ?></p>
+    <p><a href="<?= Backend::url('{{lower_author}}/{{lower_plugin}}/{{lower_name}}') ?>" class="btn btn-default">Return to {{lower_title_name}} list</a></p>
+
+<?php endif ?>

--- a/modules/backend/console/scaffold/controller/update.stub
+++ b/modules/backend/console/scaffold/controller/update.stub
@@ -1,0 +1,56 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('{{lower_author}}/{{lower_plugin}}/{{lower_name}}') ?>">{{title_name}}</a></li>
+        <li><?= e($this->pageTitle) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <?= Form::open(['class' => 'layout']) ?>
+
+        <div class="layout-row">
+            <?= $this->formRender() ?>
+        </div>
+
+        <div class="form-buttons">
+            <div class="loading-indicator-container">
+                <button
+                    type="submit"
+                    data-request="onSave"
+                    data-request-data="redirect:0"
+                    data-hotkey="ctrl+s, cmd+s"
+                    data-load-indicator="Saving {{singular_name}}..."
+                    class="btn btn-primary">
+                    <u>S</u>ave
+                </button>
+                <button
+                    type="button"
+                    data-request="onSave"
+                    data-request-data="close:1"
+                    data-hotkey="ctrl+enter, cmd+enter"
+                    data-load-indicator="Saving {{singular_name}}..."
+                    class="btn btn-default">
+                    Save and Close
+                </button>
+                <button
+                    type="button"
+                    class="wn-icon-trash-o btn-icon danger pull-right"
+                    data-request="onDelete"
+                    data-load-indicator="Deleting {{singular_name}}..."
+                    data-request-confirm="Delete this {{lower_singular_name}}?">
+                </button>
+                <span class="btn-text">
+                    or <a href="<?= Backend::url('{{lower_author}}/{{lower_plugin}}/{{lower_name}}') ?>">Cancel</a>
+                </span>
+            </div>
+        </div>
+
+    <?= Form::close() ?>
+
+<?php else: ?>
+
+    <p class="flash-message static error"><?= e($this->fatalError) ?></p>
+    <p><a href="<?= Backend::url('{{lower_author}}/{{lower_plugin}}/{{lower_name}}') ?>" class="btn btn-default">Return to {{lower_title_name}} list</a></p>
+
+<?php endif ?>

--- a/modules/backend/console/scaffold/formwidget/formwidget.stub
+++ b/modules/backend/console/scaffold/formwidget/formwidget.stub
@@ -1,0 +1,57 @@
+<?php namespace {{studly_author}}\{{studly_plugin}}\FormWidgets;
+
+use Backend\Classes\FormWidgetBase;
+
+/**
+ * {{name}} Form Widget
+ */
+class {{studly_name}} extends FormWidgetBase
+{
+    /**
+     * @inheritDoc
+     */
+    protected $defaultAlias = '{{lower_author}}_{{lower_plugin}}_{{snake_name}}';
+
+    /**
+     * @inheritDoc
+     */
+    public function init()
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function render()
+    {
+        $this->prepareVars();
+        return $this->makePartial('{{lower_name}}');
+    }
+
+    /**
+     * Prepares the form widget view data
+     */
+    public function prepareVars()
+    {
+        $this->vars['name'] = $this->formField->getName();
+        $this->vars['value'] = $this->getLoadValue();
+        $this->vars['model'] = $this->model;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function loadAssets()
+    {
+        $this->addCss('css/{{lower_name}}.css', '{{author}}.{{plugin}}');
+        $this->addJs('js/{{lower_name}}.js', '{{author}}.{{plugin}}');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSaveValue($value)
+    {
+        return $value;
+    }
+}

--- a/modules/backend/console/scaffold/formwidget/javascript.stub
+++ b/modules/backend/console/scaffold/formwidget/javascript.stub
@@ -1,0 +1,5 @@
+/*
+ * This is a sample JavaScript file used by {{name}}
+ *
+ * You can delete this file if you want
+ */

--- a/modules/backend/console/scaffold/formwidget/partial.stub
+++ b/modules/backend/console/scaffold/formwidget/partial.stub
@@ -1,0 +1,17 @@
+<?php if ($this->previewMode): ?>
+
+    <div class="form-control">
+        <?= $value ?>
+    </div>
+
+<?php else: ?>
+
+    <input
+        type="text"
+        id="<?= $this->getId('input') ?>"
+        name="<?= $name ?>"
+        value="<?= $value ?>"
+        class="form-control"
+        autocomplete="off" />
+
+<?php endif ?>

--- a/modules/backend/console/scaffold/formwidget/stylesheet.stub
+++ b/modules/backend/console/scaffold/formwidget/stylesheet.stub
@@ -1,0 +1,5 @@
+/*
+ * This is a sample StyleSheet file used by {{name}}
+ *
+ * You can delete this file if you want
+ */

--- a/modules/backend/console/scaffold/reportwidget/reportwidget.stub
+++ b/modules/backend/console/scaffold/reportwidget/reportwidget.stub
@@ -1,0 +1,63 @@
+<?php namespace {{studly_author}}\{{studly_plugin}}\ReportWidgets;
+
+use Backend\Classes\ReportWidgetBase;
+use Exception;
+
+/**
+ * {{name}} Report Widget
+ */
+class {{studly_name}} extends ReportWidgetBase
+{
+    /**
+     * @var string The default alias to use for this widget
+     */
+    protected $defaultAlias = '{{studly_name}}ReportWidget';
+
+    /**
+     * Defines the widget's properties
+     * @return array
+     */
+    public function defineProperties()
+    {
+        return [
+            'title' => [
+                'title'             => 'backend::lang.dashboard.widget_title_label',
+                'default'           => '{{title_name}} Report Widget',
+                'type'              => 'string',
+                'validationPattern' => '^.+$',
+                'validationMessage' => 'backend::lang.dashboard.widget_title_error',
+            ],
+        ];
+    }
+    
+    /**
+     * Adds widget specific asset files. Use $this->addJs() and $this->addCss()
+     * to register new assets to include on the page.
+     * @return void
+     */
+    protected function loadAssets()
+    {
+    }
+    
+    /**
+     * Renders the widget's primary contents.
+     * @return string HTML markup supplied by this widget.
+     */
+    public function render()
+    {
+        try {
+            $this->prepareVars();
+        } catch (Exception $ex) {
+            $this->vars['error'] = $ex->getMessage();
+        }
+
+        return $this->makePartial('{{lower_name}}');
+    }
+
+    /**
+     * Prepares the report widget view data
+     */
+    public function prepareVars()
+    {
+    }
+}

--- a/modules/backend/console/scaffold/reportwidget/widget.stub
+++ b/modules/backend/console/scaffold/reportwidget/widget.stub
@@ -1,0 +1,9 @@
+<div class="report-widget">
+    <h3><?= e($this->property('title')) ?></h3>
+
+    <?php if (!isset($error)): ?>
+        <p>This is the default partial content.</p>
+    <?php else: ?>
+        <p class="flash-message static warning"><?= e($error) ?></p>
+    <?php endif ?>
+</div>

--- a/modules/cms/ServiceProvider.php
+++ b/modules/cms/ServiceProvider.php
@@ -78,6 +78,9 @@ class ServiceProvider extends ModuleServiceProvider
      */
     protected function registerConsole()
     {
+        $this->registerConsoleCommand('create.component', \Cms\Console\CreateComponent::class);
+        $this->registerConsoleCommand('create.theme', \Cms\Console\CreateTheme::class);
+
         $this->registerConsoleCommand('theme.install', \Cms\Console\ThemeInstall::class);
         $this->registerConsoleCommand('theme.remove', \Cms\Console\ThemeRemove::class);
         $this->registerConsoleCommand('theme.list', \Cms\Console\ThemeList::class);

--- a/modules/cms/console/CreateComponent.php
+++ b/modules/cms/console/CreateComponent.php
@@ -1,0 +1,68 @@
+<?php namespace Cms\Console;
+
+use Winter\Storm\Scaffold\GeneratorCommand;
+
+class CreateComponent extends GeneratorCommand
+{
+    /**
+     * The default command name for lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'create:component';
+
+    /**
+     * The name and signature of this command.
+     *
+     * @var string
+     */
+    protected $signature = 'create:component
+        {plugin : The name of the plugin. <info>(eg: Winter.Blog)</info>}
+        {component : The name of the component to generate. <info>(eg: Posts)</info>}
+        {--force : Overwrite existing files with generated files.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new plugin component.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Component';
+
+    /**
+     * A mapping of stub to generated file.
+     *
+     * @var array
+     */
+    protected $stubs = [
+        'scaffold/component/component.stub'  => 'components/{{studly_name}}.php',
+        'scaffold/component/default.stub' => 'components/{{lower_name}}/default.htm',
+    ];
+
+    /**
+     * Prepare variables for stubs.
+     *
+     * return @array
+     */
+    protected function prepareVars()
+    {
+        $pluginCode = $this->argument('plugin');
+
+        $parts = explode('.', $pluginCode);
+        $plugin = array_pop($parts);
+        $author = array_pop($parts);
+        $component = $this->argument('component');
+
+        return [
+            'name' => $component,
+            'author' => $author,
+            'plugin' => $plugin
+        ];
+    }
+}

--- a/modules/cms/console/CreateTheme.php
+++ b/modules/cms/console/CreateTheme.php
@@ -1,0 +1,121 @@
+<?php namespace Cms\Console;
+
+use Exception;
+use Winter\Storm\Scaffold\GeneratorCommand;
+
+class CreateTheme extends GeneratorCommand
+{
+    /**
+     * The default command name for lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'create:theme';
+
+    /**
+     * The name and signature of this command.
+     *
+     * @var string
+     */
+    protected $signature = 'create:theme
+        {theme : The name of the theme to create. <info>(eg: MyTheme)</info>}
+        {--force : Overwrite existing files with generated files.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new theme.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Theme';
+
+    /**
+     * A mapping of stub to generated file.
+     *
+     * @var array
+     */
+    protected $stubs = [
+        'scaffold/theme/assets/js/app.stub' => 'assets/js/app.js',
+        'scaffold/theme/assets/less/theme.stub' => 'assets/less/theme.less',
+        'scaffold/theme/layouts/default.stub' => 'layouts/default.htm',
+        'scaffold/theme/pages/404.stub' => 'pages/404.htm',
+        'scaffold/theme/pages/error.stub' => 'pages/error.htm',
+        'scaffold/theme/pages/home.stub' => 'pages/home.htm',
+        'scaffold/theme/partials/meta/seo.stub' => 'partials/meta/seo.htm',
+        'scaffold/theme/partials/meta/styles.stub' => 'partials/meta/styles.htm',
+        'scaffold/theme/partials/site/header.stub' => 'partials/site/header.htm',
+        'scaffold/theme/partials/site/footer.stub' => 'partials/site/footer.htm',
+        'scaffold/theme/theme.stub' => 'theme.yaml',
+        'scaffold/theme/version.stub' => 'version.yaml',
+    ];
+
+    /**
+     * Prepare variables for stubs.
+     *
+     * return @array
+     */
+    protected function prepareVars()
+    {
+        /*
+         * Extract the author and name from the plugin code
+         */
+        $code = str_slug($this->argument('theme'));
+
+        return [
+            'code' => $code,
+        ];
+    }
+
+    /**
+     * Get the plugin path from the input.
+     *
+     * @return string
+     */
+    protected function getDestinationPath()
+    {
+        $code = $this->prepareVars()['code'];
+
+        return themes_path($code);
+    }
+
+    /**
+     * Make a single stub.
+     *
+     * @param string $stubName The source filename for the stub.
+     */
+    public function makeStub($stubName)
+    {
+        if (!isset($this->stubs[$stubName])) {
+            return;
+        }
+
+        $sourceFile = $this->getSourcePath() . '/' . $stubName;
+        $destinationFile = $this->getDestinationPath() . '/' . $this->stubs[$stubName];
+        $destinationContent = $this->files->get($sourceFile);
+
+        /*
+         * Parse each variable in to the destination content and path
+         */
+        foreach ($this->vars as $key => $var) {
+            $destinationContent = str_replace('{{' . $key . '}}', $var, $destinationContent);
+            $destinationFile = str_replace('{{' . $key . '}}', $var, $destinationFile);
+        }
+
+        $this->makeDirectory($destinationFile);
+
+        /*
+         * Make sure this file does not already exist
+         */
+        if ($this->files->exists($destinationFile) && !$this->option('force')) {
+            throw new Exception('Stop everything!!! This file already exists: ' . $destinationFile);
+        }
+
+        $this->files->put($destinationFile, $destinationContent);
+    }
+}

--- a/modules/cms/console/scaffold/component/component.stub
+++ b/modules/cms/console/scaffold/component/component.stub
@@ -1,0 +1,19 @@
+<?php namespace {{studly_author}}\{{studly_plugin}}\Components;
+
+use Cms\Classes\ComponentBase;
+
+class {{studly_name}} extends ComponentBase
+{
+    public function componentDetails()
+    {
+        return [
+            'name'        => '{{name}} Component',
+            'description' => 'No description provided yet...'
+        ];
+    }
+
+    public function defineProperties()
+    {
+        return [];
+    }
+}

--- a/modules/cms/console/scaffold/component/default.stub
+++ b/modules/cms/console/scaffold/component/default.stub
@@ -1,0 +1,3 @@
+<p>This is the default markup for component {{name}}</p>
+
+<small>You can delete this file if you want</small>

--- a/modules/cms/console/scaffold/theme/assets/js/app.stub
+++ b/modules/cms/console/scaffold/theme/assets/js/app.stub
@@ -1,0 +1,33 @@
+/*
+ * Application
+ */
+(function($) {
+    "use strict";
+
+    jQuery(document).ready(function($) {
+        /*-------------------------------
+        WINTER CMS FLASH MESSAGE HANDLING
+        ---------------------------------*/
+        $(document).on('ajaxSetup', function(event, context) {
+            // Enable AJAX handling of Flash messages on all AJAX requests
+            context.options.flash = true;
+
+            // Enable the StripeLoadIndicator on all AJAX requests
+            context.options.loading = $.oc.stripeLoadIndicator;
+
+            // Handle Flash Messages
+            context.options.handleFlashMessage = function(message, type) {
+                $.oc.flashMsg({ text: message, class: type });
+            };
+
+            // Handle Error Messages
+            context.options.handleErrorMessage = function(message) {
+                $.oc.flashMsg({ text: message, class: 'error' });
+            };
+        });
+    });
+}(jQuery));
+
+if (typeof(gtag) !== 'function') {
+    gtag = function() { console.log('GoogleAnalytics not present.'); }
+}

--- a/modules/cms/console/scaffold/theme/assets/less/theme.stub
+++ b/modules/cms/console/scaffold/theme/assets/less/theme.stub
@@ -1,0 +1,5 @@
+.content {
+    margin: 2em auto;
+    max-width: 1080px;
+    text-align: center;
+}

--- a/modules/cms/console/scaffold/theme/layouts/default.stub
+++ b/modules/cms/console/scaffold/theme/layouts/default.stub
@@ -1,0 +1,7 @@
+description = "Default layout"
+==
+{% partial "site/header" %}
+
+    {% page %}
+
+{% partial "site/footer" %}

--- a/modules/cms/console/scaffold/theme/pages/404.stub
+++ b/modules/cms/console/scaffold/theme/pages/404.stub
@@ -1,0 +1,8 @@
+title = "Page not found (404)"
+url = "/404"
+layout = "default"
+==
+<div class="content">
+    <h1>Page not found</h1>
+    <p>We're sorry, but the page you requested cannot be found.</p>
+</div>

--- a/modules/cms/console/scaffold/theme/pages/error.stub
+++ b/modules/cms/console/scaffold/theme/pages/error.stub
@@ -1,0 +1,8 @@
+title = "Error page (500)"
+url = "/error"
+layout = "default"
+==
+<div class="content">
+    <h1>Error</h1>
+    <p>We're sorry, but something went wrong and the page cannot be displayed.</p>
+</div>

--- a/modules/cms/console/scaffold/theme/pages/home.stub
+++ b/modules/cms/console/scaffold/theme/pages/home.stub
@@ -1,0 +1,7 @@
+title = "Home"
+url = "/"
+layout = "default"
+==
+<div class="content">
+    <h1>Home Page</h1>
+</div>

--- a/modules/cms/console/scaffold/theme/partials/meta/seo.stub
+++ b/modules/cms/console/scaffold/theme/partials/meta/seo.stub
@@ -1,0 +1,11 @@
+{% if this.theme.googleanalytics_id is not empty %}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ this.theme.googleanalytics_id }}"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '{{ this.theme.googleanalytics_id }}');
+    </script>
+{% endif %}

--- a/modules/cms/console/scaffold/theme/partials/meta/styles.stub
+++ b/modules/cms/console/scaffold/theme/partials/meta/styles.stub
@@ -1,0 +1,4 @@
+<link rel="stylesheet" href="{{ ['assets/less/theme.less'] | theme }}">
+
+{% styles %}
+{% placeholder head %}

--- a/modules/cms/console/scaffold/theme/partials/site/footer.stub
+++ b/modules/cms/console/scaffold/theme/partials/site/footer.stub
@@ -1,0 +1,17 @@
+        <!-- Scripts -->
+        <script src="{{ [
+            '@jquery',
+            '@framework',
+            '@framework.extras',
+
+            'assets/js/app.js',
+        ] | theme }}"></script>
+        {% scripts %}
+
+        {% flash %}
+            <p data-control="flash-message" data-interval="7" class="flashmessage {{ type }}">
+                {{ message }}
+            </p>
+        {% endflash %}
+    </body>
+</html>

--- a/modules/cms/console/scaffold/theme/partials/site/header.stub
+++ b/modules/cms/console/scaffold/theme/partials/site/header.stub
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>{% placeholder page_title default %}{{ this.page.title }}{% endplaceholder %}</title>
+        {% partial "meta/styles" %}
+        {% partial "meta/seo" %}
+        <meta name="generator" content="Winter CMS">
+    </head>
+    {% set pageId = this.page.id %}
+    {% set pageTitle = this.page.title %}
+    {% if pageId is empty %}
+        {% set pageId = page.id %}
+    {% endif %}
+    {% if pageTitle is empty %}
+        {% set pageTitle = page.title %}
+    {% endif %}
+    <body class="page-{{ pageId }} layout-{{ this.layout.id }}">

--- a/modules/cms/console/scaffold/theme/theme.stub
+++ b/modules/cms/console/scaffold/theme/theme.stub
@@ -1,0 +1,9 @@
+name: "{{code}}"
+description: "No description provided yet..."
+author: "Winter CMS Scaffold"
+homepage: "https://example.com"
+code: "{{code}}"
+form:
+    fields:
+        googleanalytics_id:
+            label: 'Google Analytics ID'

--- a/modules/cms/console/scaffold/theme/version.stub
+++ b/modules/cms/console/scaffold/theme/version.stub
@@ -1,0 +1,1 @@
+1.0.1: 'Initial version'

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -245,26 +245,31 @@ class ServiceProvider extends ModuleServiceProvider
         /*
          * Register console commands
          */
-        $this->registerConsoleCommand('winter.up', 'System\Console\WinterUp');
-        $this->registerConsoleCommand('winter.down', 'System\Console\WinterDown');
-        $this->registerConsoleCommand('winter.update', 'System\Console\WinterUpdate');
-        $this->registerConsoleCommand('winter.util', 'System\Console\WinterUtil');
-        $this->registerConsoleCommand('winter.mirror', 'System\Console\WinterMirror');
-        $this->registerConsoleCommand('winter.fresh', 'System\Console\WinterFresh');
-        $this->registerConsoleCommand('winter.env', 'System\Console\WinterEnv');
-        $this->registerConsoleCommand('winter.install', 'System\Console\WinterInstall');
-        $this->registerConsoleCommand('winter.passwd', 'System\Console\WinterPasswd');
-        $this->registerConsoleCommand('winter.version', 'System\Console\WinterVersion');
-        $this->registerConsoleCommand('winter.manifest', 'System\Console\WinterManifest');
-        $this->registerConsoleCommand('winter.test', 'System\Console\WinterTest');
+        $this->registerConsoleCommand('create.command', \System\Console\CreateCommand::class);
+        $this->registerConsoleCommand('create.model', \System\Console\CreateModel::class);
+        $this->registerConsoleCommand('create.plugin', \System\Console\CreatePlugin::class);
+        $this->registerConsoleCommand('create.settings', \System\Console\CreateSettings::class);
 
-        $this->registerConsoleCommand('plugin.install', 'System\Console\PluginInstall');
-        $this->registerConsoleCommand('plugin.remove', 'System\Console\PluginRemove');
-        $this->registerConsoleCommand('plugin.disable', 'System\Console\PluginDisable');
-        $this->registerConsoleCommand('plugin.enable', 'System\Console\PluginEnable');
-        $this->registerConsoleCommand('plugin.refresh', 'System\Console\PluginRefresh');
-        $this->registerConsoleCommand('plugin.rollback', 'System\Console\PluginRollback');
-        $this->registerConsoleCommand('plugin.list', 'System\Console\PluginList');
+        $this->registerConsoleCommand('winter.up', \System\Console\WinterUp::class);
+        $this->registerConsoleCommand('winter.down', \System\Console\WinterDown::class);
+        $this->registerConsoleCommand('winter.update', \System\Console\WinterUpdate::class);
+        $this->registerConsoleCommand('winter.util', \System\Console\WinterUtil::class);
+        $this->registerConsoleCommand('winter.mirror', \System\Console\WinterMirror::class);
+        $this->registerConsoleCommand('winter.fresh', \System\Console\WinterFresh::class);
+        $this->registerConsoleCommand('winter.env', \System\Console\WinterEnv::class);
+        $this->registerConsoleCommand('winter.install', \System\Console\WinterInstall::class);
+        $this->registerConsoleCommand('winter.passwd', \System\Console\WinterPasswd::class);
+        $this->registerConsoleCommand('winter.version', \System\Console\WinterVersion::class);
+        $this->registerConsoleCommand('winter.manifest', \System\Console\WinterManifest::class);
+        $this->registerConsoleCommand('winter.test', \System\Console\WinterTest::class);
+
+        $this->registerConsoleCommand('plugin.install', \System\Console\PluginInstall::class);
+        $this->registerConsoleCommand('plugin.remove', \System\Console\PluginRemove::class);
+        $this->registerConsoleCommand('plugin.disable', \System\Console\PluginDisable::class);
+        $this->registerConsoleCommand('plugin.enable', \System\Console\PluginEnable::class);
+        $this->registerConsoleCommand('plugin.refresh', \System\Console\PluginRefresh::class);
+        $this->registerConsoleCommand('plugin.rollback', \System\Console\PluginRollback::class);
+        $this->registerConsoleCommand('plugin.list', \System\Console\PluginList::class);
 
         $this->registerConsoleCommand('mix.install', \System\Console\MixInstall::class);
         $this->registerConsoleCommand('mix.list', \System\Console\MixList::class);

--- a/modules/system/aliases.php
+++ b/modules/system/aliases.php
@@ -88,4 +88,15 @@ return [
 
     // Illuminate's HtmlDumper was "dumped" in Laravel 6 - we'll route this to Symfony's HtmlDumper as Laravel have done.
     'Illuminate\Support\Debug\HtmlDumper' => Symfony\Component\VarDumper\Dumper\HtmlDumper::class,
+
+    // Scaffolds were moved from the Storm library into their corresponding modules.
+    'Winter\Storm\Scaffold\Console\CreateCommand'        => System\Console\CreateCommand::class,
+    'Winter\Storm\Scaffold\Console\CreateModel'          => System\Console\CreateModel::class,
+    'Winter\Storm\Scaffold\Console\CreatePlugin'         => System\Console\CreatePlugin::class,
+    'Winter\Storm\Scaffold\Console\CreateSettings'       => System\Console\CreateSettings::class,
+    'Winter\Storm\Scaffold\Console\CreateController'     => Backend\Console\CreateController::class,
+    'Winter\Storm\Scaffold\Console\CreateFormWidget'     => Backend\Console\CreateFormWidget::class,
+    'Winter\Storm\Scaffold\Console\CreateReportWidget'   => Backend\Console\CreateReportWidget::class,
+    'Winter\Storm\Scaffold\Console\CreateTheme'          => Cms\Console\CreateTheme::class,
+    'Winter\Storm\Scaffold\Console\CreateComponent'      => Cms\Console\CreateComponent::class,
 ];

--- a/modules/system/aliases.php
+++ b/modules/system/aliases.php
@@ -99,4 +99,14 @@ return [
     'Winter\Storm\Scaffold\Console\CreateReportWidget'   => Backend\Console\CreateReportWidget::class,
     'Winter\Storm\Scaffold\Console\CreateTheme'          => Cms\Console\CreateTheme::class,
     'Winter\Storm\Scaffold\Console\CreateComponent'      => Cms\Console\CreateComponent::class,
+
+    'October\Rain\Scaffold\Console\CreateCommand'        => System\Console\CreateCommand::class,
+    'October\Rain\Scaffold\Console\CreateModel'          => System\Console\CreateModel::class,
+    'October\Rain\Scaffold\Console\CreatePlugin'         => System\Console\CreatePlugin::class,
+    'October\Rain\Scaffold\Console\CreateSettings'       => System\Console\CreateSettings::class,
+    'October\Rain\Scaffold\Console\CreateController'     => Backend\Console\CreateController::class,
+    'October\Rain\Scaffold\Console\CreateFormWidget'     => Backend\Console\CreateFormWidget::class,
+    'October\Rain\Scaffold\Console\CreateReportWidget'   => Backend\Console\CreateReportWidget::class,
+    'October\Rain\Scaffold\Console\CreateTheme'          => Cms\Console\CreateTheme::class,
+    'October\Rain\Scaffold\Console\CreateComponent'      => Cms\Console\CreateComponent::class,
 ];

--- a/modules/system/console/CreateCommand.php
+++ b/modules/system/console/CreateCommand.php
@@ -1,0 +1,67 @@
+<?php namespace System\Console;
+
+use Winter\Storm\Scaffold\GeneratorCommand;
+
+class CreateCommand extends GeneratorCommand
+{
+    /**
+     * The default command name for lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'create:command';
+
+    /**
+     * The name and signature of this command.
+     *
+     * @var string
+     */
+    protected $signature = 'create:command
+        {plugin : The name of the plugin. <info>(eg: Winter.Blog)</info>}
+        {name : The name of the command to generate. <info>(eg: create)</info>}
+        {--force : Overwrite existing files with generated files.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new console command.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Command';
+
+    /**
+     * A mapping of stub to generated file.
+     *
+     * @var array
+     */
+    protected $stubs = [
+        'scaffold/command/command.stub' => 'console/{{studly_name}}.php',
+    ];
+
+    /**
+     * Prepare variables for stubs.
+     *
+     * return @array
+     */
+    protected function prepareVars()
+    {
+        $pluginCode = $this->argument('plugin');
+
+        $parts = explode('.', $pluginCode);
+        $plugin = array_pop($parts);
+        $author = array_pop($parts);
+        $command = $this->argument('name');
+
+        return [
+            'name' => $command,
+            'author' => $author,
+            'plugin' => $plugin
+        ];
+    }
+}

--- a/modules/system/console/CreateModel.php
+++ b/modules/system/console/CreateModel.php
@@ -1,0 +1,71 @@
+<?php namespace System\Console;
+
+use Winter\Storm\Scaffold\GeneratorCommand;
+
+class CreateModel extends GeneratorCommand
+{
+    /**
+     * The default command name for lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'create:model';
+
+    /**
+     * The name and signature of this command.
+     *
+     * @var string
+     */
+    protected $signature = 'create:model
+        {plugin : The name of the plugin. <info>(eg: Winter.Blog)</info>}
+        {model : The name of the model to generate. <info>(eg: Post)</info>}
+        {--force : Overwrite existing files with generated files.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new model.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Model';
+
+    /**
+     * A mapping of stub to generated file.
+     *
+     * @var array
+     */
+    protected $stubs = [
+        'scaffold/model/model.stub'        => 'models/{{studly_name}}.php',
+        'scaffold/model/fields.stub'       => 'models/{{lower_name}}/fields.yaml',
+        'scaffold/model/columns.stub'      => 'models/{{lower_name}}/columns.yaml',
+        'scaffold/model/create_table.stub' => 'updates/create_{{snake_plural_name}}_table.php',
+    ];
+
+    /**
+     * Prepare variables for stubs.
+     *
+     * return @array
+     */
+    protected function prepareVars()
+    {
+        $pluginCode = $this->argument('plugin');
+
+        $parts = explode('.', $pluginCode);
+        $plugin = array_pop($parts);
+        $author = array_pop($parts);
+
+        $model = $this->argument('model');
+
+        return [
+            'name' => $model,
+            'author' => $author,
+            'plugin' => $plugin
+        ];
+    }
+}

--- a/modules/system/console/CreatePlugin.php
+++ b/modules/system/console/CreatePlugin.php
@@ -1,0 +1,75 @@
+<?php namespace System\Console;
+
+use Winter\Storm\Scaffold\GeneratorCommand;
+
+class CreatePlugin extends GeneratorCommand
+{
+    /**
+     * The default command name for lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'create:plugin';
+
+    /**
+     * The name and signature of this command.
+     *
+     * @var string
+     */
+    protected $signature = 'create:plugin
+        {plugin : The name of the plugin to create. <info>(eg: Winter.Blog)</info>}
+        {--force : Overwrite existing files with generated files.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new plugin.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Plugin';
+
+    /**
+     * A mapping of stub to generated file.
+     *
+     * @var array
+     */
+    protected $stubs = [
+        'scaffold/plugin/plugin.stub'  => 'Plugin.php',
+        'scaffold/plugin/version.stub' => 'updates/version.yaml',
+    ];
+
+    /**
+     * Prepare variables for stubs.
+     *
+     * return @array
+     */
+    protected function prepareVars()
+    {
+        /*
+         * Extract the author and name from the plugin code
+         */
+        $pluginCode = $this->argument('plugin');
+        $parts = explode('.', $pluginCode);
+
+        if (count($parts) != 2) {
+            $this->error('Invalid plugin name, either too many dots or not enough.');
+            $this->error('Example name: AuthorName.PluginName');
+            return;
+        }
+
+
+        $pluginName = array_pop($parts);
+        $authorName = array_pop($parts);
+
+        return [
+            'name'   => $pluginName,
+            'author' => $authorName,
+        ];
+    }
+}

--- a/modules/system/console/CreateSettings.php
+++ b/modules/system/console/CreateSettings.php
@@ -1,0 +1,68 @@
+<?php namespace System\Console;
+
+use Winter\Storm\Scaffold\GeneratorCommand;
+
+class CreateSettings extends GeneratorCommand
+{
+    /**
+     * The default command name for lazy loading.
+     *
+     * @var string|null
+     */
+    protected static $defaultName = 'create:settings';
+
+    /**
+     * The name and signature of this command.
+     *
+     * @var string
+     */
+    protected $signature = 'create:settings
+        {plugin : The name of the plugin. <info>(eg: Winter.Blog)</info>}
+        {settings : The name of the settings model to generate. <info>(eg: BlogSettings)</info>}
+        {--force : Overwrite existing files with generated files.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new settings model.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Settings Model';
+
+    /**
+     * A mapping of stubs to generated files.
+     *
+     * @var array
+     */
+    protected $stubs = [
+        'scaffold/settings/model.stub' => 'models/{{studly_name}}.php',
+        'scaffold/settings/fields.stub'   => 'models/{{lower_name}}/fields.yaml'
+    ];
+
+    /**
+     * Prepare variables for stubs.
+     *
+     * return @array
+     */
+    protected function prepareVars()
+    {
+        $pluginCode = $this->argument('plugin');
+
+        $parts = explode('.', $pluginCode);
+        $plugin = array_pop($parts);
+        $author = array_pop($parts);
+        $settings = $this->argument('settings') ?? 'Settings';
+
+        return [
+            'name' => $settings,
+            'author' => $author,
+            'plugin' => $plugin
+        ];
+    }
+}

--- a/modules/system/console/scaffold/command/command.stub
+++ b/modules/system/console/scaffold/command/command.stub
@@ -1,0 +1,63 @@
+<?php namespace {{studly_author}}\{{studly_plugin}}\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+
+class {{studly_name}} extends Command
+{
+    /**
+     * @var string The console command name.
+     */
+    protected static $defaultName = '{{lower_plugin}}:{{lower_name}}';
+
+    /**
+     * @var string The console command description.
+     */
+    protected $description = 'No description provided yet...';
+
+    /**
+     * Execute the console command.
+     * @return void
+     */
+    public function handle()
+    {
+        $this->output->writeln('Hello world!');
+    }
+
+    /**
+     * Get the console command arguments.
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [];
+    }
+
+    /**
+     * Get the console command options.
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+
+    /**
+     * Provide autocompletion for this command's input
+     */
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        // Suggest values for arguments provided by this command
+        // if ($input->mustSuggestArgumentValuesFor('nameOfArgument')) {
+        //     $suggestions->suggestValues(['valid', 'argument', 'values', 'here']]);
+        // }
+
+        // Suggest values for options provided by this command
+        // if ($input->mustSuggestOptionValuesFor('nameOfOption')) {
+        //     $suggestions->suggestValues(['valid', 'option', 'values', 'here']);
+        // }
+    }
+}

--- a/modules/system/console/scaffold/model/columns.stub
+++ b/modules/system/console/scaffold/model/columns.stub
@@ -1,0 +1,8 @@
+# ===================================
+#  List Column Definitions
+# ===================================
+
+columns:
+    id:
+        label: ID
+        searchable: true

--- a/modules/system/console/scaffold/model/create_table.stub
+++ b/modules/system/console/scaffold/model/create_table.stub
@@ -1,0 +1,22 @@
+<?php namespace {{studly_author}}\{{studly_plugin}}\Updates;
+
+use Schema;
+use Winter\Storm\Database\Schema\Blueprint;
+use Winter\Storm\Database\Updates\Migration;
+
+class Create{{studly_plural_name}}Table extends Migration
+{
+    public function up()
+    {
+        Schema::create('{{lower_author}}_{{lower_plugin}}_{{snake_plural_name}}', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            $table->increments('id');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('{{lower_author}}_{{lower_plugin}}_{{snake_plural_name}}');
+    }
+}

--- a/modules/system/console/scaffold/model/create_table.stub
+++ b/modules/system/console/scaffold/model/create_table.stub
@@ -1,10 +1,9 @@
-<?php namespace {{studly_author}}\{{studly_plugin}}\Updates;
+<?php
 
-use Schema;
 use Winter\Storm\Database\Schema\Blueprint;
 use Winter\Storm\Database\Updates\Migration;
 
-class Create{{studly_plural_name}}Table extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -19,4 +18,4 @@ class Create{{studly_plural_name}}Table extends Migration
     {
         Schema::dropIfExists('{{lower_author}}_{{lower_plugin}}_{{snake_plural_name}}');
     }
-}
+};

--- a/modules/system/console/scaffold/model/fields.stub
+++ b/modules/system/console/scaffold/model/fields.stub
@@ -1,0 +1,8 @@
+# ===================================
+#  Form Field Definitions
+# ===================================
+
+fields:
+    id:
+        label: ID
+        disabled: true

--- a/modules/system/console/scaffold/model/model.stub
+++ b/modules/system/console/scaffold/model/model.stub
@@ -1,0 +1,74 @@
+<?php namespace {{studly_author}}\{{studly_plugin}}\Models;
+
+use Model;
+
+/**
+ * {{name}} Model
+ */
+class {{studly_name}} extends Model
+{
+    use \Winter\Storm\Database\Traits\Validation;
+
+    /**
+     * @var string The database table used by the model.
+     */
+    public $table = '{{lower_author}}_{{lower_plugin}}_{{snake_plural_name}}';
+
+    /**
+     * @var array Guarded fields
+     */
+    protected $guarded = ['*'];
+
+    /**
+     * @var array Fillable fields
+     */
+    protected $fillable = [];
+
+    /**
+     * @var array Validation rules for attributes
+     */
+    public $rules = [];
+
+    /**
+     * @var array Attributes to be cast to native types
+     */
+    protected $casts = [];
+
+    /**
+     * @var array Attributes to be cast to JSON
+     */
+    protected $jsonable = [];
+
+    /**
+     * @var array Attributes to be appended to the API representation of the model (ex. toArray())
+     */
+    protected $appends = [];
+
+    /**
+     * @var array Attributes to be removed from the API representation of the model (ex. toArray())
+     */
+    protected $hidden = [];
+
+    /**
+     * @var array Attributes to be cast to Argon (Carbon) instances
+     */
+    protected $dates = [
+        'created_at',
+        'updated_at'
+    ];
+
+    /**
+     * @var array Relations
+     */
+    public $hasOne = [];
+    public $hasMany = [];
+    public $hasOneThrough = [];
+    public $hasManyThrough = [];
+    public $belongsTo = [];
+    public $belongsToMany = [];
+    public $morphTo = [];
+    public $morphOne = [];
+    public $morphMany = [];
+    public $attachOne = [];
+    public $attachMany = [];
+}

--- a/modules/system/console/scaffold/plugin/plugin.stub
+++ b/modules/system/console/scaffold/plugin/plugin.stub
@@ -1,0 +1,98 @@
+<?php namespace {{studly_author}}\{{studly_name}};
+
+use Backend;
+use Backend\Models\UserRole;
+use System\Classes\PluginBase;
+
+/**
+ * {{name}} Plugin Information File
+ */
+class Plugin extends PluginBase
+{
+    /**
+     * Returns information about this plugin.
+     *
+     * @return array
+     */
+    public function pluginDetails()
+    {
+        return [
+            'name'        => '{{name}}',
+            'description' => 'No description provided yet...',
+            'author'      => '{{author}}',
+            'icon'        => 'icon-leaf'
+        ];
+    }
+
+    /**
+     * Register method, called when the plugin is first registered.
+     *
+     * @return void
+     */
+    public function register()
+    {
+
+    }
+
+    /**
+     * Boot method, called right before the request route.
+     *
+     * @return array
+     */
+    public function boot()
+    {
+
+    }
+
+    /**
+     * Registers any front-end components implemented in this plugin.
+     *
+     * @return array
+     */
+    public function registerComponents()
+    {
+        return []; // Remove this line to activate
+
+        return [
+            '{{studly_author}}\{{studly_name}}\Components\MyComponent' => 'myComponent',
+        ];
+    }
+
+    /**
+     * Registers any back-end permissions used by this plugin.
+     *
+     * @return array
+     */
+    public function registerPermissions()
+    {
+        return []; // Remove this line to activate
+
+        return [
+            '{{lower_author}}.{{lower_name}}.some_permission' => [
+                'tab' => '{{name}}',
+                'label' => 'Some permission',
+                'roles' => [UserRole::CODE_DEVELOPER, UserRole::CODE_PUBLISHER],
+            ],
+        ];
+    }
+
+    /**
+     * Registers back-end navigation items for this plugin.
+     *
+     * @return array
+     */
+    public function registerNavigation()
+    {
+        return []; // Remove this line to activate
+
+        return [
+            '{{lower_name}}' => [
+                'label'       => '{{name}}',
+                'url'         => Backend::url('{{lower_author}}/{{lower_name}}/mycontroller'),
+                'icon'        => 'icon-leaf',
+                'permissions' => ['{{lower_author}}.{{lower_name}}.*'],
+                'order'       => 500,
+            ],
+        ];
+    }
+}

--- a/modules/system/console/scaffold/plugin/version.stub
+++ b/modules/system/console/scaffold/plugin/version.stub
@@ -1,0 +1,1 @@
+1.0.0: First version of {{name}}

--- a/modules/system/console/scaffold/settings/fields.stub
+++ b/modules/system/console/scaffold/settings/fields.stub
@@ -1,0 +1,7 @@
+# ===================================
+#  Form Field Definitions
+# ===================================
+
+fields:
+    settings_option:
+        label: This is a sample settings field used by {{author}}.{{plugin}}

--- a/modules/system/console/scaffold/settings/model.stub
+++ b/modules/system/console/scaffold/settings/model.stub
@@ -1,0 +1,31 @@
+<?php namespace {{studly_author}}\{{studly_plugin}}\Models;
+
+use Model;
+
+/**
+ * {{name}} Model
+ */
+class {{studly_name}} extends Model
+{
+    use \Winter\Storm\Database\Traits\Validation;
+
+    /**
+     * @var array Behaviors implemented by this model.
+     */
+    public $implement = ['System.Behaviors.SettingsModel'];
+
+    /**
+     * @var string Unique code
+     */
+    public $settingsCode = '{{lower_author}}_{{lower_plugin}}_{{lower_name}}';
+
+    /**
+     * @var mixed Settings form field definitions
+     */
+    public $settingsFields = 'fields.yaml';
+
+    /**
+     * @var array Validation rules
+     */
+    public $rules = [];
+}

--- a/modules/system/providers.php
+++ b/modules/system/providers.php
@@ -30,7 +30,6 @@ return [
     Winter\Storm\Html\HtmlServiceProvider::class,
     Winter\Storm\Html\UrlServiceProvider::class,
     Winter\Storm\Network\NetworkServiceProvider::class,
-    Winter\Storm\Scaffold\ScaffoldServiceProvider::class,
     Winter\Storm\Flash\FlashServiceProvider::class,
     Winter\Storm\Mail\MailServiceProvider::class,
     Winter\Storm\Argon\ArgonServiceProvider::class,


### PR DESCRIPTION
Fixes #270.

Moves the Scaffolding commands out of Storm, and into the modules that the scaffold generates code for.

As discussed in the issue above, this makes more sense to keep Storm agnostic, and allows for the commands to be hidden if a particular module is not used in a Winter instance.

<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/471"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

