### PR TITLE
Fix Exception class not found in PluginTestCase

### DIFF
--- a/modules/system/tests/bootstrap/PluginTestCase.php
+++ b/modules/system/tests/bootstrap/PluginTestCase.php
@@ -11,6 +11,7 @@ use Config;
 use Mail;
 use Artisan;
 use ReflectionClass;
+use Exception;
 
 abstract class PluginTestCase extends TestCase
 {
@@ -132,7 +133,7 @@ abstract class PluginTestCase extends TestCase
             if (!$throwException) {
                 return;
             }
-            throw new \Exception(sprintf('Invalid plugin code: "%s"', $code));
+            throw new Exception(sprintf('Invalid plugin code: "%s"', $code));
         }
 
         $manager = PluginManager::instance();


### PR DESCRIPTION
I tried to run some databases tests using the `PluginTestCase` but for some reason I'm trying to figure out, the `Database.Tester` is not found on my system (but that's another problem).

This ended to this error:
```
System\Tests\Plugins\Database\NestedTreeModelTest::testGetNested
Error: Class "System\Tests\Bootstrap\Exception" not found

/home/vagrant/code/modules/system/tests/bootstrap/PluginTestCase.php:152
/home/vagrant/code/modules/system/tests/plugins/database/NestedTreeModelTest.php:17
```

I fixed it using the general codestyle: importing the `Exception` class with an `use` statement and removing the backslash when present.

To be crystal clear, the error was thrown by this line which didn't use the backslash:

https://github.com/wintercms/winter/blob/7fe167c41fc2007e44201dff60136bdd083bf2b4/modules/system/tests/bootstrap/PluginTestCase.php#L148-L153
------
**[EDIT]** To see the error by yourself (now that I know why the `Database.Tester` plugin was not found on my machine), just rollback this changes: https://github.com/wintercms/winter/commit/7fe167c41fc2007e44201dff60136bdd083bf2b4#diff-7382f8d196c94d9c7562f9c1d5d9780aedf59889b83b0c0e950dee45b01e777dL99  
this will make the `PluginTestCase` to not found the plugin,  
and run any test that rely on the `PluginTestCase` class:
```
php artisan winter:test -m system -- --filter NestedTreeModelTest
```