### PR TITLE
Fix typo in MediaManager.php

### DIFF
--- a/modules/backend/widgets/MediaManager.php
+++ b/modules/backend/widgets/MediaManager.php
@@ -1215,7 +1215,7 @@ class MediaManager extends WidgetBase
             return [
                 'id' => $id,
                 'markup' => $this->makePartial('thumbnail-image', [
-                    'imageUrl' => MediaLibary::url($thumbnailInfo['path']),
+                    'imageUrl' => MediaLibrary::url($thumbnailInfo['path']),
                 ]),
             ];
         }


### PR DESCRIPTION
Fix a typo in reference to MediaLibrary, fixing an error when getting vector image thumbnails in the media manager.