### PR TITLE
Fix column preview on Import

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -17,7 +17,6 @@ use ApplicationException;
 use SplTempFileObject;
 use Exception;
 
-
 /**
  * Adds features for importing and exporting data.
  *
@@ -255,11 +254,7 @@ class ImportExportController extends ControllerBehavior
             $reader->setHeaderOffset(1);
         }
 
-        $result = (new CsvStatement())
-            ￼            ->limit(50)
-            ￼            ->process($reader)
-            ￼            ->fetchColumn((int) $columnId);
-        ￼
+        $result = (new CsvStatement())->limit(50)->process($reader)->fetchColumn((int) $columnId);
         $data = iterator_to_array($result, false);
 
         /*

--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -12,9 +12,11 @@ use Illuminate\Database\Eloquent\MassAssignmentException;
 use League\Csv\Reader as CsvReader;
 use League\Csv\Writer as CsvWriter;
 use League\Csv\EscapeFormula as CsvEscapeFormula;
+use League\Csv\Statement as CsvStatement;
 use ApplicationException;
 use SplTempFileObject;
 use Exception;
+
 
 /**
  * Adds features for importing and exporting data.
@@ -250,10 +252,14 @@ class ImportExportController extends ControllerBehavior
         $reader = $this->createCsvReader($path);
 
         if (post('first_row_titles')) {
-            $reader->setOffset(1);
+            $reader->setHeaderOffset(1);
         }
 
-        $result = $reader->setLimit(50)->fetchColumn((int) $columnId);
+        $result = (new CsvStatement())
+            ￼            ->limit(50)
+            ￼            ->process($reader)
+            ￼            ->fetchColumn((int) $columnId);
+        ￼
         $data = iterator_to_array($result, false);
 
         /*


### PR DESCRIPTION
Fixes the following error when previewing a column on Import:

```php
"Call to undefined method League\Csv\Reader::setOffset()"
on line 253 of modules/backend/behaviors/ImportExportController.php
```
Credit to @alxy
ref. https://github.com/octobercms/october/pull/5629