### PR TITLE
Add previewMode check

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -349,7 +349,7 @@ class RelationController extends ControllerBehavior
             $this->applyExtraConfig($extraConfig);
         }
 
-        if (\Request::is('*/preview/*')) { 
+        if (\Request::is('*/preview/*')) {
             $this->previewMode = true;
         }
 

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -216,6 +216,11 @@ class RelationController extends ControllerBehavior
     public $deferredBinding = false;
 
     /**
+     * @var bool Returns if controller is in preview mode or not
+     */
+    public $previewMode = false;
+    
+    /**
      * Behavior constructor
      * @param Backend\Classes\Controller $controller
      */
@@ -342,6 +347,10 @@ class RelationController extends ControllerBehavior
 
         if ($extraConfig = post(self::PARAM_EXTRA_CONFIG)) {
             $this->applyExtraConfig($extraConfig);
+        }
+
+        if (\Request::is('*/preview/*')) { 
+            $this->previewMode = true;
         }
 
         $this->alias = camel_case('relation ' . $field);

--- a/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
+++ b/modules/backend/behaviors/relationcontroller/partials/_toolbar.htm
@@ -1,3 +1,4 @@
+<?php if (!$this->previewMode): ?>
 <div data-control="toolbar">
 
     <?php foreach ($relationToolbarButtons as $type => $text): ?>
@@ -16,3 +17,4 @@
     <?php endforeach ?>
 
 </div>
+<?php endif ?>


### PR DESCRIPTION
RelationControllers display the toolbar buttons in every context.
The toolbar buttons should be hidden when you are previewing the record.
Right now, the toolbar buttons are displayed and you can edit the, for example, hasOne relation while in preview mode.
This PR fixes that problem.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->