### PR TITLE
[WIP] 1.2 - AssetMaker respect app.asset_url

### DIFF
--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -299,6 +299,10 @@ trait AssetMaker
             return $fileName;
         }
 
+        if ($assetUrl = config('app.asset_url')) {
+            $assetPath = $assetUrl . '/' . ltrim($assetPath, '/');
+        }
+
         return $assetPath . '/' . $fileName;
     }
 

--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -296,7 +296,7 @@ trait AssetMaker
         }
 
         if (substr($fileName, 0, 1) == '/' || $assetPath === null) {
-            return $fileName;
+            return Url::asset($fileName);
         }
 
         return Url::asset($assetPath . '/' . $fileName);

--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -299,11 +299,7 @@ trait AssetMaker
             return $fileName;
         }
 
-        if ($assetUrl = config('app.asset_url')) {
-            $assetPath = $assetUrl . '/' . ltrim($assetPath, '/');
-        }
-
-        return $assetPath . '/' . $fileName;
+        return Url::asset($assetPath . '/' . $fileName);
     }
 
     /**


### PR DESCRIPTION
Simple fix that updates the AssetMaker trait to respect the `app.asset_url` config value.