### PR TITLE
Hide smtp user/password fields if smtp authorization is false.

### DIFF
--- a/modules/system/models/MailSetting.php
+++ b/modules/system/models/MailSetting.php
@@ -155,5 +155,9 @@ class MailSetting extends Model
                     break;
             }
         }
+        if (!$fields->smtp_authorization->value) {
+            $fields->smtp_user->hidden = true;
+            $fields->smtp_password->hidden = true;
+        }
     }
 }

--- a/modules/system/models/mailsetting/fields.yaml
+++ b/modules/system/models/mailsetting/fields.yaml
@@ -67,6 +67,7 @@ tabs:
             label: system::lang.mail.smtp_username
             tab: system::lang.mail.general
             span: left
+            dependsOn: smtp_authorization
             trigger:
                 action: show
                 field: send_mode
@@ -77,6 +78,7 @@ tabs:
             tab: system::lang.mail.general
             type: sensitive
             span: right
+            dependsOn: smtp_authorization
             trigger:
                 action: show
                 field: send_mode


### PR DESCRIPTION
Improve user experience when smtp authorization is unchecked, hide smtp_user & smtp_password fields.