### PR TITLE
[WIP] 1.2 winter:mirror Enhancements

### DIFF
--- a/modules/system/console/WinterMirror.php
+++ b/modules/system/console/WinterMirror.php
@@ -2,7 +2,6 @@
 
 use File;
 use Event;
-use JetBrains\PhpStorm\ArrayShape;
 use StdClass;
 use Winter\Storm\Console\Command;
 

--- a/modules/system/console/WinterMirror.php
+++ b/modules/system/console/WinterMirror.php
@@ -162,7 +162,7 @@ class WinterMirror extends Command
 
         $dest = $this->getDestinationPath().'/'.$directory;
 
-        if (!File::isDirectory($src) || File::isDirectory($dest)) {
+        if (!File::isDirectory($src) || (File::isDirectory($dest) && !$this->option('copy'))) {
             return false;
         }
 
@@ -241,7 +241,9 @@ class WinterMirror extends Command
             ) as $item
         ) {
             if ($item->isDir()) {
-                File::makeDirectory($dest . DIRECTORY_SEPARATOR . $iterator->getSubPathname());
+                if (!File::isDirectory($dest . DIRECTORY_SEPARATOR . $iterator->getSubPathname())) {
+                    File::makeDirectory($dest . DIRECTORY_SEPARATOR . $iterator->getSubPathname());
+                }
                 continue;
             }
             File::copy($item, $dest . DIRECTORY_SEPARATOR . $iterator->getSubPathname());

--- a/modules/system/console/WinterMirror.php
+++ b/modules/system/console/WinterMirror.php
@@ -205,18 +205,21 @@ class WinterMirror extends Command
         }
 
         if (!$this->option('copy')) {
-            symlink($src, $dest);
+            File::link($src, $dest);
             $this->info('Linked: ' . $dest);
             return true;
         }
 
-        if (is_dir($src) && !is_dir($dest)) {
-            mkdir($dest, 0755, true);
+        if (File::isDirectory($src) && !File::isDirectory($dest)) {
+            File::makeDirectory($dest, 0755, true);
         }
 
-        if (is_file($src)) {
-            !is_dir(dirname($dest)) && mkdir(dirname($dest), 0755, true);
-            copy($src, $dest);
+        if (File::isFile($src)) {
+            if (!File::isDirectory(dirname($dest))) {
+                File::makeDirectory(dirname($dest), 0755, true);
+            }
+
+            File::copy($src, $dest);
             $this->info('Copied: ' . $dest);
             return true;
         }
@@ -231,10 +234,10 @@ class WinterMirror extends Command
             ) as $item
         ) {
             if ($item->isDir()) {
-                mkdir($dest . DIRECTORY_SEPARATOR . $iterator->getSubPathname());
+                File::makeDirectory($dest . DIRECTORY_SEPARATOR . $iterator->getSubPathname());
                 continue;
             }
-            copy($item, $dest . DIRECTORY_SEPARATOR . $iterator->getSubPathname());
+            File::copy($item, $dest . DIRECTORY_SEPARATOR . $iterator->getSubPathname());
         }
 
         $this->info('Copied: ' . $dest);
@@ -269,7 +272,7 @@ class WinterMirror extends Command
         $from = str_replace('\\', '/', $from);
         $to = str_replace('\\', '/', $to);
 
-        $dir = explode('/', is_file($from) ? dirname($from) : rtrim($from, '/'));
+        $dir = explode('/', File::isFile($from) ? dirname($from) : rtrim($from, '/'));
         $file = explode('/', $to);
 
         while ($dir && $file && ($dir[0] == $file[0])) {


### PR DESCRIPTION
This PR adds support for `--copy` & `--ignore "/pattern/"` to the `winter:mirror` command. These flags allow the mirror command to be used by Laravel Vapor to extract assets during the build stage.

The changes here supersede those made in:
https://github.com/wintercms/storm/pull/68
https://github.com/wintercms/winter/pull/430

Originally Vapor only supported 400 assets per project, meaning that we had to use the mirror command to mirror to a disk (remote s3 bucket), however with [this update](https://blog.laravel.com/vapor-unlimited-assets-uploads-10x-faster) this is no longer required and we therefore don't need the extra functionality, instead we can use copy the files so Vapor can pick them up and ignore development files or files not required for remote deployment.