### PR TITLE
Clean up of base plugin test case class

### DIFF
--- a/modules/system/tests/bootstrap/PluginTestCase.php
+++ b/modules/system/tests/bootstrap/PluginTestCase.php
@@ -70,8 +70,6 @@ abstract class PluginTestCase extends TestCase
 
     /**
      * Perform test case set up.
-     *
-     * @return void
      */
     public function setUp(): void
     {
@@ -98,8 +96,7 @@ abstract class PluginTestCase extends TestCase
     }
 
     /**
-     * Flush event listeners and collect garbage.
-     * @return void
+     * Flush event listeners and tear down.
      */
     public function tearDown(): void
     {
@@ -117,7 +114,7 @@ abstract class PluginTestCase extends TestCase
      * @deprecated v1.2.1 Use `instantiatePlugin()` instead.
      * @return void
      */
-    protected function runPluginRefreshCommand($code, $throwException = true): void
+    protected function runPluginRefreshCommand($code, $throwException = true)
     {
         $this->instantiatePlugin((string) $code, (bool) $throwException);
     }
@@ -127,7 +124,6 @@ abstract class PluginTestCase extends TestCase
      *
      * @param string $code Plugin code.
      * @param boolean $throw Throw an exception if the plugin cannot be found.
-     * @return void
      */
     protected function instantiatePlugin(string $code, bool $throw = true): void
     {
@@ -183,8 +179,6 @@ abstract class PluginTestCase extends TestCase
 
     /**
      * Returns a plugin object from its code, useful for registering events, etc.
-     *
-     * @return PluginBase|null
      */
     protected function getPluginObject($code = null): ?PluginBase
     {
@@ -200,8 +194,6 @@ abstract class PluginTestCase extends TestCase
      * targeted and reset, ready for a new test cycle.
      *
      * Pivot models are an exception since they are internally managed.
-     *
-     * @return void
      */
     protected function flushModelEventListeners(): void
     {

--- a/modules/system/tests/bootstrap/PluginTestCase.php
+++ b/modules/system/tests/bootstrap/PluginTestCase.php
@@ -2,29 +2,38 @@
 
 namespace System\Tests\Bootstrap;
 
-use Backend\Classes\AuthManager;
-use System\Classes\UpdateManager;
-use System\Classes\PluginManager;
-use Winter\Storm\Database\Model as ActiveRecord;
-use Backend\Tests\Concerns\InteractsWithAuthentication;
-use Config;
 use Mail;
+use Config;
 use Artisan;
-use ReflectionClass;
 use Exception;
+use ReflectionClass;
+use Backend\Classes\AuthManager;
+use Backend\Tests\Concerns\InteractsWithAuthentication;
+use System\Classes\PluginBase;
+use System\Classes\PluginManager;
+use System\Classes\UpdateManager;
+use Winter\Storm\Database\Model as BaseModel;
 
+/**
+ * Plugin test case.
+ *
+ * The base test case that should be used for plugin tests. It instantiates the given plugin and
+ * its dependencies, and ensures that the plugin is available for use within the tests.
+ *
+ * @package winter/wn-system-module
+ */
 abstract class PluginTestCase extends TestCase
 {
     use InteractsWithAuthentication;
 
     /**
-     * @var array Cache for storing which plugins have been loaded
-     * and refreshed.
+     * @var array Cache for storing which plugins have been loaded.
      */
     protected $pluginTestCaseLoadedPlugins = [];
 
     /**
      * Creates the application.
+     *
      * @return \Symfony\Component\HttpKernel\HttpKernelInterface
      */
     public function createApplication()
@@ -41,9 +50,7 @@ abstract class PluginTestCase extends TestCase
             return AuthManager::instance();
         });
 
-        /*
-         * Store database in memory by default unless specified otherwise
-         */
+        // Store database in memory by default unless otherwise specified
         if (!file_exists(base_path('config/testing/database.php'))) {
             $app['config']->set('database.connections.testing', [
                 'driver'   => 'sqlite',
@@ -55,9 +62,7 @@ abstract class PluginTestCase extends TestCase
         // Set random encryption key
         $app['config']->set('app.key', bin2hex(random_bytes(16)));
 
-        /*
-         * Modify the plugin path away from the test context
-         */
+        // Modify the plugin path away from the test context
         $app->setPluginsPath(realpath(base_path() . Config::get('cms.pluginsPath')));
 
         return $app;
@@ -65,39 +70,27 @@ abstract class PluginTestCase extends TestCase
 
     /**
      * Perform test case set up.
+     *
      * @return void
      */
-    public function setUp() : void
+    public function setUp(): void
     {
-        /*
-         * Force reload of Winter singletons
-         */
+        // Reload the plugin and update manager singletons
         PluginManager::forgetInstance();
         UpdateManager::forgetInstance();
 
-        /*
-         * Create application instance
-         */
         parent::setUp();
 
-        /*
-         * Ensure system is up to date
-         */
-        $this->runWinterUpCommand();
+        // Run all migrations
+        Artisan::call('winter:up');
 
-        /*
-         * Detect plugin from test and autoload it
-         */
+        // Reset loaded plugins for this test
         $this->pluginTestCaseLoadedPlugins = [];
-        $pluginCode = $this->guessPluginCodeFromTest();
 
-        if ($pluginCode !== false) {
-            $this->runPluginRefreshCommand($pluginCode, false);
-        }
+        // Detect the plugin being tested and load it automatically
+        $this->guessAndLoadPlugin();
 
-        /*
-         * Disable mailer
-         */
+        // Disable mailing
         Mail::pretend();
     }
 
@@ -105,7 +98,7 @@ abstract class PluginTestCase extends TestCase
      * Flush event listeners and collect garbage.
      * @return void
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         $this->flushModelEventListeners();
         parent::tearDown();
@@ -113,24 +106,31 @@ abstract class PluginTestCase extends TestCase
     }
 
     /**
-     * Migrate database using winter:up command.
+     * Refreshes a plugin for testing.
+     *
+     * Since the test environment has loaded all the test plugins natively, this method will ensure
+     * the desired plugin is loaded in the system before proceeding to migrate it.
+     *
+     * @deprecated v1.2.1 Use `instantiatePlugin()` instead.
      * @return void
      */
-    protected function runWinterUpCommand()
+    protected function runPluginRefreshCommand($code, $throwException = true): void
     {
-        Artisan::call('winter:up');
+        $this->instantiatePlugin((string) $code, (bool) $throwException);
     }
 
     /**
-     * Since the test environment has loaded all the test plugins
-     * natively, this method will ensure the desired plugin is
-     * loaded in the system before proceeding to migrate it.
+     * Instantiates a plugin for testing.
+     *
+     * @param string $code Plugin code.
+     * @param boolean $throw Throw an exception if the plugin cannot be found.
      * @return void
      */
-    protected function runPluginRefreshCommand($code, $throwException = true)
+    protected function instantiatePlugin(string $code, bool $throw = true): void
     {
+        // Check plugin code is valid
         if (!preg_match('/^[\w+]*\.[\w+]*$/', $code)) {
-            if (!$throwException) {
+            if (!$throw) {
                 return;
             }
             throw new Exception(sprintf('Invalid plugin code: "%s"', $code));
@@ -138,16 +138,15 @@ abstract class PluginTestCase extends TestCase
 
         $manager = PluginManager::instance();
         $plugin = $manager->findByIdentifier($code);
+        $firstLoad = !$plugin;
 
-        /*
-         * First time seeing this plugin, load it up
-         */
-        if (!$plugin) {
+        // First time seeing this plugin, load it up
+        if ($firstLoad) {
             $namespace = '\\'.str_replace('.', '\\', strtolower($code));
             $path = array_get($manager->getPluginNamespaces(), $namespace);
 
             if (!$path) {
-                if (!$throwException) {
+                if (!$throw) {
                     return;
                 }
                 throw new Exception(sprintf('Unable to find plugin with code: "%s"', $code));
@@ -157,40 +156,36 @@ abstract class PluginTestCase extends TestCase
             $manager->registerPlugin($plugin);
         }
 
-        /*
-         * Spin over dependencies and refresh them too
-         */
         $this->pluginTestCaseLoadedPlugins[$code] = $plugin;
 
+        // Load any dependencies
         if (!empty($plugin->require)) {
             foreach ((array) $plugin->require as $dependency) {
                 if (isset($this->pluginTestCaseLoadedPlugins[$dependency])) {
                     continue;
                 }
 
-                $this->runPluginRefreshCommand($dependency);
+                $this->instantiatePlugin($dependency);
             }
         }
 
-        /*
-         * Execute the command
-         */
+        // Refresh the plugin's tables
         Artisan::call('plugin:refresh', ['plugin' => $code, '--force' => true]);
+
+        // Boot the plugin if this is the first load
+        if ($firstLoad) {
+            $manager->bootPlugin($plugin);
+        }
     }
 
     /**
      * Returns a plugin object from its code, useful for registering events, etc.
-     * @return PluginBase
+     *
+     * @return PluginBase|null
      */
-    protected function getPluginObject($code = null)
+    protected function getPluginObject($code = null): ?PluginBase
     {
-        if ($code === null) {
-            $code = $this->guessPluginCodeFromTest();
-        }
-
-        if (isset($this->pluginTestCaseLoadedPlugins[$code])) {
-            return $this->pluginTestCaseLoadedPlugins[$code];
-        }
+        return $this->pluginTestCaseLoadedPlugins[$code] ?? null;
     }
 
     /**
@@ -199,7 +194,7 @@ abstract class PluginTestCase extends TestCase
      * Pivot models are an exception since they are internally managed.
      * @return void
      */
-    protected function flushModelEventListeners()
+    protected function flushModelEventListeners(): void
     {
         foreach (get_declared_classes() as $class) {
             if ($class === 'Winter\Storm\Database\Pivot' || strtolower($class) === 'october\rain\database\pivot') {
@@ -218,26 +213,37 @@ abstract class PluginTestCase extends TestCase
             $class::flushEventListeners();
         }
 
-        ActiveRecord::flushEventListeners();
+        BaseModel::flushEventListeners();
     }
 
     /**
-     * Locates the plugin code based on the test file location.
-     * @return string|bool
+     * Locates the plugin code based on the test file location and loads it.
+     *
+     * @return void
      */
-    protected function guessPluginCodeFromTest()
+    protected function guessAndLoadPlugin(): void
     {
         $reflect = new ReflectionClass($this);
-        $path = $reflect->getFilename();
-        $basePath = $this->app->pluginsPath();
+        $fqClass = $reflect->getName();
+        $namespace = $reflect->getNamespaceName();
 
-        $result = false;
+        if (empty($namespace)) {
+            // Try to determine from the path instead
+            $path = $reflect->getFilename();
+            $basePath = $this->app->pluginsPath();
 
-        if (strpos($path, $basePath) === 0) {
-            $result = ltrim(str_replace('\\', '/', substr($path, strlen($basePath))), '/');
-            $result = implode('.', array_slice(explode('/', $result), 0, 2));
+            if (!strpos($path, $basePath) === 0) {
+                return;
+            }
+
+            $pluginCode = ltrim(str_replace('\\', '/', substr($path, strlen($basePath))), '/');
+            $pluginCode = implode('.', array_slice(explode('/', $pluginCode), 0, 2));
+        } else {
+            // Determine code from namespace
+            $manager = PluginManager::instance();
+            $pluginCode = $manager->getIdentifier($fqClass);
         }
 
-        return $result;
+        $this->instantiatePlugin($pluginCode, false);
     }
 }


### PR DESCRIPTION
- Deprecate `runPluginRefreshCommand` method and replace with `instantiatePlugin`, to better describe the functionality within.
- Run instantiated plugin's `boot` method to ensure all needed functionality is correctly loaded.
- Use namespace to guess plugin being detected, falling back to path if there is no namespace given - this fixes testing for symlinked plugins.
- Add type hints and return types for most methods

This should fix the issues in some PRs ([like this one](https://github.com/wintercms/wn-redirect-plugin/pull/10#issuecomment-1236415903)) where the plugin's `boot` method did not seem to load.