### PR TITLE
Getting and storing system boot date value with Parameter model

### DIFF
--- a/modules/system/database/migrations/2022_08_06_000026_Db_System_Add_App_Birthday_Date.php
+++ b/modules/system/database/migrations/2022_08_06_000026_Db_System_Add_App_Birthday_Date.php
@@ -5,7 +5,7 @@ use Carbon\Carbon;
 use System\Models\Parameter;
 use System\Models\PluginVersion;
 
-class DbSystemAddAppBirthdayDate extends Migration
+return new class extends extends Migration
 {
     public function up()
     {

--- a/modules/system/database/migrations/2022_08_06_000026_Db_System_Add_App_Birthday_Date.php
+++ b/modules/system/database/migrations/2022_08_06_000026_Db_System_Add_App_Birthday_Date.php
@@ -1,0 +1,32 @@
+<?php
+
+use Winter\Storm\Database\Updates\Migration;
+use Carbon\Carbon;
+use System\Models\Parameter;
+use System\Models\PluginVersion;
+
+class DbSystemAddAppBirthdayDate extends Migration
+{
+    public function up()
+    {
+        $appBirthday = Parameter::get('system::app.birthday');
+
+        if (is_null($appBirthday)) {
+            $appBirthdayFromPlugins = PluginVersion::orderBy('created_at')->first()?->created_at;
+
+            if (is_null($appBirthdayFromPlugins)) {
+                $appBirthday = Carbon::now()->timestamp;
+            } else {
+                $appBirthday = Carbon::parse($appBirthdayFromPlugins)->timestamp;
+            }
+
+            Parameter::set('system::app.birthday', $appBirthday);
+        }
+
+        return $appBirthday;
+    }
+
+    public function down()
+    {
+    }
+}

--- a/modules/system/database/migrations/2022_08_06_000026_Db_System_Add_App_Birthday_Date.php
+++ b/modules/system/database/migrations/2022_08_06_000026_Db_System_Add_App_Birthday_Date.php
@@ -5,7 +5,7 @@ use Carbon\Carbon;
 use System\Models\Parameter;
 use System\Models\PluginVersion;
 
-return new class extends extends Migration
+return new class extends Migration
 {
     public function up()
     {
@@ -27,4 +27,4 @@ return new class extends extends Migration
     public function down()
     {
     }
-}
+};

--- a/modules/system/database/migrations/2022_08_06_000026_Db_System_Add_App_Birthday_Date.php
+++ b/modules/system/database/migrations/2022_08_06_000026_Db_System_Add_App_Birthday_Date.php
@@ -11,17 +11,14 @@ class DbSystemAddAppBirthdayDate extends Migration
     {
         $appBirthday = Parameter::get('system::app.birthday');
 
-        if (is_null($appBirthday)) {
-            $appBirthdayFromPlugins = PluginVersion::orderBy('created_at')->first()?->created_at;
-
-            if (is_null($appBirthdayFromPlugins)) {
-                $appBirthday = Carbon::now()->timestamp;
-            } else {
-                $appBirthday = Carbon::parse($appBirthdayFromPlugins)->timestamp;
-            }
-
-            Parameter::set('system::app.birthday', $appBirthday);
+        if ($appBirthday) {
+            return $appBirthday;
         }
+
+        $appBirthdayFromPlugins = PluginVersion::orderBy('created_at')->first()?->created_at;
+        $appBirthday = $appBirthdayFromPlugins ? Carbon::parse($appBirthdayFromPlugins)->timestamp : Carbon::now()->timestamp;
+
+        Parameter::set('system::app.birthday', $appBirthday);
 
         return $appBirthday;
     }

--- a/modules/system/database/migrations/2022_08_06_000026_Db_System_Add_App_Birthday_Date.php
+++ b/modules/system/database/migrations/2022_08_06_000026_Db_System_Add_App_Birthday_Date.php
@@ -10,17 +10,18 @@ class DbSystemAddAppBirthdayDate extends Migration
     public function up()
     {
         $appBirthday = Parameter::get('system::app.birthday');
-
         if ($appBirthday) {
-            return $appBirthday;
+            // Return early if the birthday has already been set
+            return;
         }
 
-        $appBirthdayFromPlugins = PluginVersion::orderBy('created_at')->first()?->created_at;
-        $appBirthday = $appBirthdayFromPlugins ? Carbon::parse($appBirthdayFromPlugins)->timestamp : Carbon::now()->timestamp;
+        $firstPluginCreated = PluginVersion::orderBy('created_at')
+            ->first()
+            ?->created_at;
+
+        $appBirthday = $firstPluginCreated ?: Carbon::now();
 
         Parameter::set('system::app.birthday', $appBirthday);
-
-        return $appBirthday;
     }
 
     public function down()

--- a/modules/system/reportwidgets/Status.php
+++ b/modules/system/reportwidgets/Status.php
@@ -3,7 +3,6 @@
 use Lang;
 use Config;
 use BackendAuth;
-use Carbon\Carbon;
 use System\Models\Parameter;
 use System\Models\LogSetting;
 use System\Classes\UpdateManager;
@@ -12,7 +11,6 @@ use Backend\Classes\ReportWidgetBase;
 use Backend\Models\User;
 use System\Models\EventLog;
 use System\Models\RequestLog;
-use System\Models\PluginVersion;
 use Exception;
 
 /**
@@ -70,32 +68,13 @@ class Status extends ReportWidgetBase
         $this->vars['requestLog']    = RequestLog::count();
         $this->vars['requestLogMsg'] = LogSetting::get('log_requests', false) ? false : true;
 
-        $this->vars['appBirthday'] = $this->getAppBirthday();
+        $this->vars['appBirthday'] = Parameter::get('system::app.birthday');
     }
 
     public function onLoadWarningsForm()
     {
         $this->vars['warnings'] = $this->getSystemWarnings();
         return $this->makePartial('warnings_form');
-    }
-
-    protected function getAppBirthday()
-    {
-        $appBirthday = Parameter::get('system::app.birthday', null);
-
-        if (is_null($appBirthday)) {
-            $appBirthdayFromPlugins = PluginVersion::orderBy('created_at')->first()?->created_at;
-
-            if (is_null($appBirthdayFromPlugins)) {
-                $appBirthday = Carbon::now()->timestamp;
-            } else {
-                $appBirthday = Carbon::parse($appBirthdayFromPlugins)->timestamp;
-            }
-
-            Parameter::set('system::app.birthday', $appBirthday);
-        }
-
-        return $appBirthday;
     }
 
     protected function getSystemWarnings()


### PR DESCRIPTION
This PR changes the logic how the system boot date (appBirthday) parameter value is handled by introducing `system::app.birthday` Parameter. Also additional logic is added to handle parameter value in existing Winter CMS installations:

1. If no `system::app.birthday` Parameter value exists then we try to get the installation date of the first plugin of system (this is the current behavior); if plugin version value exists then we store it as `system::app.birthday` value so we don't need to do this step again in the future;
2. If step 1 fails (system has no plugins installed) then we assume that app birthday is today and we set `system::app.birthday` value.

One additional note - `system::app.birthday` value also could be set in `WinterInstall.php` for all new installations but currently I am not sure where is the best place to add that logic, my current guess is - at the end part of `handle()` function, right before `$this->displayOutro()`.