### PR TITLE
Fix nested tree listsNested method returning unordered hierarchy

### DIFF
--- a/modules/system/tests/plugins/database/NestedTreeModelTest.php
+++ b/modules/system/tests/plugins/database/NestedTreeModelTest.php
@@ -115,12 +115,32 @@ class NestedTreeModelTest extends PluginTestCase
 
         $autumn = $orange->children()->create([
             'name' => 'Autumn Leaves',
-            'description' => 'Disccusion about the season of falling leaves.'
+            'description' => 'Discussion about the season of falling leaves.'
         ]);
 
         $autumn->children()->create([
             'name' => 'September',
             'description' => 'The start of the fall season.'
+        ]);
+
+        $orange->children()->create([
+            'name' => 'Summer Breeze',
+            'description' => 'Discussion about the wind at the ocean.'
+        ]);
+
+        $green = CategoryNested::create([
+            'name' => 'Category Green',
+            'description' => 'A root level test category',
+        ]);
+
+        $green->children()->create([
+            'name' => 'Winter Snow',
+            'description' => 'Discussion about the frosty snow flakes.'
+        ]);
+
+        $green->children()->create([
+            'name' => 'Spring Trees',
+            'description' => 'Discussion about the blooming gardens.'
         ]);
 
         $autumn->children()->create([
@@ -131,26 +151,6 @@ class NestedTreeModelTest extends PluginTestCase
         $autumn->children()->create([
             'name' => 'November',
             'description' => 'The end of the fall season.'
-        ]);
-
-        $orange->children()->create([
-            'name' => 'Summer Breeze',
-            'description' => 'Disccusion about the wind at the ocean.'
-        ]);
-
-        $green = CategoryNested::create([
-            'name' => 'Category Green',
-            'description' => 'A root level test category',
-        ]);
-
-        $green->children()->create([
-            'name' => 'Winter Snow',
-            'description' => 'Disccusion about the frosty snow flakes.'
-        ]);
-
-        $green->children()->create([
-            'name' => 'Spring Trees',
-            'description' => 'Disccusion about the blooming gardens.'
         ]);
 
         Model::reguard();


### PR DESCRIPTION
Hi!
When toying with the `NestedTree` trait, I discovered something which looks to me like an unwanted behavior:
The `listsNested` scope doesn't order properly the tree hierarchy. Actually it doesn't order anything as of today and just returns the collection in the order of the database entries.

In this draft PR, I just mixed the `NestedTreeModelTest` entries to make the test fail and discuss if this is the wanted behavior or if this should be fixed. I just moved the `September` and `October` savings at the end of the seeder method.

I expected that it wouldn't change anything but it does change the order.

Before doing the modification, I'd like to have some thoughts about that.

_There is some other modifications to fix some typos_