### PR TITLE
Undefined variable $packagePath

### DIFF
--- a/modules/system/console/MixWatch.php
+++ b/modules/system/console/MixWatch.php
@@ -45,7 +45,7 @@ class MixWatch extends MixCompile
         $relativeMixJsPath = $package['mix'];
         if (!$this->canCompilePackage($relativeMixJsPath)) {
             $this->error(
-                sprintf('Unable to watch "%s", %s was not found in the package.json\'s workspaces.packages property. Try running mix:install first.', $name, $packagePath)
+                sprintf('Unable to watch "%s", %s was not found in the package.json\'s workspaces.packages property. Try running mix:install first.', $name, $name)
             );
             return 1;
         }

--- a/modules/system/console/MixWatch.php
+++ b/modules/system/console/MixWatch.php
@@ -45,7 +45,7 @@ class MixWatch extends MixCompile
         $relativeMixJsPath = $package['mix'];
         if (!$this->canCompilePackage($relativeMixJsPath)) {
             $this->error(
-                sprintf('Unable to watch "%s", %s was not found in the package.json\'s workspaces.packages property. Try running mix:install first.', $name, $name)
+                sprintf('Unable to watch "%s", %s was not found in the package.json\'s workspaces.packages property. Try running mix:install first.', $name, $relativeMixJsPath)
             );
             return 1;
         }


### PR DESCRIPTION
When the package is not present in package.json, the correct error is not thrown because $packagePath not exists. I'm not sure what kind of feedback you would like to send, with this edit it'll be something like:

"Unable to watch "packagename", packagename was not found in the package.json's workspaces.packages property. Try running mix:install first."

Cheers!

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->

<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/485"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

