### PR TITLE
[FIX] Switched file to storage for plugin disabled

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -9,6 +9,7 @@ use Lang;
 use View;
 use Config;
 use Schema;
+use Storage;
 use SystemException;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
@@ -91,7 +92,7 @@ class PluginManager
     protected function init()
     {
         $this->bindContainerObjects();
-        $this->metaFile = storage_path('cms/disabled.json');
+        $this->metaFile = 'cms/disabled.json';
         $this->loadDisabled();
         $this->loadPlugins();
 
@@ -607,7 +608,7 @@ class PluginManager
      */
     public function clearDisabledCache()
     {
-        File::delete($this->metaFile);
+        Storage::delete($this->metaFile);
         $this->disabledPlugins = [];
     }
 
@@ -626,8 +627,8 @@ class PluginManager
             }
         }
 
-        if (File::exists($path)) {
-            $disabled = json_decode(File::get($path), true) ?: [];
+        if (Storage::exists($path)) {
+            $disabled = json_decode(Storage::get($path), true) ?: [];
             $this->disabledPlugins = array_merge($this->disabledPlugins, $disabled);
         } else {
             $this->populateDisabledPluginsFromDb();
@@ -657,7 +658,7 @@ class PluginManager
      */
     protected function writeDisabled()
     {
-        File::put($this->metaFile, json_encode($this->disabledPlugins));
+        Storage::put($this->metaFile, json_encode($this->disabledPlugins));
     }
 
     /**


### PR DESCRIPTION
Simple fix to allow for `disabled.json` to use the storage facade rather than file, this creates support for read only filesystems

<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/474"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

