### PR TITLE
[FIX] Has plugin fix

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -455,8 +455,14 @@ class PluginManager
             return $identifier;
         }
 
-        if (!$ignoreReplacements && is_string($identifier) && isset($this->replacementMap[$identifier])) {
-            $identifier = $this->replacementMap[$identifier];
+        // TODO: we should refactor the plugin manager to handle identifiers internally as lowers
+        $replacementMap = array_combine(
+            array_map('strtolower', array_keys($this->replacementMap)),
+            array_values($this->replacementMap)
+        );
+
+        if (!$ignoreReplacements && is_string($identifier) && isset($replacementMap[strtolower($identifier)])) {
+            $identifier = $replacementMap[strtolower($identifier)];
         }
 
         if (!isset($this->plugins[$identifier])) {

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -473,7 +473,10 @@ class PluginManager
     {
         $normalized = $this->getNormalizedIdentifier($plugin);
 
-        return isset($this->plugins[$normalized]) || isset($this->replacementMap[$normalized]);
+        return isset($this->plugins[$normalized])
+            || isset($this->replacementMap[$normalized])
+            // TODO: we should refactor the plugin manager to handle identifiers internally as lowers
+            || in_array(strtolower($normalized), array_map('strtolower', array_keys($this->replacementMap)));
     }
 
     /**

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -571,8 +571,7 @@ class PluginManager
      */
     public function normalizeIdentifier(string $code): string
     {
-        $code = strtolower($code);
-        return $this->normalizedMap[$code] ?? $code;
+        return $this->normalizedMap[strtolower($code)] ?? $code;
     }
 
     /**

--- a/tests/fixtures/plugins/winter/replacenotinstalled/Plugin.php
+++ b/tests/fixtures/plugins/winter/replacenotinstalled/Plugin.php
@@ -1,0 +1,18 @@
+<?php namespace Winter\ReplaceNotInstalled;
+
+use System\Classes\PluginBase;
+
+class Plugin extends PluginBase
+{
+    public function pluginDetails()
+    {
+        return [
+            'name' => 'Winter Sample Plugin',
+            'description' => 'Sample plugin used by unit tests.',
+            'author' => 'Alexey Bobkov, Samuel Georges',
+            'replaces' => [
+                'Winter.NotInstalled' => '>=1.0.3'
+            ]
+        ];
+    }
+}

--- a/tests/fixtures/plugins/winter/replacenotinstalled/updates/version.yaml
+++ b/tests/fixtures/plugins/winter/replacenotinstalled/updates/version.yaml
@@ -1,0 +1,2 @@
+1.0.0: Initial build
+1.0.1: Updated plugin

--- a/tests/unit/system/classes/PluginManagerTest.php
+++ b/tests/unit/system/classes/PluginManagerTest.php
@@ -378,6 +378,27 @@ class PluginManagerTest extends TestCase
         $this->assertInstanceOf(\Winter\Original\Plugin::class, $this->manager->findByIdentifier('Winter.Original', true));
     }
 
+    public function testHasPluginReplacementMixedCase()
+    {
+        // test checking casing of installed plugin (resolved via getNormalizedIdentifier())
+        $this->assertTrue($this->manager->hasPlugin('Winter.ReplaceNotInstalled'));
+        $this->assertTrue($this->manager->hasPlugin('Winter.replaceNotInstalled'));
+        $this->assertTrue($this->manager->hasPlugin('Winter.replacenotInstalled'));
+        $this->assertTrue($this->manager->hasPlugin('winter.replacenotInstalled'));
+        $this->assertTrue($this->manager->hasPlugin('winter.replacenotinstalled'));
+
+        // test checking casing of installed replaced plugin (resolved via getNormalizedIdentifier() & replacementMap)
+        $this->assertTrue($this->manager->hasPlugin('Winter.Original'));
+        $this->assertTrue($this->manager->hasPlugin('Winter.original'));
+        $this->assertTrue($this->manager->hasPlugin('winter.original'));
+
+        // test checking casing of uninstalled plugin (resolved via strtolower() on replacement keys)
+        $this->assertTrue($this->manager->hasPlugin('Winter.NotInstalled'));
+        $this->assertTrue($this->manager->hasPlugin('Winter.notInstalled'));
+        $this->assertTrue($this->manager->hasPlugin('winter.notInstalled'));
+        $this->assertTrue($this->manager->hasPlugin('Winter.notinstalled'));
+    }
+
     public function testGetReplacements()
     {
         $replacementPluginReplaces = $this->manager->findByIdentifier('Winter.Replacement')->getReplaces();

--- a/tests/unit/system/classes/PluginManagerTest.php
+++ b/tests/unit/system/classes/PluginManagerTest.php
@@ -399,6 +399,53 @@ class PluginManagerTest extends TestCase
         $this->assertTrue($this->manager->hasPlugin('Winter.notinstalled'));
     }
 
+    public function testExistsReplacementMixedCase()
+    {
+        // test checking casing of installed plugin (resolved via getNormalizedIdentifier())
+        $this->assertTrue($this->manager->exists('Winter.ReplaceNotInstalled'));
+        $this->assertTrue($this->manager->exists('Winter.replaceNotInstalled'));
+        $this->assertTrue($this->manager->exists('Winter.replacenotInstalled'));
+        $this->assertTrue($this->manager->exists('winter.replacenotInstalled'));
+        $this->assertTrue($this->manager->exists('winter.replacenotinstalled'));
+
+        // test checking casing of installed replaced plugin (resolved via getNormalizedIdentifier() & replacementMap)
+        $this->assertFalse($this->manager->exists('Winter.Original'));
+        $this->assertFalse($this->manager->exists('Winter.original'));
+        $this->assertFalse($this->manager->exists('winter.original'));
+
+        // test checking casing of uninstalled plugin (resolved via strtolower() on replacement keys)
+        $this->assertTrue($this->manager->exists('Winter.NotInstalled'));
+        $this->assertTrue($this->manager->exists('Winter.notInstalled'));
+        $this->assertTrue($this->manager->exists('winter.notInstalled'));
+        $this->assertTrue($this->manager->exists('Winter.notinstalled'));
+    }
+
+    public function testFindByIdentifierReplacementMixedCase()
+    {
+        // test resolving plugin with mixed casing
+        $this->assertInstanceOf(\Winter\ReplaceNotInstalled\Plugin::class, $this->manager->findByIdentifier('Winter.ReplaceNotInstalled'));
+        $this->assertInstanceOf(\Winter\ReplaceNotInstalled\Plugin::class, $this->manager->findByIdentifier('Winter.replaceNotInstalled'));
+        $this->assertInstanceOf(\Winter\ReplaceNotInstalled\Plugin::class, $this->manager->findByIdentifier('Winter.replacenotInstalled'));
+        $this->assertInstanceOf(\Winter\ReplaceNotInstalled\Plugin::class, $this->manager->findByIdentifier('winter.replacenotInstalled'));
+        $this->assertInstanceOf(\Winter\ReplaceNotInstalled\Plugin::class, $this->manager->findByIdentifier('winter.replacenotinstalled'));
+
+        // test resolving replacement plugin with mixed casing
+        $this->assertInstanceOf(\Winter\Replacement\Plugin::class, $this->manager->findByIdentifier('Winter.Original'));
+        $this->assertInstanceOf(\Winter\Replacement\Plugin::class, $this->manager->findByIdentifier('Winter.original'));
+        $this->assertInstanceOf(\Winter\Replacement\Plugin::class, $this->manager->findByIdentifier('winter.original'));
+
+        // test resolving original plugin with mixed casing when ignoring replacements
+        $this->assertInstanceOf(\Winter\Original\Plugin::class, $this->manager->findByIdentifier('Winter.Original', true));
+        $this->assertInstanceOf(\Winter\Original\Plugin::class, $this->manager->findByIdentifier('Winter.original', true));
+        $this->assertInstanceOf(\Winter\Original\Plugin::class, $this->manager->findByIdentifier('winter.original', true));
+
+        // test resolving replacement plugin of uninstalled plugin with mixed casing
+        $this->assertInstanceOf(\Winter\ReplaceNotInstalled\Plugin::class, $this->manager->findByIdentifier('Winter.NotInstalled'));
+        $this->assertInstanceOf(\Winter\ReplaceNotInstalled\Plugin::class, $this->manager->findByIdentifier('Winter.notInstalled'));
+        $this->assertInstanceOf(\Winter\ReplaceNotInstalled\Plugin::class, $this->manager->findByIdentifier('winter.notInstalled'));
+        $this->assertInstanceOf(\Winter\ReplaceNotInstalled\Plugin::class, $this->manager->findByIdentifier('Winter.notinstalled'));
+    }
+
     public function testGetReplacements()
     {
         $replacementPluginReplaces = $this->manager->findByIdentifier('Winter.Replacement')->getReplaces();


### PR DESCRIPTION
This PR resolves the issue raised in https://github.com/wintercms/winter/issues/575.

Simply it ensures that `normalizeIdentifier()` returns the value passed if the key is not found in the `normalizedMap` array.