### PR TITLE
[Fix] 1.2 - PluginManager Normalization

### DIFF
--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -571,11 +571,12 @@ class PluginManager
      * Normalizes the provided plugin identifier (author.plugin) and resolves
      * it case-insensitively to the normalized identifier (Author.Plugin)
      * Returns the provided identifier if a match isn't found
+     *
+     * This is an alias for `getNormalizedIdentifier()`
      */
     public function normalizeIdentifier(string $code): string
     {
-        $code = strtolower($code);
-        return $this->normalizedMap[$code] ?? $code;
+        return $this->getNormalizedIdentifier($code);
     }
 
     /**
@@ -584,7 +585,8 @@ class PluginManager
      */
     public function getNormalizedIdentifier(PluginBase|string $plugin, bool $lower = false): string
     {
-        $identifier = $this->normalizeIdentifier($this->getIdentifier($plugin));
+        $code = $this->getIdentifier($plugin);
+        $identifier = $this->normalizedMap[strtolower($code)] ?? $code;
         return $lower ? strtolower($identifier) : $identifier;
     }
 

--- a/modules/system/classes/PluginManager.php
+++ b/modules/system/classes/PluginManager.php
@@ -571,8 +571,6 @@ class PluginManager
      * Normalizes the provided plugin identifier (author.plugin) and resolves
      * it case-insensitively to the normalized identifier (Author.Plugin)
      * Returns the provided identifier if a match isn't found
-     *
-     * This is an alias for `getNormalizedIdentifier()`
      */
     public function normalizeIdentifier(string $code): string
     {


### PR DESCRIPTION
Fix for https://github.com/wintercms/winter/issues/569

This PR updates the `PluginManager` to ensure that when calling `getNormalizedIdentifier` or `normalizeIdentifier` the input is returned if the not found in the normalize map. 

Also as these methods were performing similar functions, and internally calling each other, I've updated `normalizeIdentifier` to call `getNormalizedIdentifier` and act as an alias.

I've added tests to ensure we do not run into regressions in the future.