### PR TITLE
Add support for overriding phpunit bootstrap

### DIFF
--- a/modules/system/console/WinterTest.php
+++ b/modules/system/console/WinterTest.php
@@ -141,6 +141,13 @@ class WinterTest extends Command
         // Resolve the configuration path based on the current working directory
         $config = realpath($config);
         $bootstrapPath = base_path('modules/system/tests/bootstrap/app.php');
+        
+        if (
+            ($configBoostrap = (string) simplexml_load_file($config)['bootstrap'])
+            && str_starts_with($configBoostrap, './')
+        ) {
+            $bootstrapPath = dirname($config) . ltrim($configBoostrap, '.');
+        }
 
         $process = new Process(
             array_merge([$this->phpUnitExec, '--configuration=' . $config, '--bootstrap=' . $bootstrapPath], $args),

--- a/modules/system/console/WinterTest.php
+++ b/modules/system/console/WinterTest.php
@@ -142,11 +142,8 @@ class WinterTest extends Command
         $config = realpath($config);
         $bootstrapPath = base_path('modules/system/tests/bootstrap/app.php');
         
-        if (
-            ($configBoostrap = (string) simplexml_load_file($config)['bootstrap'])
-            && str_starts_with($configBoostrap, './')
-        ) {
-            $bootstrapPath = dirname($config) . ltrim($configBoostrap, '.');
+        if ($configBoostrap = (string) simplexml_load_file($config)['bootstrap']) {
+            $bootstrapPath = dirname($config) . DIRECTORY_SEPARATOR . $configBoostrap;
         }
 
         $process = new Process(


### PR DESCRIPTION
This PR allows for testables to implement their own bootstrap file.

Configurable via the `boostrap` attribute in `phpunit.xml`