### PR TITLE
[Draft] Fix #578

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -306,15 +306,7 @@ class Controller
         /*
          * The 'this' variable is reserved for default variables.
          */
-        $this->vars['this'] = [
-            'page'        => $this->page,
-            'layout'      => $this->layout,
-            'theme'       => $this->theme,
-            'param'       => $this->router->getParameters(),
-            'controller'  => $this,
-            'environment' => App::environment(),
-            'session'     => App::make('session'),
-        ];
+        $this->vars['this'] = $this->getFrontendContext();
 
         /*
          * Check for the presence of validation errors in the session.
@@ -584,6 +576,7 @@ class Controller
     protected function initTwigEnvironment()
     {
         $this->twig = App::make('twig.environment.cms');
+        $this->twig->getExtension('Cms\Twig\Extension')->setController($this);
     }
 
     /**
@@ -1563,5 +1556,22 @@ class Controller
     protected function isSoftComponent($label)
     {
         return starts_with($label, '@');
+    }
+
+    /**
+     * Returns the frontend context variables
+     * @return array
+     */
+    public function getFrontendContext(): array
+    {
+        return [
+            'page'        => $this->page,
+            'layout'      => $this->layout,
+            'theme'       => $this->theme,
+            'param'       => $this->router->getParameters(),
+            'controller'  => $this,
+            'environment' => App::environment(),
+            'session'     => App::make('session'),
+        ];
     }
 }

--- a/modules/cms/twig/Extension.php
+++ b/modules/cms/twig/Extension.php
@@ -117,7 +117,7 @@ class Extension extends TwigExtension
     /**
      * Renders placeholder content, without removing the block, must be called before the placeholder tag itself
      */
-    public function placeholderFunction(string $name, string $default = null): string
+    public function placeholderFunction(string $name, string $default = null): ?string
     {
         if (($result = Block::get($name)) === null) {
             return null;

--- a/modules/cms/twig/Extension.php
+++ b/modules/cms/twig/Extension.php
@@ -1,6 +1,7 @@
 <?php namespace Cms\Twig;
 
 use Block;
+use Cms\Classes\Controller;
 use Event;
 use Twig\Extension\AbstractExtension as TwigExtension;
 use Twig\TwigFilter as TwigSimpleFilter;
@@ -14,6 +15,8 @@ use Twig\TwigFunction as TwigSimpleFunction;
  */
 class Extension extends TwigExtension
 {
+    protected Controller $controller;
+
     /**
      * Returns an array of functions to add to the existing list.
      */
@@ -67,6 +70,7 @@ class Extension extends TwigExtension
             new FlashTokenParser,
             new ScriptsTokenParser,
             new StylesTokenParser,
+            new MacroTokenParser,
         ];
     }
 
@@ -113,7 +117,7 @@ class Extension extends TwigExtension
     /**
      * Renders placeholder content, without removing the block, must be called before the placeholder tag itself
      */
-    public function placeholderFunction(string $name, string $default = null): ?string
+    public function placeholderFunction(string $name, string $default = null): string
     {
         if (($result = Block::get($name)) === null) {
             return null;
@@ -192,5 +196,15 @@ class Extension extends TwigExtension
     public function endBlock($append = true): void
     {
         Block::endBlock($append);
+    }
+
+    public function getFrontendContext(): array
+    {
+        return $this->controller->getFrontendContext();
+    }
+
+    public function setController(Controller $controller)
+    {
+        $this->controller = $controller;
     }
 }

--- a/modules/cms/twig/MacroNode.php
+++ b/modules/cms/twig/MacroNode.php
@@ -1,0 +1,97 @@
+<?php namespace Cms\Twig;
+
+use Twig\Compiler;
+use Twig\Compiler as TwigCompiler;
+
+/**
+ * Extends the twig's native macro node to inject appropriate context
+ *
+ * @package winter\wn-cms-module
+ * @author Romain BILLOIR
+ */
+class MacroNode extends \Twig\Node\MacroNode
+{
+    /**
+     * Compiles the node to PHP.
+     *
+     * @param TwigCompiler $compiler A TwigCompiler instance
+     */
+    public function compile(Compiler $compiler): void
+    {
+        $compiler
+            ->addDebugInfo($this)
+            ->write(sprintf('public function macro_%s(', $this->getAttribute('name')))
+        ;
+
+        $count = \count($this->getNode('arguments'));
+        $pos = 0;
+        foreach ($this->getNode('arguments') as $name => $default) {
+            $compiler
+                ->raw('$__'.$name.'__ = ')
+                ->subcompile($default)
+            ;
+
+            if (++$pos < $count) {
+                $compiler->raw(', ');
+            }
+        }
+
+        if ($count) {
+            $compiler->raw(', ');
+        }
+
+        $compiler
+            ->raw('...$__varargs__')
+            ->raw(")\n")
+            ->write("{\n")
+            ->indent()
+            ->write("\$macros = \$this->macros;\n")
+            ->write("\$context = \$this->env->mergeGlobals(array_merge(\n")
+            ->indent()
+            ->write("['this' => \$this->env->getExtension('Cms\Twig\Extension')->getFrontendContext()],\n")
+            ->write("[\n")
+        ;
+
+        foreach ($this->getNode('arguments') as $name => $default) {
+            $compiler
+                ->write('')
+                ->string($name)
+                ->raw(' => $__'.$name.'__')
+                ->raw(",\n")
+            ;
+        }
+
+        $compiler
+            ->write('')
+            ->string(self::VARARGS_NAME)
+            ->raw(' => ')
+        ;
+
+        $compiler
+            ->raw("\$__varargs__,\n")
+            ->outdent()
+            ->write("]));\n\n")
+            ->write("\$blocks = [];\n\n")
+        ;
+        if ($compiler->getEnvironment()->isDebug()) {
+            $compiler->write("ob_start();\n");
+        } else {
+            $compiler->write("ob_start(function () { return ''; });\n");
+        }
+        $compiler
+            ->write("try {\n")
+            ->indent()
+            ->subcompile($this->getNode('body'))
+            ->raw("\n")
+            ->write("return ('' === \$tmp = ob_get_contents()) ? '' : new Markup(\$tmp, \$this->env->getCharset());\n")
+            ->outdent()
+            ->write("} finally {\n")
+            ->indent()
+            ->write("ob_end_clean();\n")
+            ->outdent()
+            ->write("}\n")
+            ->outdent()
+            ->write("}\n\n")
+        ;
+    }
+}

--- a/modules/cms/twig/MacroTokenParser.php
+++ b/modules/cms/twig/MacroTokenParser.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Cms\Twig;
+
+use App;
+use Twig\Error\SyntaxError;
+use Twig\Node\BodyNode;
+use Twig\Node\Node;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+
+/**
+ * Duplication of the twig's native macro token parser to use the Winter's MacroNode
+ *
+ * @package winter\wn-cms-module
+ * @author Romain BILLOIR
+ */
+class MacroTokenParser extends AbstractTokenParser
+{
+    public function parse(Token $token): Node
+    {
+        $lineno = $token->getLine();
+        $stream = $this->parser->getStream();
+        $name = $stream->expect(/* Token::NAME_TYPE */ 5)->getValue();
+
+        $arguments = $this->parser->getExpressionParser()->parseArguments(true, true);
+
+        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+        $this->parser->pushLocalScope();
+        $body = $this->parser->subparse([$this, 'decideBlockEnd'], true);
+        if ($token = $stream->nextIf(/* Token::NAME_TYPE */ 5)) {
+            $value = $token->getValue();
+
+            if ($value != $name) {
+                throw new SyntaxError(sprintf('Expected endmacro for macro "%s" (but "%s" given).', $name, $value), $stream->getCurrent()->getLine(), $stream->getSourceContext());
+            }
+        }
+        $this->parser->popLocalScope();
+        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+
+        $this->parser->setMacro($name, new MacroNode($name, new BodyNode([$body]), $arguments, $lineno, $this->getTag()));
+
+        return new Node();
+    }
+
+    public function decideBlockEnd(Token $token): bool
+    {
+        return $token->test('endmacro');
+    }
+
+    public function getTag(): string
+    {
+        return 'macro';
+    }
+}


### PR DESCRIPTION
Here is my first attempt to fix #578 without reintroducing a global context.

Two concerns here disturb me:
- The Twig `MacroTokenParser` class is final so we need to rewrite the full class
- Most important: In the #455 PR, @LukeTowers removed the `controller` property inside the Twig cms `Extension` class, but without this, I can't get any reference of the currently running controller to retrieve the controller context's variable, so afaik we need to reintroduce it. I created a method `setController` to bind the controller to the extension.