### PR TITLE
Multiple file attachments in theme customization

### DIFF
--- a/modules/cms/models/ThemeData.php
+++ b/modules/cms/models/ThemeData.php
@@ -113,19 +113,24 @@ class ThemeData extends Model
     {
         $data = (array) $this->data + $this->getDefaultValues();
 
-        /*
-         * Repeater form fields store arrays and must be jsonable.
-         */
         foreach ($this->getFormFields() as $id => $field) {
             if (!isset($field['type'])) {
                 continue;
             }
 
+            /*
+             * Repeater form fields store arrays and must be jsonable.
+             */
             if ($field['type'] === 'repeater') {
                 $this->jsonable[] = $id;
             }
             elseif ($field['type'] === 'fileupload') {
-                $this->attachOne[$id] = File::class;
+                if (array_get($field, 'multiple', false)) {
+                    $this->attachMany[$id] = File::class;
+                }
+                else {
+                    $this->attachOne[$id] = File::class;
+                }
                 unset($data[$id]);
             }
         }

--- a/modules/cms/models/ThemeData.php
+++ b/modules/cms/models/ThemeData.php
@@ -127,8 +127,7 @@ class ThemeData extends Model
             elseif ($field['type'] === 'fileupload') {
                 if (array_get($field, 'multiple', false)) {
                     $this->attachMany[$id] = File::class;
-                }
-                else {
+                } else {
                     $this->attachOne[$id] = File::class;
                 }
                 unset($data[$id]);


### PR DESCRIPTION
This PR add a `multiple` property to fields in [theme customization](https://wintercms.com/docs/themes/development#customization).  
If `multiple: true`, the field is added to `attachMany` and allow multiple files selection, in all other cases the current behavior applied.

<a href="https://gitpod.io/#https://github.com/wintercms/winter/pull/495"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

