### PR TITLE
Added parent args to signature

### DIFF
--- a/modules/system/console/MixWatch.php
+++ b/modules/system/console/MixWatch.php
@@ -17,7 +17,9 @@ class MixWatch extends MixCompile implements SignalableCommandInterface
     protected $signature = 'mix:watch
         {package : Defines the package to watch for changes}
         {webpackArgs?* : Arguments to pass through to the Webpack CLI}
-        {--f|production : Runs compilation in "production" mode}';
+        {--f|production : Runs compilation in "production" mode}
+        {--m|manifest= : Defines package.json to use for compile}
+        {--s|silent : Silent mode}';
 
     /**
      * @var string The console command description.


### PR DESCRIPTION
Because `MixWatch` extends `MixCompile` when ran the `readNpmPackageManifest()` method is called, it expects the command to be setup to handle `--manifest`.  The same issue is present with `--silent`.

This PR adds the option to allow `mix:watch` to run without errors.