### PR TITLE
Fix status widget output on clean installation

### DIFF
--- a/modules/system/reportwidgets/Status.php
+++ b/modules/system/reportwidgets/Status.php
@@ -70,12 +70,7 @@ class Status extends ReportWidgetBase
         $this->vars['requestLogMsg'] = LogSetting::get('log_requests', false) ? false : true;
 
         // TODO: Store system boot date in `Parameter`
-        $this->vars['appBirthday'] = null;
-        $appBirthday = PluginVersion::orderBy('created_at')->first();
-
-        if ($appBirthday) {
-            $this->vars['appBirthday'] = $appBirthday->created_at;
-        }
+        $this->vars['appBirthday'] = PluginVersion::orderBy('created_at')->first()?->created_at;
     }
 
     public function onLoadWarningsForm()

--- a/modules/system/reportwidgets/Status.php
+++ b/modules/system/reportwidgets/Status.php
@@ -70,7 +70,12 @@ class Status extends ReportWidgetBase
         $this->vars['requestLogMsg'] = LogSetting::get('log_requests', false) ? false : true;
 
         // TODO: Store system boot date in `Parameter`
-        $this->vars['appBirthday'] = PluginVersion::orderBy('created_at')->first()->created_at;
+        $this->vars['appBirthday'] = null;
+        $appBirthday = PluginVersion::orderBy('created_at')->first();
+
+        if ($appBirthday) {
+            $this->vars['appBirthday'] = $appBirthday->created_at;
+        }
     }
 
     public function onLoadWarningsForm()


### PR DESCRIPTION
This fixes following error/incorrect output of fresh Winter CMS 1.2 installation:

![2022-08-02_23-50](https://user-images.githubusercontent.com/626982/182471402-617b769e-e7f6-4d37-b38f-d115c5d45eff.png)

Later this could be rewritten to use system boot date from `Parameter` model; if no parameter value is set then the parameter value should be stored from date of the first installed plugin (similar like current logics) or if it's fresh installation then set from current date.