### PR TITLE
Fix site relative partial paths failing in 1.2

### DIFF
--- a/modules/system/console/WinterTest.php
+++ b/modules/system/console/WinterTest.php
@@ -143,7 +143,7 @@ class WinterTest extends Command
 
         $process = new Process(
             array_merge([$this->phpUnitExec, '--configuration=' . $config], $args),
-            dirname($config),
+            base_path(),
             null,
             null
         );

--- a/modules/system/traits/ViewMaker.php
+++ b/modules/system/traits/ViewMaker.php
@@ -186,31 +186,29 @@ trait ViewMaker
             $fileName = substr($fileName, 0, strrpos($fileName, '.'));
         }
 
+        // Check if this is a local path reference first
+        $absolutePath = File::symbolizePath($fileName);
+        foreach ($allowedExtensions as $ext) {
+            $viewPath = $absolutePath . ".$ext";
 
-        if (File::isPathSymbol($fileName)) {
-            // Handle path symbols
-            $absolutePath = File::symbolizePath($fileName);
-            foreach ($allowedExtensions as $ext) {
-                $viewPath = $absolutePath . ".$ext";
-
-                if (
-                    File::isLocalPath($viewPath)
-                    || (
-                        !Config::get('cms.restrictBaseDir', true)
-                        && realpath($viewPath) !== false
-                    )
-                ) {
-                    return $viewPath;
-                }
+            if (
+                File::isLocalPath($viewPath)
+                || (
+                    !Config::get('cms.restrictBaseDir', true)
+                    && realpath($viewPath) !== false
+                )
+            ) {
+                return $viewPath;
             }
-        } else {
-            foreach ($viewPaths as $path) {
-                $absolutePath = File::symbolizePath($path);
-                foreach ($allowedExtensions as $ext) {
-                    $viewPath = $absolutePath . DIRECTORY_SEPARATOR . $fileName . ".$ext";
-                    if (File::isFile($viewPath)) {
-                        return $viewPath;
-                    }
+        }
+
+        // Next, check if this a path relative to the view paths
+        foreach ($viewPaths as $path) {
+            $absolutePath = File::symbolizePath($path);
+            foreach ($allowedExtensions as $ext) {
+                $viewPath = $absolutePath . DIRECTORY_SEPARATOR . $fileName . ".$ext";
+                if (File::isFile($viewPath)) {
+                    return $viewPath;
                 }
             }
         }

--- a/modules/system/traits/ViewMaker.php
+++ b/modules/system/traits/ViewMaker.php
@@ -186,7 +186,18 @@ trait ViewMaker
             $fileName = substr($fileName, 0, strrpos($fileName, '.'));
         }
 
-        // Check if this is a local path reference first
+        // Check if this a path relative to the view paths
+        foreach ($viewPaths as $path) {
+            $absolutePath = File::symbolizePath($path);
+            foreach ($allowedExtensions as $ext) {
+                $viewPath = $absolutePath . DIRECTORY_SEPARATOR . $fileName . ".$ext";
+                if (File::isFile($viewPath)) {
+                    return $viewPath;
+                }
+            }
+        }
+
+        // Next, check if this is a local path reference
         $absolutePath = File::symbolizePath($fileName);
         foreach ($allowedExtensions as $ext) {
             $viewPath = $absolutePath . ".$ext";
@@ -199,17 +210,6 @@ trait ViewMaker
                 )
             ) {
                 return $viewPath;
-            }
-        }
-
-        // Next, check if this a path relative to the view paths
-        foreach ($viewPaths as $path) {
-            $absolutePath = File::symbolizePath($path);
-            foreach ($allowedExtensions as $ext) {
-                $viewPath = $absolutePath . DIRECTORY_SEPARATOR . $fileName . ".$ext";
-                if (File::isFile($viewPath)) {
-                    return $viewPath;
-                }
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/wintercms/winter/issues/571

This PR changes the behaviour in the `ViewMaker` trait to more closely match the `ViewMaker` in 1.1, while still retaining the multiple extension support introduced in https://github.com/wintercms/winter/commit/643a581ce93cc5f8efb3fc8a2420c8dc014c8787#diff-47d4d0a41b9809a09c2b0c209309cd6b776645682610fa2c1906ed66d6ef1b4b.

If a path that is relative the base path is encountered in the `getViewPath` method, and with one of the allowed extensions matches a valid file, this will be accepted as a partial path. If not, then the ViewMaker will attempt to same within the view paths added at that point. Previously, the base relative paths would only be checked if the path was symbolized in some fashion.

This PR also introduces a fix to the `winter:test` command by ensuring that the current working directory is always the base path. This matches the behaviour of a web request which would presume the same, and thus ensures that the changes above work in the tests as well.