### PR TITLE
Fix "inline-options" class for checkbox list field

### DIFF
--- a/modules/system/assets/ui/less/checkbox.less
+++ b/modules/system/assets/ui/less/checkbox.less
@@ -173,12 +173,16 @@
 }
 
 .inline-options {
-    .field-checkboxlist:not(.is-scrollable) {
+    .field-checkboxlist-scrollable {
+        padding-left: 0;
+    }
+
+    .field-checkboxlist-inner {
         padding: 10px 20px 20px 20px !important;
 
         .custom-checkbox {
             display: inline-block;
-            margin: 0;
+            margin: 0 5px 10px 0;
 
             label {
                 margin-bottom: 0 !important;


### PR DESCRIPTION
In checkboxlist fields, `.inline-options` is not working. When applied it search for:
```
.field-checkboxlist:not(.is-scrollable)
```
that is the first container, not acting on checkbox items.

Others `.field-checkboxlist` classes are specifically named to:

```
.field-checkboxlist-scrollable
```

```
.field-checkboxlist-inner
```

So, i changed .less definitions to reflect this naming.

In addition, i added a little margin to single item for a better UI/UX.

 - replaced `:not(.is-scrollable)` selector with direct classes `.field-checkboxlist-scrollable` and `.field-checkboxlist-inner`
 - added margins to single checkbox for improved mobile UI/UX