### PR TITLE
[WIP] 1.2 - Fix Brand Settings

### DIFF
--- a/modules/backend/models/BrandSetting.php
+++ b/modules/backend/models/BrandSetting.php
@@ -145,7 +145,7 @@ class BrandSetting extends Model
         $this->menu_mode = $config->get('brand.menuMode', self::INLINE_MENU);
 
         // Attempt to load custom CSS
-        $brandCssPath = File::symbolizePath(Config::get('brand.customLessPath'));
+        $brandCssPath = File::symbolizePath(Config::get('brand.customLessPath', ''));
         if ($brandCssPath && File::exists($brandCssPath)) {
             $this->custom_css = File::get($brandCssPath);
         }
@@ -231,7 +231,7 @@ class BrandSetting extends Model
 
     public static function getDefaultFavicon()
     {
-        $faviconPath = File::symbolizePath(Config::get('brand.faviconPath'));
+        $faviconPath = File::symbolizePath(Config::get('brand.faviconPath', ''));
 
         if ($faviconPath && File::exists($faviconPath)) {
             return Url::asset(File::localToPublic($faviconPath));
@@ -242,7 +242,7 @@ class BrandSetting extends Model
 
     public static function getDefaultLogo()
     {
-        $logoPath = File::symbolizePath(Config::get('brand.logoPath'));
+        $logoPath = File::symbolizePath(Config::get('brand.logoPath', ''));
 
         if ($logoPath && File::exists($logoPath)) {
             return Url::asset(File::localToPublic($logoPath));


### PR DESCRIPTION
This PR introduces a fix to brand settings to prevent:

`TypeError: Winter\Storm\Filesystem\Filesystem::symbolizePath(): Argument #1 ($path) must be of type string, null given`

This error is being thrown due to the default config return being `null`, defaulting the return to an empty string should resolve this error.