### PR TITLE
Explicitly define an index on component list hidden fields

### DIFF
--- a/modules/cms/assets/js/winter.cmspage.js
+++ b/modules/cms/assets/js/winter.cmspage.js
@@ -399,7 +399,7 @@
         var element = ev.target,
             values = JSON.parse($('[data-inspector-values]', element).val())
 
-        $('[name="component_aliases[]"]', element).val(values['oc.alias'])
+        $('[name^="component_aliases["]', element).val(values['oc.alias'])
         $('span.alias', element).text(values['oc.alias'])
     }
 
@@ -411,10 +411,11 @@
             $cell = $(ev.target).parent()
 
         $('div.layout-cell', $componentList).each(function(){
-            if ($cell.get(0) == this)
+            if ($cell.get(0) == this) {
                 return true
+            }
 
-            var $input = $('input[name="component_aliases[]"]', this)
+            var $input = $('input[name^="component_aliases["]', this)
 
             if ($input.val() == alias) {
                 ev.preventDefault()
@@ -473,9 +474,10 @@
             alias = $aliasInput.val(),
             originalAlias = alias,
             counter = 2,
+            index = $componentList.children().length,
             existingAliases = []
 
-        $('div.layout-cell input[name="component_aliases[]"]', $componentList).each(function(){
+        $('div.layout-cell input[name^="component_aliases["]', $componentList).each(function(){
             existingAliases.push($(this).val())
         })
 
@@ -499,10 +501,18 @@
             'data-inspector-class': $classInput.val()
         })
 
+        // Set component input indexes
+        $('input[name^="component_"]', $component).each(function () {
+            $(this).attr('name', $(this).attr('name').replace('[]', '[' + index + ']'))
+        })
+        var $indexInput = $('<input type="hidden">')
+        $indexInput.attr('data-component-index', index)
+        $('input[name^="component_properties["]', $component).before($indexInput)
+
         $configInput.remove()
-        $('input[name="component_names[]"]', $component).val($nameInput.val())
+        $('input[name^="component_names["]', $component).val($nameInput.val())
         $nameInput.remove()
-        $('input[name="component_aliases[]"]', $component).val(alias)
+        $('input[name^="component_aliases["]', $component).val(alias)
         $component.find('span.alias').text(alias)
         $valuesInput.val($valuesInput.val().replace('--alias--', alias))
         $aliasInput.remove()

--- a/modules/cms/assets/js/winter.cmspage.js
+++ b/modules/cms/assets/js/winter.cmspage.js
@@ -404,9 +404,7 @@
     }
 
     CmsPage.prototype.onInspectorHiding = function(ev, values) {
-        var element = ev.target,
-            values = JSON.parse($('[data-inspector-values]', element).val()),
-            alias = values['oc.alias'],
+        var alias = values.values['oc.alias'],
             $componentList = $('#cms-master-tabs > div.tab-content > .tab-pane.active .control-componentlist .layout'),
             $cell = $(ev.target).parent()
 

--- a/modules/cms/formwidgets/components/partials/_component.php
+++ b/modules/cms/formwidgets/components/partials/_component.php
@@ -12,9 +12,10 @@
         <span class="name"><?= $name ?></span>
         <span class="description"><?= $description ?></span>
         <span class="alias wn-icon-code"><?= e($component->alias) ?></span>
-        <input type="hidden" name="component_properties[]" data-inspector-values value="<?= e($this->getComponentPropertyValues($component)) ?>" />
-        <input type="hidden" name="component_names[]" value="<?= e($component->name) ?>" />
-        <input type="hidden" name="component_aliases[]" value="<?= e($component->alias) ?>" />
+        <input type="hidden" data-component-index="<?= $index ?>">
+        <input type="hidden" name="component_properties[<?= $index ?>]" data-inspector-values value="<?= e($this->getComponentPropertyValues($component)) ?>" />
+        <input type="hidden" name="component_names[<?= $index ?>]" value="<?= e($component->name) ?>" />
+        <input type="hidden" name="component_aliases[<?= $index ?>]" value="<?= e($component->alias) ?>" />
         <a href="#" class="remove">&times;</a>
     </div>
 </div>

--- a/modules/cms/formwidgets/components/partials/_formcomponents.php
+++ b/modules/cms/formwidgets/components/partials/_formcomponents.php
@@ -1,15 +1,15 @@
 <div class="control-componentlist bg-s">
-    <?php foreach ($components as $component): ?>
+    <?php foreach ($components as $index => $component): ?>
         <?php if ($component->isHidden): ?>
-            <?= $this->makePartial('component', ['component' => $component]) ?>
+            <?= $this->makePartial('component', ['component' => $component, 'index' => $index]) ?>
         <?php endif ?>
     <?php endforeach ?>
 
     <div class="components" data-control="toolbar">
         <div class="layout">
-            <?php foreach ($components as $component): ?>
+            <?php foreach ($components as $index => $component): ?>
                 <?php if (!$component->isHidden): ?>
-                    <?= $this->makePartial('component', ['component' => $component]) ?>
+                    <?= $this->makePartial('component', ['component' => $component, 'index' => $index]) ?>
                 <?php endif ?>
             <?php endforeach ?>
         </div>


### PR DESCRIPTION
Fixes #683

It appears that either the browsers, or perhaps the framework, are not picking up component field names with the "append" array syntax in the field name (ie. `component_properties[]`, `component_aliases[]`). The result of this is that it is discarding the properties of earlier components in the component list and only saving the last component when saving a CMS partial.

This PR adds explicit indexes to the field names to ensure that the data is correctly sent across as indexed values, similar to the repeater or data table widget.

I've also included a slight tweak to the alias validation to check for duplicate alias *before* writing the alias to the component, thereby ensuring all aliases are unique.