### PR TITLE
Allow disabling/enabling of sorting with Repeater widget

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -26,7 +26,7 @@ class Repeater extends FormWidgetBase
     /**
      * @var bool Items can be sorted.
      */
-    public $sortable = false;
+    public $sortable = true;
 
     /**
      * @var string Field name to use for the title of collapsed items

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -166,6 +166,7 @@ class Repeater extends FormWidgetBase
         $this->vars['titleFrom'] = $this->titleFrom;
         $this->vars['minItems'] = $this->minItems;
         $this->vars['maxItems'] = $this->maxItems;
+        $this->vars['sortable'] = $this->sortable;
         $this->vars['style'] = $this->style;
 
         $this->vars['useGroups'] = $this->useGroups;

--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -20,7 +20,9 @@
     var Repeater = function(element, options) {
         this.options   = options
         this.$el       = $(element)
-        this.$sortable = $(options.sortableContainer, this.$el)
+        if (this.options.sortable) {
+            this.$sortable = $(options.sortableContainer, this.$el)
+        }
 
         $.wn.foundation.controlUtils.markDisposable(element)
         Base.call(this)
@@ -36,6 +38,7 @@
         titleFrom: null,
         minItems: null,
         maxItems: null,
+        sortable: true,
         style: 'default',
     }
 
@@ -54,7 +57,9 @@
     }
 
     Repeater.prototype.dispose = function() {
-        this.$sortable.sortable('destroy')
+        if (this.options.sortable) {
+            this.$sortable.sortable('destroy')
+        }
 
         this.$el.off('ajaxDone', '> .field-repeater-items > .field-repeater-item > .repeater-item-remove > [data-repeater-remove]', this.proxy(this.onRemoveItemSuccess))
         this.$el.off('ajaxDone', '> .field-repeater-add-item > [data-repeater-add]', this.proxy(this.onAddItemSuccess))
@@ -77,12 +82,14 @@
     }
 
     Repeater.prototype.bindSorting = function() {
-        var sortableOptions = {
-            handle: this.options.sortableHandle,
-            nested: false
-        }
+        if (this.options.sortable) {
+            var sortableOptions = {
+                handle: this.options.sortableHandle,
+                nested: false
+            }
 
-        this.$sortable.sortable(sortableOptions)
+            this.$sortable.sortable(sortableOptions)
+        }
     }
 
     Repeater.prototype.clickAddGroupButton = function(ev) {
@@ -308,7 +315,7 @@
     // ===============
 
     $(document).render(function() {
-        $('[data-control="fieldrepeater"][data-sortable]').fieldRepeater()
+        $('[data-control="fieldrepeater"]').fieldRepeater()
     });
 
 }(window.jQuery);

--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -308,7 +308,7 @@
     // ===============
 
     $(document).render(function() {
-        $('[data-control="fieldrepeater"]').fieldRepeater()
+        $('[data-control="fieldrepeater"][data-sortable]').fieldRepeater()
     });
 
 }(window.jQuery);

--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -38,12 +38,14 @@
         titleFrom: null,
         minItems: null,
         maxItems: null,
-        sortable: true,
+        sortable: false,
         style: 'default',
     }
 
     Repeater.prototype.init = function() {
-        this.bindSorting()
+        if (this.options.sortable) {
+            this.bindSorting()
+        }
 
         this.$el.on('ajaxDone', '> .field-repeater-items > .field-repeater-item > .repeater-item-remove > [data-repeater-remove]', this.proxy(this.onRemoveItemSuccess))
         this.$el.on('ajaxDone', '> .field-repeater-add-item > [data-repeater-add]', this.proxy(this.onAddItemSuccess))
@@ -82,14 +84,12 @@
     }
 
     Repeater.prototype.bindSorting = function() {
-        if (this.options.sortable) {
-            var sortableOptions = {
-                handle: this.options.sortableHandle,
-                nested: false
-            }
-
-            this.$sortable.sortable(sortableOptions)
+        var sortableOptions = {
+            handle: this.options.sortableHandle,
+            nested: false
         }
+
+        this.$sortable.sortable(sortableOptions)
     }
 
     Repeater.prototype.clickAddGroupButton = function(ev) {

--- a/modules/backend/formwidgets/repeater/partials/_repeater.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater.htm
@@ -1,13 +1,15 @@
 <div class="field-repeater"
-     data-control="fieldrepeater"
-     <?= $titleFrom ? 'data-title-from="'.$titleFrom.'"' : '' ?>
-     <?= $minItems ? 'data-min-items="'.$minItems.'"' : '' ?>
-     <?= $maxItems ? 'data-max-items="'.$maxItems.'"' : '' ?>
-     <?= $style ? 'data-style="'.$style.'"' : '' ?>
-     data-sortable="<?= $sortable ? '1' : '0' ?>"
-     data-sortable-container="#<?= $this->getId('items') ?>"
-     data-sortable-handle=".<?= $this->getId('items') ?>-handle">
-
+    data-control="fieldrepeater"
+    <?= $titleFrom ? 'data-title-from="'.$titleFrom.'"' : '' ?>
+    <?= $minItems ? 'data-min-items="'.$minItems.'"' : '' ?>
+    <?= $maxItems ? 'data-max-items="'.$maxItems.'"' : '' ?>
+    <?= $style ? 'data-style="'.$style.'"' : '' ?>
+    <?php if ($sortable): ?>
+    data-sortable="true"
+    data-sortable-container="#<?= $this->getId('items') ?>"
+    data-sortable-handle=".<?= $this->getId('items') ?>-handle"
+    <?php endif ?>
+>
     <ul id="<?= $this->getId('items') ?>" class="field-repeater-items">
         <?php foreach ($formWidgets as $index => $widget): ?>
             <?= $this->makePartial('repeater_item', [

--- a/modules/backend/formwidgets/repeater/partials/_repeater.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater.htm
@@ -4,7 +4,7 @@
      <?= $minItems ? 'data-min-items="'.$minItems.'"' : '' ?>
      <?= $maxItems ? 'data-max-items="'.$maxItems.'"' : '' ?>
      <?= $style ? 'data-style="'.$style.'"' : '' ?>
-     <?= $sortable ? 'data-sortable' : '' ?>
+     data-sortable="<?= $sortable ? '1' : '0' ?>"
      data-sortable-container="#<?= $this->getId('items') ?>"
      data-sortable-handle=".<?= $this->getId('items') ?>-handle">
 

--- a/modules/backend/formwidgets/repeater/partials/_repeater.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater.htm
@@ -4,8 +4,9 @@
      <?= $minItems ? 'data-min-items="'.$minItems.'"' : '' ?>
      <?= $maxItems ? 'data-max-items="'.$maxItems.'"' : '' ?>
      <?= $style ? 'data-style="'.$style.'"' : '' ?>
-     data-sortable-container="#<?= $this->getId('items') ?>"
-     data-sortable-handle=".<?= $this->getId('items') ?>-handle">
+     <?= $sortable ? 'data-sortable-container="#'.$this->getId('items').'"' : '' ?>
+     <?= $sortable ? 'data-sortable-handle=".'.$this->getId('items').'-handle"' : '' ?>
+>
 
     <ul id="<?= $this->getId('items') ?>" class="field-repeater-items">
         <?php foreach ($formWidgets as $index => $widget): ?>

--- a/modules/backend/formwidgets/repeater/partials/_repeater.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater.htm
@@ -8,7 +8,7 @@
     data-sortable="true"
     data-sortable-container="#<?= $this->getId('items') ?>"
     data-sortable-handle=".<?= $this->getId('items') ?>-handle"
-    <?php endif ?>
+    <?php endif; ?>
 >
     <ul id="<?= $this->getId('items') ?>" class="field-repeater-items">
         <?php foreach ($formWidgets as $index => $widget): ?>

--- a/modules/backend/formwidgets/repeater/partials/_repeater.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater.htm
@@ -4,6 +4,7 @@
      <?= $minItems ? 'data-min-items="'.$minItems.'"' : '' ?>
      <?= $maxItems ? 'data-max-items="'.$maxItems.'"' : '' ?>
      <?= $style ? 'data-style="'.$style.'"' : '' ?>
+     <?= $sortable ? 'data-sortable' : '' ?>
      data-sortable-container="#<?= $this->getId('items') ?>"
      data-sortable-handle=".<?= $this->getId('items') ?>-handle">
 

--- a/modules/backend/formwidgets/repeater/partials/_repeater.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater.htm
@@ -6,7 +6,6 @@
      <?= $style ? 'data-style="'.$style.'"' : '' ?>
      data-sortable-container="#<?= $this->getId('items') ?>"
      data-sortable-handle=".<?= $this->getId('items') ?>-handle">
->
 
     <ul id="<?= $this->getId('items') ?>" class="field-repeater-items">
         <?php foreach ($formWidgets as $index => $widget): ?>

--- a/modules/backend/formwidgets/repeater/partials/_repeater.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater.htm
@@ -4,8 +4,8 @@
      <?= $minItems ? 'data-min-items="'.$minItems.'"' : '' ?>
      <?= $maxItems ? 'data-max-items="'.$maxItems.'"' : '' ?>
      <?= $style ? 'data-style="'.$style.'"' : '' ?>
-     <?= $sortable ? 'data-sortable-container="#'.$this->getId('items').'"' : '' ?>
-     <?= $sortable ? 'data-sortable-handle=".'.$this->getId('items').'-handle"' : '' ?>
+     data-sortable-container="#<?= $this->getId('items') ?>"
+     data-sortable-handle=".<?= $this->getId('items') ?>-handle">
 >
 
     <ul id="<?= $this->getId('items') ?>" class="field-repeater-items">

--- a/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
@@ -7,9 +7,11 @@
     class="field-repeater-item">
 
     <?php if (!$this->previewMode): ?>
-        <div class="repeater-item-handle <?= $this->getId('items') ?>-handle">
-            <i class="icon-bars"></i>
-        </div>
+        <?php if ($sortable): ?>
+            <div class="repeater-item-handle <?= $this->getId('items') ?>-handle">
+                <i class="icon-bars"></i>
+            </div>
+        <?php endif; ?>
 
         <div class="repeater-item-remove">
             <button

--- a/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
@@ -11,7 +11,7 @@
             <div class="repeater-item-handle <?= $this->getId('items') ?>-handle">
                 <i class="icon-bars"></i>
             </div>
-        <?php endif ?>
+        <?php endif; ?>
 
         <div class="repeater-item-remove">
             <button

--- a/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
+++ b/modules/backend/formwidgets/repeater/partials/_repeater_item.htm
@@ -11,7 +11,7 @@
             <div class="repeater-item-handle <?= $this->getId('items') ?>-handle">
                 <i class="icon-bars"></i>
             </div>
-        <?php endif; ?>
+        <?php endif ?>
 
         <div class="repeater-item-remove">
             <button


### PR DESCRIPTION
`Repeater` widget currently supports accepting a `sortable` option but it doesn't actually do anything. This PR removes formwidget sortability when `sortable: false` is passed to it.

I've made the widget sortable by default for backwards compatibility.