### PR TITLE
[FIX] 1.2 - Plugin namespace aliasing

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -181,7 +181,12 @@ class PluginManager
         $replaces = $pluginObj->getReplaces();
         if ($replaces) {
             foreach ($replaces as $replace) {
-                $this->replacementMap[strtolower($replace)] = $lowerClassId;
+                $lowerReplace = strtolower($replace);
+                $this->replacementMap[$lowerReplace] = $lowerClassId;
+
+                if (!isset($this->normalizedMap[$lowerReplace])) {
+                    $this->normalizedMap[$lowerReplace] = $replace;
+                }
             }
         }
 
@@ -745,6 +750,11 @@ class PluginManager
     protected function registerPluginReplacements(): void
     {
         foreach ($this->replacementMap as $target => $replacement) {
+            list($target, $replacement) = array_map(
+                fn($plugin) => $this->normalizeIdentifier($plugin),
+                [$target, $replacement]
+            );
+
             // Alias the replaced plugin to the replacing plugin
             $this->aliasPluginAs($replacement, $target);
 


### PR DESCRIPTION
This PR adds a fix for a combination of issues added with the previous updates to the PluginManager that ensures that namespace aliasing for a replaced plugin which isn't installed occurs correctly.

The issue for this was that the replaced plugin was never added to the `normalizeMap` and therefore couldn't be converted into the proper `Winter.Test` style plugin ID, which lead to the namespace alias being registered as `winter\test\` rather than `Winter\Test`.