### PR TITLE
[WIP] Split Test - 1.2 - PluginManager lower case internal IDs

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -136,7 +136,7 @@ class PluginManager
         // Sort all the plugins by number of dependencies
         $this->sortByDependencies();
 
-        return $this->plugins;
+        return $this->getAllPlugins();
     }
 
     /**
@@ -173,14 +173,15 @@ class PluginManager
         }
 
         $classId = $this->getIdentifier($pluginObj);
+        $lowerClassId = strtolower($classId);
 
-        $this->plugins[$classId] = $pluginObj;
-        $this->normalizedMap[strtolower($classId)] = $classId;
+        $this->plugins[$lowerClassId] = $pluginObj;
+        $this->normalizedMap[$lowerClassId] = $classId;
 
         $replaces = $pluginObj->getReplaces();
         if ($replaces) {
             foreach ($replaces as $replace) {
-                $this->replacementMap[$replace] = $classId;
+                $this->replacementMap[strtolower($replace)] = $lowerClassId;
             }
         }
 
@@ -226,7 +227,7 @@ class PluginManager
             ];
         });
 
-        list($this->pluginFlag, $this->replacementMap, $this->activeReplacementMap) = $data;
+        list($this->pluginFlags, $this->replacementMap, $this->activeReplacementMap) = $data;
     }
 
     /**
@@ -409,7 +410,14 @@ class PluginManager
      */
     public function getPlugins(): array
     {
-        return array_diff_key($this->plugins, $this->pluginFlags);
+        $plugins = array_diff_key($this->plugins, $this->pluginFlags);
+        $keys = [];
+
+        foreach ($plugins as $code => $plugin) {
+            $keys[] = $this->normalizedMap[$code];
+        }
+
+        return array_combine($keys, $plugins);
     }
 
     /**
@@ -419,7 +427,13 @@ class PluginManager
      */
     public function getAllPlugins(): array
     {
-        return $this->plugins;
+        $plugins = [];
+
+        foreach ($this->plugins as $code => $plugin) {
+            $plugins[$this->normalizedMap[$code]] = $plugin;
+        }
+
+        return $plugins;
     }
 
     /**
@@ -427,7 +441,7 @@ class PluginManager
      */
     public function findByNamespace(string $namespace): ?PluginBase
     {
-        $identifier = $this->getIdentifier($namespace);
+        $identifier = $this->getIdentifier($namespace, true);
 
         return $this->plugins[$identifier] ?? null;
     }
@@ -441,12 +455,10 @@ class PluginManager
             return $identifier;
         }
 
-        if (!$ignoreReplacements && is_string($identifier) && isset($this->replacementMap[$identifier])) {
-            $identifier = $this->replacementMap[$identifier];
-        }
+        $identifier = $this->getNormalizedIdentifier($identifier, true);
 
-        if (!isset($this->plugins[$identifier])) {
-            $identifier = $this->getNormalizedIdentifier($identifier);
+        if (!$ignoreReplacements && isset($this->replacementMap[$identifier])) {
+            $identifier = $this->replacementMap[$identifier];
         }
 
         return $this->plugins[$identifier] ?? null;
@@ -457,7 +469,7 @@ class PluginManager
      */
     public function hasPlugin(PluginBase|string $plugin): bool
     {
-        $normalized = $this->getNormalizedIdentifier($plugin);
+        $normalized = $this->getNormalizedIdentifier($plugin, true);
 
         return isset($this->plugins[$normalized]) || isset($this->replacementMap[$normalized]);
     }
@@ -518,7 +530,7 @@ class PluginManager
      * Resolves a plugin identifier (Author.Plugin) from a plugin class name
      * (Author\Plugin) or PluginBase instance.
      */
-    public function getIdentifier(PluginBase|string $plugin): string
+    public function getIdentifier(PluginBase|string $plugin, bool $lower = false): string
     {
         $namespace = Str::normalizeClassName($plugin);
         if (strpos($namespace, '\\') === null) {
@@ -529,7 +541,7 @@ class PluginManager
         $slice = array_slice($parts, 1, 2);
         $namespace = implode('.', $slice);
 
-        return $namespace;
+        return $lower ? strtolower($namespace) : $namespace;
     }
 
     /**
@@ -565,9 +577,10 @@ class PluginManager
      * Returns the normalized identifier (i.e. Winter.Blog) from the provided
      * string or PluginBase instance.
      */
-    public function getNormalizedIdentifier(PluginBase|string $plugin): string
+    public function getNormalizedIdentifier(PluginBase|string $plugin, bool $lower = false): string
     {
-        return $this->normalizeIdentifier($this->getIdentifier($plugin));
+        $identifier = $this->normalizeIdentifier($this->getIdentifier($plugin));
+        return $lower ? strtolower($identifier) : $identifier;
     }
 
     /**
@@ -600,7 +613,7 @@ class PluginManager
 
     public function getPluginFlags(PluginBase|string $plugin): array
     {
-        $code = $this->getNormalizedIdentifier($plugin);
+        $code = $this->getNormalizedIdentifier($plugin, true);
         return $this->pluginFlags[$code] ?? [];
     }
 
@@ -609,7 +622,7 @@ class PluginManager
      */
     protected function flagPlugin(PluginBase|string $plugin, string $flag): void
     {
-        $code = $this->getNormalizedIdentifier($plugin);
+        $code = $this->getNormalizedIdentifier($plugin, true);
         $this->pluginFlags[$code][$flag] = true;
     }
 
@@ -618,7 +631,7 @@ class PluginManager
      */
     protected function unflagPlugin(PluginBase|string $plugin, string $flag): void
     {
-        $code = $this->getNormalizedIdentifier($plugin);
+        $code = $this->getNormalizedIdentifier($plugin, true);
         unset($this->pluginFlags[$code][$flag]);
     }
 
@@ -652,7 +665,7 @@ class PluginManager
      */
     public function isDisabled(PluginBase|string $plugin): bool
     {
-        $code = $this->getNormalizedIdentifier($plugin);
+        $code = $this->getNormalizedIdentifier($plugin, true);
 
         // @TODO: Limit this to only disabled flags if we add more than disabled flags
         return !empty($this->pluginFlags[$code]);
@@ -671,9 +684,18 @@ class PluginManager
      */
     public function getActiveReplacementMap(PluginBase|string $plugin = null): array|string|null
     {
-        return $plugin
-            ? $this->activeReplacementMap[$this->getNormalizedIdentifier($plugin)] ?? null
-            : $this->activeReplacementMap;
+        if ($plugin) {
+            return $this->normalizedMap[
+                $this->activeReplacementMap[$this->getNormalizedIdentifier($plugin, true)] ?? null
+            ] ?? null;
+        }
+
+        $map = [];
+        foreach ($this->activeReplacementMap as $key => $value) {
+            $map[$this->normalizedMap[$key]] = $this->normalizedMap[$value];
+        }
+
+        return $map;
     }
 
     /**
@@ -694,7 +716,12 @@ class PluginManager
 
             // Only allow one of the replaced plugin or the replacing plugin to exist
             // at once depending on whether the version constraints are met or not
-            if ($this->plugins[$replacement]->canReplacePlugin($target, $this->plugins[$target]->getPluginVersion())) {
+            if (
+                $this->plugins[$replacement]->canReplacePlugin(
+                    $this->normalizeIdentifier($target),
+                    $this->plugins[$target]->getPluginVersion()
+                )
+            ) {
                 // Set the plugin flags to disable the target plugin
                 $this->flagPlugin($target, static::DISABLED_REPLACED);
                 $this->unflagPlugin($replacement, static::DISABLED_REPLACEMENT_FAILED);

--- a/modules/system/tests/fixtures/plugins/winter/replacenotinstalled/Plugin.php
+++ b/modules/system/tests/fixtures/plugins/winter/replacenotinstalled/Plugin.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Winter\ReplaceNotInstalled;
+
+use System\Classes\PluginBase;
+
+class Plugin extends PluginBase
+{
+    public function pluginDetails()
+    {
+        return [
+            'name' => 'Winter Sample Plugin',
+            'description' => 'Sample plugin used by unit tests.',
+            'author' => 'Alexey Bobkov, Samuel Georges',
+            'replaces' => [
+                'Winter.NotInstalled' => '>=1.0.3'
+            ]
+        ];
+    }
+}

--- a/modules/system/tests/fixtures/plugins/winter/replacenotinstalled/updates/version.yaml
+++ b/modules/system/tests/fixtures/plugins/winter/replacenotinstalled/updates/version.yaml
@@ -1,0 +1,2 @@
+1.0.0: Initial build
+1.0.1: Updated plugin


### PR DESCRIPTION
This PR modifies the plugin manager to internally treat plugin identifiers as lower case strings, only transforming them to their normalised versions when requested by methods like `getPlugins()` & `getAllPlugins()`.

The idea behind this is that it provides a much simpler way to internally handle checking, especially for plugin replacement where casing could cause issues.