### PR TITLE
[POC] Disabled the plusplus checking rule

### DIFF
--- a/modules/system/.eslintrc.json
+++ b/modules/system/.eslintrc.json
@@ -18,6 +18,7 @@
         "max-len": ["off"],
         "new-cap": ["error", { "properties": false }],
         "no-alert": ["off"],
+        "no-plusplus": "off",
         "no-param-reassign": ["error", {
             "props": false
         }],


### PR DESCRIPTION
As discussed in the discord, the no-plusplus rule is less than ideal as it prevents using a useful language feature. Therefore this PR disables the rule.

For outsiders, our current eslint configuration does not allow for:

```javascript
++something
something++
--something
something--
```

The logic behind the rule can be found here: https://airbnb.io/javascript/#variables--unary-increment-decrement

Rather than just force this change through, I thought it would be nice to have it as a PR people can comment on :)