### PR TITLE
Add anchor attributes for menu items

### DIFF
--- a/modules/backend/layouts/_sidenav.php
+++ b/modules/backend/layouts/_sidenav.php
@@ -22,7 +22,7 @@
                             >
                                 <a
                                     href="<?= $item->url ?>"
-                                    <?= Html::attributes($item->anchorAttributes) ?>
+                                    <?= isset($item->anchorAttributes) ? Html::attributes($item->anchorAttributes) : '' ?>
                                 >
                                     <span class="nav-icon">
                                         <?php if ($item->iconSvg): ?>

--- a/modules/backend/layouts/_sidenav.php
+++ b/modules/backend/layouts/_sidenav.php
@@ -20,7 +20,10 @@
                                 class="<?= BackendMenu::isSideMenuItemActive($item) ? 'active' : null ?>"
                                 <?= Html::attributes($item->attributes) ?>
                             >
-                                <a href="<?= $item->url ?>">
+                                <a
+                                    href="<?= $item->url ?>"
+                                    <?= Html::attributes($item->anchorAttributes) ?>
+                                >
                                     <span class="nav-icon">
                                         <?php if ($item->iconSvg): ?>
                                             <img class="svg-icon" src="<?= Url::asset($item->iconSvg) ?>">


### PR DESCRIPTION
Allows for attributes to be added to the actual anchor of the navigation. This will allow for things like `target` to be set.

There will be another PR for the docs linked below