### PR TITLE
Fix isActive for CMS page with "/" as URL

### DIFF
--- a/modules/cms/classes/Page.php
+++ b/modules/cms/classes/Page.php
@@ -209,7 +209,7 @@ class Page extends CmsCompoundObject
 
             $result = [];
             $result['url'] = $pageUrl;
-            $result['isActive'] = rtrim($pageUrl, "/") === rtrim($url, "/");
+            $result['isActive'] = rtrim($pageUrl, '/') === rtrim($url, '/');
             $result['mtime'] = $page ? $page->mtime : null;
         }
 

--- a/modules/cms/classes/Page.php
+++ b/modules/cms/classes/Page.php
@@ -209,7 +209,7 @@ class Page extends CmsCompoundObject
 
             $result = [];
             $result['url'] = $pageUrl;
-            $result['isActive'] = $pageUrl == $url;
+            $result['isActive'] = $pageUrl === trim($url, "/");
             $result['mtime'] = $page ? $page->mtime : null;
         }
 

--- a/modules/cms/classes/Page.php
+++ b/modules/cms/classes/Page.php
@@ -209,7 +209,7 @@ class Page extends CmsCompoundObject
 
             $result = [];
             $result['url'] = $pageUrl;
-            $result['isActive'] = $pageUrl === trim($url, "/");
+            $result['isActive'] = rtrim($pageUrl, "/") === rtrim($url, "/");
             $result['mtime'] = $page ? $page->mtime : null;
         }
 

--- a/tests/unit/cms/classes/PageTest.php
+++ b/tests/unit/cms/classes/PageTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Cms\Classes\Controller;
+use Cms\Classes\Page;
+use Cms\Classes\Theme;
+
+class PageTest extends TestCase
+{
+    public function setUp() : void
+    {
+        parent::setUp();
+
+    }
+
+    public function testResolveMenuItem()
+    {
+        $themeName = 'test';
+
+        $theme = Theme::load($themeName);
+        $controller = new Controller;
+
+        $item = (object) [
+            'type' => 'cms-page',
+            'reference' => 'index',
+        ];
+
+        // fake current URL to be the same as menu item reference page with extra "/" at the end.
+        $url = $controller->pageUrl($item->reference) . '/';
+
+        $result = Page::resolveMenuItem($item, $url, $theme);
+
+        $this->assertTrue($result['isActive']);
+    }
+}

--- a/tests/unit/cms/classes/PageTest.php
+++ b/tests/unit/cms/classes/PageTest.php
@@ -6,11 +6,6 @@ use Cms\Classes\Theme;
 
 class PageTest extends TestCase
 {
-    public function setUp() : void
-    {
-        parent::setUp();
-    }
-
     public function testResolveMenuItem()
     {
         $themeName = 'test';

--- a/tests/unit/cms/classes/PageTest.php
+++ b/tests/unit/cms/classes/PageTest.php
@@ -8,9 +8,7 @@ class PageTest extends TestCase
 {
     public function testResolveMenuItem()
     {
-        $themeName = 'test';
-
-        $theme = Theme::load($themeName);
+        $theme = Theme::load('test');
         $controller = new Controller;
 
         $item = (object) [
@@ -18,11 +16,15 @@ class PageTest extends TestCase
             'reference' => 'index',
         ];
 
-        // fake current URL to be the same as menu item reference page with extra "/" at the end.
-        $url = $controller->pageUrl($item->reference) . '/';
+        // Check to make sure that resolved menuItems for the provided URL are considered active
+        // with or without a trailing slash
+        $url = $controller->pageUrl($item->reference);
+        $trailingUrl = $url . '/';
 
         $result = Page::resolveMenuItem($item, $url, $theme);
+        $this->assertTrue($result['isActive']);
 
+        $result = Page::resolveMenuItem($item, $trailingUrl, $theme);
         $this->assertTrue($result['isActive']);
     }
 }

--- a/tests/unit/cms/classes/PageTest.php
+++ b/tests/unit/cms/classes/PageTest.php
@@ -9,7 +9,6 @@ class PageTest extends TestCase
     public function setUp() : void
     {
         parent::setUp();
-
     }
 
     public function testResolveMenuItem()


### PR DESCRIPTION
Fix #478 



<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/479"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

