### PR TITLE
feat: Make `winter:install` password generation transparent

### DIFF
--- a/modules/backend/database/seeds/DatabaseSeeder.php
+++ b/modules/backend/database/seeds/DatabaseSeeder.php
@@ -14,7 +14,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        $shouldRandomizePassword = SeedSetupAdmin::$password === 'admin';
+        $shouldRandomizePassword = SeedSetupAdmin::$password === '';
         $adminPassword = $shouldRandomizePassword ? Str::random(22) : SeedSetupAdmin::$password;
 
         Eloquent::unguarded(function () use ($adminPassword) {

--- a/modules/backend/database/seeds/SeedSetupAdmin.php
+++ b/modules/backend/database/seeds/SeedSetupAdmin.php
@@ -9,7 +9,7 @@ class SeedSetupAdmin extends Seeder
 {
     public static $email = 'admin@example.com';
     public static $login = 'admin';
-    public static $password = 'admin';
+    public static $password = '';
     public static $firstName = 'Admin';
     public static $lastName = 'Person';
 

--- a/modules/system/console/WinterInstall.php
+++ b/modules/system/console/WinterInstall.php
@@ -361,15 +361,13 @@ class WinterInstall extends Command
 
     protected function setupAdminUser()
     {
-        SeedSetupAdmin::$password = Str::random(22);
-
         $this->line('Enter a new value, or press ENTER for the default');
 
         SeedSetupAdmin::$firstName = $this->ask('First Name', SeedSetupAdmin::$firstName);
         SeedSetupAdmin::$lastName = $this->ask('Last Name', SeedSetupAdmin::$lastName);
         SeedSetupAdmin::$email = $this->ask('Email Address', SeedSetupAdmin::$email);
         SeedSetupAdmin::$login = $this->ask('Admin Login', SeedSetupAdmin::$login);
-        SeedSetupAdmin::$password = $this->ask('Admin Password', SeedSetupAdmin::$password);
+        SeedSetupAdmin::$password = $this->ask('Admin Password', Str::random(22));
 
         if (!$this->confirm('Is the information correct?', true)) {
             $this->setupAdminUser();

--- a/modules/system/console/WinterInstall.php
+++ b/modules/system/console/WinterInstall.php
@@ -361,6 +361,8 @@ class WinterInstall extends Command
 
     protected function setupAdminUser()
     {
+        SeedSetupAdmin::$password = Str::random(22);
+
         $this->line('Enter a new value, or press ENTER for the default');
 
         SeedSetupAdmin::$firstName = $this->ask('First Name', SeedSetupAdmin::$firstName);


### PR DESCRIPTION
# Description

This PR changes the way admin passwords are generated on new installations slightly in order to make it transparent for users of the `winter:install` command without impeding functionality for those who opt to use `winter:up` and a custom configuration.

The problem right now is that the password "admin" is practically forbidden since it will be replaced with a random generated password.

To users of `winter:up`, this doesn't matter since the generated random password will be one of the final emitted lines and is therefore easy to see (+ since the command is completely non-interactive, you kind of expect that the command will tell you the admin password).

For users of the `winter:install` command, however, this leads to confusion because of two reasons:

1. The command prompt that asks for a password displays `admin` as the default, suggesting that the default password will be indeed `admin` if you do not change it explicitly.
2. The generated password will be hidden by a few lines of additional output (the `displayOutro`-function), so in addition to you assuming you don't have to search for a random generated password will easily miss it in the command's output.

To sum up, the current way of generating admin-passwords have two problems:

1. For users of `winter:install`, the process of password generation is intransparent
2. The password "admin" is practically forbidden, even if you want to use it

# Changes

1. The default password in `SeedSetupAdmin` will now be preset with an empty string. Since empty passwords are forbidden anyways, this is a better default than `admin` which, depending on your use-case, may be the password that you actually want (keyword: local development install).
2. The database seeder will still sneakily exchange the default password – but only if the password is completely empty.
3. The `winter:install` command will now set the password to a random generated one before asking the user for the password, ensuring that whatever is displayed as the default will be used if not overridden by the user.
4. In turn, this means that `admin` is now also an acceptable admin password. By setting the default to a random string, however, a certain amount of security is ensured, as you have to explicitly type "admin" if you really want to use it.
5. Lastly, how the password generation works for users of the non-interactive install does not change due to this PR.