### PR TITLE
Add support for input range

### DIFF
--- a/modules/backend/widgets/form/partials/_field_range.php
+++ b/modules/backend/widgets/form/partials/_field_range.php
@@ -3,16 +3,16 @@
     <span class="form-control"><?= isset($field->value) ? e($field->value) : '&nbsp;' ?></span>
 <?php else: ?>
     <?php
-        $min = $field->config['min'] ?? 0;
-        $max = $field->config['max'] ?? 100;
-        $step = $field->config['step'] ?? 1;
-        $value = $field->value;
-        if ($min > $max) {
-            $min = $max - $step;
-        }
-        if (is_null($value)) {
-            $value = ($min + $max) / 2;
-        }
+    $min = $field->config['min'] ?? 0;
+    $max = $field->config['max'] ?? 100;
+    $step = $field->config['step'] ?? 1;
+    $value = $field->value;
+    if ($min > $max) {
+        $min = $max - $step;
+    }
+    if (is_null($value)) {
+        $value = ($min + $max) / 2;
+    }
     ?>
 
     <input

--- a/modules/backend/widgets/form/partials/_field_range.php
+++ b/modules/backend/widgets/form/partials/_field_range.php
@@ -1,0 +1,33 @@
+<!-- Range -->
+<?php if ($this->previewMode): ?>
+    <span class="form-control"><?= isset($field->value) ? e($field->value) : '&nbsp;' ?></span>
+<?php else: ?>
+    <?php
+        $min = $field->config['min'] ?? 0;
+        $max = $field->config['max'] ?? 100;
+        $step = $field->config['step'] ?? 1;
+    ?>
+
+    <input
+        type="range"
+        step="<?= $step ?>"
+        name="<?= $field->getName() ?>"
+        id="<?= $field->getId() ?>"
+        value="<?= e($field->value) ?>"
+        min="<?= $min ?>"
+        min="<?= $max ?>"
+        <?= $field->getAttributes() ?>
+    />
+    <span style="position: absolute; transform: translateX(-50%)"><?= isset($field->value) ? $field->value : 50 ?></span>
+    <script>
+        $(document).ready(function () {
+            const input = document.getElementById("<?= $field->getId() ?>");
+            input.addEventListener("input", function () {
+                this.nextElementSibling.innerHTML = this.value;
+                var pos = ((this.value - <?= $min ?>) / (<?= $max ?> - <?= $min ?>) * 100);
+                this.nextElementSibling.style.left = `calc(${pos}% + ${8 - pos * 0.15}px)`;
+            });
+            input.dispatchEvent(new Event('input'));
+        });
+    </script>
+<?php endif ?>

--- a/modules/backend/widgets/form/partials/_field_range.php
+++ b/modules/backend/widgets/form/partials/_field_range.php
@@ -20,7 +20,7 @@
     />
     <span style="position: absolute; transform: translateX(-50%)"><?= isset($field->value) ? $field->value : 50 ?></span>
     <script>
-        $(document).ready(function () {
+        (() => {
             const input = document.getElementById("<?= $field->getId() ?>");
             input.addEventListener("input", function () {
                 this.nextElementSibling.innerHTML = this.value;
@@ -28,6 +28,6 @@
                 this.nextElementSibling.style.left = `calc(${pos}% + ${8 - pos * 0.15}px)`;
             });
             input.dispatchEvent(new Event('input'));
-        });
+        })();
     </script>
 <?php endif ?>

--- a/modules/backend/widgets/form/partials/_field_range.php
+++ b/modules/backend/widgets/form/partials/_field_range.php
@@ -6,6 +6,13 @@
         $min = $field->config['min'] ?? 0;
         $max = $field->config['max'] ?? 100;
         $step = $field->config['step'] ?? 1;
+        $value = $field->value;
+        if ($min > $max) {
+            $min = $max - $step;
+        }
+        if (is_null($value)) {
+            $value = ($min + $max) / 2;
+        }
     ?>
 
     <input
@@ -13,12 +20,12 @@
         step="<?= $step ?>"
         name="<?= $field->getName() ?>"
         id="<?= $field->getId() ?>"
-        value="<?= e($field->value) ?>"
+        value="<?= e($value) ?>"
         min="<?= $min ?>"
-        min="<?= $max ?>"
+        max="<?= $max ?>"
         <?= $field->getAttributes() ?>
     />
-    <span style="position: absolute; transform: translateX(-50%)"><?= isset($field->value) ? $field->value : 50 ?></span>
+    <span style="position: absolute; transform: translateX(-50%)"></span>
     <script>
         (() => {
             const input = document.getElementById("<?= $field->getId() ?>");
@@ -30,4 +37,4 @@
             input.dispatchEvent(new Event('input'));
         })();
     </script>
-<?php endif ?>
+<?php endif; ?>


### PR DESCRIPTION
This PR adds support for the input range as a form field.

Screenshot:
![image](https://user-images.githubusercontent.com/9019306/188149730-f2c4cc35-a36f-461e-b700-091605df73f8.png)

By default, input ranges do not have a way to display their current value, so I have added an extra element that follows the handle.

Here is the PR on the docs repo that should ideally be merged in at the same time: https://github.com/wintercms/docs/pull/91