### PR TITLE
Prevent error if accessing undefined $resizer variable

### DIFF
--- a/modules/system/classes/SystemController.php
+++ b/modules/system/classes/SystemController.php
@@ -72,7 +72,7 @@ class SystemController extends ControllerBase
         } catch (Exception $ex) {
             // If it failed for any other reason, restore the config so that
             // the resizer route will continue to work until it succeeds
-            if ($resizer) {
+            if (!empty($resizer)) {
                 $resizer->storeConfig();
             }
 


### PR DESCRIPTION
When exception happens within the `ImageResizer::fromIdentifier()` call, the $resizer variable is not defined within the catch() block