### PR TITLE
Let composer resolve current php process in scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,12 +55,12 @@
     },
     "scripts": {
         "post-create-project-cmd": [
-            "php artisan key:generate",
-            "php artisan package:discover"
+            "@php artisan key:generate",
+            "@php artisan package:discover"
         ],
         "post-update-cmd": [
-            "php artisan winter:version",
-            "php artisan package:discover"
+            "@php artisan winter:version",
+            "@php artisan package:discover"
         ],
         "test": [
             "phpunit --stop-on-failure"


### PR DESCRIPTION
On my shared hosting environment, `php` always defaults to `php4.4`.

Commands like `php8.1 composer.phar install` resulted in a successful installation but failed during the execution of the "post-update-cmd"-Script.

`@php` should fix this (and did it on my environment), according to:
https://getcomposer.org/doc/articles/scripts.md#executing-php-scripts