### PR TITLE
Strip double / prefix when uploading to Media root directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "files.associations": {
         "**/modules/*/behaviors/*/partials/*.htm": "php",
-        "**/modules/*/controllers/*.htm": "php",
+        "**/modules/*/controllers/*/*.htm": "php",
         "**/modules/*/formwidgets/*/partials/*.htm": "php",
         "**/modules/*/layouts/*.htm": "php",
         "**/modules/*/models/*/*.htm": "php",

--- a/modules/backend/traits/UploadableWidget.php
+++ b/modules/backend/traits/UploadableWidget.php
@@ -80,7 +80,7 @@ trait UploadableWidget
             // Use the configured upload path unless it's null, in which case use the user-provided path
             $path = !empty($this->uploadPath) ? $this->uploadPath : Request::input('path');
             $path = MediaLibrary::validatePath($path);
-            $filePath = $path . '/' . $fileName;
+            $filePath = rtrim($path, '/') . '/' . $fileName;
 
             /*
              * getRealPath() can be empty for some environments (IIS)

--- a/modules/system/classes/MediaLibrary.php
+++ b/modules/system/classes/MediaLibrary.php
@@ -774,7 +774,7 @@ class MediaLibrary
      * communicating with the remote storage.
      * @return mixed Returns the storage disk object.
      */
-    protected function getStorageDisk()
+    public function getStorageDisk()
     {
         if ($this->storageDisk) {
             return $this->storageDisk;

--- a/modules/system/classes/MediaLibrary.php
+++ b/modules/system/classes/MediaLibrary.php
@@ -556,7 +556,7 @@ class MediaLibrary
      * @param string $path Specifies a path to process.
      * @return string Returns a processed string.
      */
-    protected function getMediaPath($path)
+    public function getMediaPath($path)
     {
         return $this->storageFolder.$path;
     }


### PR DESCRIPTION
When uploading to the Media Manager's root directory, the *media.file.upload* event will prefix the $path variable with two `/` characters. This PR strips the first one.

# Steps to Replicate:
* In any plugin add the following to your Plugin.php's `boot` method:
```php
Event::listen('media.file.upload', function (\Backend\Widgets\MediaManager $mediaWidget, string $path, \Symfony\Component\HttpFoundation\File\UploadedFile $uploadedFile) {
    \Log::info($path);
});
```
* Go to Backend - Media section and upload an image to the root directory. 
* Open */storage/logs/system.log* and see the filepath logged was *//myimage.jpg*

# The problem in depth

When uploading to the root directory, the following line produces a path of / because you're uploading to the Media Manager's root directory:
https://github.com/wintercms/winter/blob/86cfbfa98b46d4e700c2495ab929c21a4e46006d/modules/backend/traits/UploadableWidget.php#L81
On the very next line we call `validatePath`:
https://github.com/wintercms/winter/blob/86cfbfa98b46d4e700c2495ab929c21a4e46006d/modules/backend/traits/UploadableWidget.php#L82
which strips the `/` suffix but then adds it back as a prefix:
https://github.com/wintercms/winter/blob/86cfbfa98b46d4e700c2495ab929c21a4e46006d/modules/system/classes/MediaLibrary.php#L471
and finally on the next line, we add yet another `/` resulting in the behaviour we see in my issue:
https://github.com/wintercms/winter/blob/86cfbfa98b46d4e700c2495ab929c21a4e46006d/modules/backend/traits/UploadableWidget.php#L83

This should result in uploads to the root directory of the Media Manager having a `$path` of */myimage.jpg* as it should.

<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/491"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

