### PR TITLE
Config - MySQL - default username

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -55,7 +55,7 @@ return [
             'strict' => true,
             'unix_socket' => env('DB_SOCKET', ''),
             'url' => env('DATABASE_URL'),
-            'username' => env('DB_USERNAME', 'winter'),
+            'username' => env('DB_USERNAME', 'root'),
         ],
         'pgsql' => [
             'charset' => 'utf8',


### PR DESCRIPTION
For MySQL, the default value for `username` is `root`.
This makes it easy to install on localhost.