### PR TITLE
Convert afterFetch() method to an event handler for model.afterFetch

### DIFF
--- a/modules/cms/models/ThemeData.php
+++ b/modules/cms/models/ThemeData.php
@@ -53,6 +53,16 @@ class ThemeData extends Model
     protected static $instances = [];
 
     /**
+     * Constructor
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct();
+
+        $this->bindEvent('model.afterFetch', [$this, 'afterFetchHandler']);
+    }
+
+    /**
      * Before saving the model, strip dynamic attributes applied from config.
      * @return void
      */
@@ -109,7 +119,7 @@ class ThemeData extends Model
      * on form field definitions.
      * @return void
      */
-    public function afterFetch()
+    protected function afterFetchHandler()
     {
         $data = (array) $this->data + $this->getDefaultValues();
 

--- a/modules/cms/models/ThemeData.php
+++ b/modules/cms/models/ThemeData.php
@@ -121,14 +121,14 @@ class ThemeData extends Model
     {
         $data = (array) $this->data + $this->getDefaultValues();
 
-        /*
-         * Repeater form fields store arrays and must be jsonable.
-         */
         foreach ($this->getFormFields() as $id => $field) {
             if (!isset($field['type'])) {
                 continue;
             }
 
+            /*
+             * Repeater form fields store arrays and must be jsonable.
+             */
             if ($field['type'] === 'repeater') {
                 $this->jsonable[] = $id;
             }

--- a/modules/cms/models/ThemeData.php
+++ b/modules/cms/models/ThemeData.php
@@ -53,12 +53,10 @@ class ThemeData extends Model
     protected static $instances = [];
 
     /**
-     * Constructor
+     * after the model is booted, bind to 'model.afterFetch' event
      */
-    public function __construct(array $attributes = [])
+    public function afterBoot()
     {
-        parent::__construct();
-
         $this->bindEvent('model.afterFetch', [$this, 'afterFetchHandler']);
     }
 


### PR DESCRIPTION
This change allows a plugin to handle the `model.afterFetch` event AFTER the Model handler.

The current code uses the `afterFetch()` method which always runs AFTER any event handler.

ref. https://github.com/wintercms/storm/blob/develop/src/Database/Model.php#L162-L168

The alternative would be to modify the code referenced above in the base Database/Model, but that could lead to breakage in backward compatibility.

<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/494"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

