### PR TITLE
Can't pass null to non-nullable arguments

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -687,8 +687,8 @@ class Filter extends WidgetBase
      */
     protected function makeFilterScope($name, $config)
     {
-        $label = $config['label'] ?? null;
-        $scopeType = $config['type'] ?? null;
+        $label = $config['label'] ?? '';
+        $scopeType = $config['type'] ?? '';
 
         $scope = new FilterScope($name, $label);
         $scope->displayAs($scopeType, $config);

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -926,7 +926,7 @@ class Lists extends WidgetBase
             $config['searchable'] = false;
         }
 
-        $columnType = $config['type'] ?? null;
+        $columnType = $config['type'] ?? '';
 
         $column = new ListColumn($name, $label);
         $column->displayAs($columnType, $config);

--- a/modules/system/classes/SettingsManager.php
+++ b/modules/system/classes/SettingsManager.php
@@ -357,7 +357,7 @@ class SettingsManager
     {
         return (object) [
             'itemCode' => $this->contextItemCode,
-            'owner' => strtolower($this->aliases[$this->contextOwner] ?? $this->contextOwner),
+            'owner' => strtolower($this->aliases[$this->contextOwner] ?? ($this->contextOwner ?? '')),
         ];
     }
 

--- a/modules/system/helpers/DateTime.php
+++ b/modules/system/helpers/DateTime.php
@@ -130,6 +130,6 @@ class DateTime
             $replacements['\\'.$from] = '['.$from.']';
         }
 
-        return strtr($format, $replacements);
+        return strtr($format ?? '', $replacements);
     }
 }

--- a/modules/system/partials/_settings_menu_items.htm
+++ b/modules/system/partials/_settings_menu_items.htm
@@ -2,7 +2,7 @@
     $context = System\Classes\SettingsManager::instance()->getContext();
 
     $collapsedGroups = explode('|',
-        isset($_COOKIE['sidenav_treegroupStatus']) ? $_COOKIE['sidenav_treegroupStatus'] : null
+        isset($_COOKIE['sidenav_treegroupStatus']) ? $_COOKIE['sidenav_treegroupStatus'] : ''
     );
 
 ?>


### PR DESCRIPTION
This is in regards to: https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg

I'm getting this deprecation warning throughout all of winter with php 8.1 and it's happening in both winter and storm