### PR TITLE
Add ability to run AJAX handlers in partial components

### DIFF
--- a/config/cms.php
+++ b/config/cms.php
@@ -494,6 +494,6 @@ return [
     |
     */
 
-    'runAjaxInPartials' => false,
+    'runAjaxInPartialComponents' => false,
 
 ];

--- a/config/cms.php
+++ b/config/cms.php
@@ -469,4 +469,31 @@ return [
     */
 
     'enableBackendServiceWorkers' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allow AJAX handlers to be run in partial components
+    |--------------------------------------------------------------------------
+    |
+    | By default, for historical and performance reasons, AJAX handlers are
+    | are not executed for a component if it is within a partial. You may opt
+    | to enable this ability if you wish to use components in partials that
+    | rely on AJAX functionality.
+    |
+    | Be aware that this may result in a slight decrease in performance for
+    | some AJAX calls, and the system will run the handler of the first
+    | component it finds that matches the given component and handler. We
+    | recommend the use of aliases for components in partials with this
+    | feature enabled.
+    |
+    | true  - allow AJAX handlers to run for page, layout and partial
+    |         components
+    |
+    | false - allow AJAX handlers to run for page and layout components
+    |         only
+    |
+    */
+
+    'runAjaxInPartials' => false,
+
 ];

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -841,7 +841,7 @@ class Controller
            /*
             * Simulate a page render, and track components in partials
             */
-            if (Config::get('cms.runAjaxInPartials', false) && is_null($this->trackComponent)) {
+            if (Config::get('cms.runAjaxInPartialComponents', false) && is_null($this->trackComponent)) {
                 $this->trackComponent = $componentName;
                 $this->trackHandler = $handlerName;
                 $this->trackResult = false;
@@ -1074,7 +1074,7 @@ class Controller
                 $this->setComponentPropertiesFromParams($componentObj, $parameters);
                 $componentObj->init();
 
-                if (Config::get('cms.runAjaxInPartials', false)) {
+                if (Config::get('cms.runAjaxInPartialComponents', false)) {
                     // If we're tracking an AJAX call through partials, and the alias matches, attempt the component AJAX
                     // call here
                     if (!is_null($this->trackComponent) && $this->trackComponent === $alias) {


### PR DESCRIPTION
Traditionally, as per [our docs](https://wintercms.com/docs/cms/partials#life-cycle-limitations), components located within partials are unable to use the AJAX framework.

While the docs state this is because partials are rendered late in the render lifecycle of a page (which is technically correct), it is also the result of the fact that when an AJAX request is made, the render is skipped entirely and the CMS module's controller only has knowledge of the layout and page in use, and their components. This makes sense - there's no need to render the page for an AJAX response - but this means that the Controller does not know which partials are in use, or the components used within, so the AJAX handling functionality cannot find the component that an AJAX request is for in this case.

This PR is a potential way to support this capability. It works by tracking a component and handler for an AJAX request and simulating a render, which renders all partials and their components, and then attempts to find a component within the full suite of templating presented on a page.

The reason for this, in my experience, is that partials are a great way of abstracting usage of common elements across multiple pages and layouts. In my case, I wanted a search component in my main navigation that uses the new Search plugin, with this navigation being used in four different layouts as they all share the same navigation. However, it's not possible to use this component due to the fact that the AJAX request won't work. The only alternative is to have the entire navigation code and components in all layouts, which as you can imagine increases the maintenance burden if we wish to make a change to the navigation down the track.

A few notes on this PR for further consideration:

- Components within the page or layout are prioritized first, if they share the same alias as a component inside a partial.
- The **last** component that matches the alias requested is the one that will populate the result, unless we find a way to safely kill the render when it finds a valid component. This may *not* be the component instance the person used on the page. I would recommend if we do implement this that we document that aliases should be used for components within partials if this functionality is enabled.
- This PR has no bearing on AJAX calls made inside a partial that attempt to use a handler in the partial's PHP code. I feel that's outside the scope of this change.
- This does result in a performance decrease for AJAX calls if it reaches the stage where it has to simulate the render. If the page itself is slow to load normally, the AJAX call will be just as slow. During my testing, it meant my AJAX calls went from 30ms to 80ms to respond, but it'll be wildly different in other cases.
- Because this is a change in behaviour, and may result in unintended side effects for sites already using Winter, I've opted to wrap this in a configuration value (`cms.runAjaxInPartialComponents`), disabled by default to maintain the current behaviour. So it's opt-in.