### PR TITLE
Fix inspector depends functionality.

### DIFF
--- a/modules/system/assets/ui/js/inspector.editor.dropdown.js
+++ b/modules/system/assets/ui/js/inspector.editor.dropdown.js
@@ -313,6 +313,11 @@
             $form = $(this.getSelect()).closest('form'),
             dependents = this.inspector.findDependentProperties(this.propertyDefinition.property)
 
+        if (this.inspector.options.parentContainer) {
+            // get parent container data values instead (ref. objectlist editor)
+            data = this.inspector.options.parentContainer.getValues()
+        }
+
         if (currentValue === undefined) {
             currentValue = this.propertyDefinition.default
         }
@@ -382,7 +387,7 @@
 
         for (var i = 0, len = this.propertyDefinition.depends.length; i < len; i++) {
             var property = this.propertyDefinition.depends[i],
-                value = this.inspector.getPropertyValue(property)
+                value = this.getRootSurface().getPropertyValue(property)
 
             if (value === undefined) {
                 value = '';

--- a/modules/system/assets/ui/js/inspector.editor.objectlist.js
+++ b/modules/system/assets/ui/js/inspector.editor.objectlist.js
@@ -302,7 +302,7 @@
                 enableExternalParameterEditor: false,
                 onChange: this.proxy(this.onInspectorDataChange),
                 inspectorClass: this.inspector.options.inspectorClass,
-                parentContainer: this.inspector.getRootSurface(),
+                parentContainer: this.getRootSurface(),
             }
 
         this.currentRowInspector = new $.wn.inspector.surface(inspectorContainer, properties, values,

--- a/modules/system/assets/ui/js/inspector.editor.objectlist.js
+++ b/modules/system/assets/ui/js/inspector.editor.objectlist.js
@@ -301,11 +301,12 @@
             options = {
                 enableExternalParameterEditor: false,
                 onChange: this.proxy(this.onInspectorDataChange),
-                inspectorClass: this.inspector.options.inspectorClass
+                inspectorClass: this.inspector.options.inspectorClass,
+                parentContainer: this.inspector.getRootSurface(),
             }
 
         this.currentRowInspector = new $.wn.inspector.surface(inspectorContainer, properties, values,
-            $.wn.inspector.helpers.generateElementUniqueId(inspectorContainer), options)
+            $.wn.inspector.helpers.generateElementUniqueId(inspectorContainer), options, null, null, this.propertyDefinition.property)
     }
 
     ObjectListEditor.prototype.disposeInspector = function() {

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -3680,7 +3680,7 @@ this.createPlaceholder(select)
 this.createOptions(select,this.propertyDefinition.options)
 if(value===undefined){value=this.propertyDefinition.default}select.value=value}
 DropdownEditor.prototype.loadDynamicOptions=function(initialization){var currentValue=this.inspector.getPropertyValue(this.propertyDefinition.property),data=this.getRootSurface().getValues(),self=this,$form=$(this.getSelect()).closest('form'),dependents=this.inspector.findDependentProperties(this.propertyDefinition.property)
-if(currentValue===undefined){currentValue=this.propertyDefinition.default}var callback=function dropdownOptionsRequestDoneClosure(data){self.hideLoadingIndicator()
+if(this.inspector.options.parentContainer){data=this.inspector.options.parentContainer.getValues()}if(currentValue===undefined){currentValue=this.propertyDefinition.default}var callback=function dropdownOptionsRequestDoneClosure(data){self.hideLoadingIndicator()
 self.optionsRequestDone(data,currentValue,true)
 if(dependents.length>0){for(var i in dependents){var editor=self.inspector.findPropertyEditor(dependents[i])
 if(editor&&typeof editor.onInspectorPropertyChanged==='function'){editor.onInspectorPropertyChanged(self.propertyDefinition.property)}}}}
@@ -3694,7 +3694,7 @@ $inspectable.trigger(optionsEvent,[{values:values,callback:callback,property:thi
 if(optionsEvent.isDefaultPrevented()){return false}return true}
 DropdownEditor.prototype.saveDependencyValues=function(){this.prevDependencyValues=this.getDependencyValues()}
 DropdownEditor.prototype.getDependencyValues=function(){var result=''
-for(var i=0,len=this.propertyDefinition.depends.length;i<len;i++){var property=this.propertyDefinition.depends[i],value=this.inspector.getPropertyValue(property)
+for(var i=0,len=this.propertyDefinition.depends.length;i<len;i++){var property=this.propertyDefinition.depends[i],value=this.getRootSurface().getPropertyValue(property)
 if(value===undefined){value='';}result+=property+':'+value+'-'}return result}
 DropdownEditor.prototype.showLoadingIndicator=function(){if(!Modernizr.touchevents){this.indicatorContainer.loadIndicator()}}
 DropdownEditor.prototype.hideLoadingIndicator=function(){if(this.isDisposed()){return}if(!Modernizr.touchevents){this.indicatorContainer.loadIndicator('hide')
@@ -3983,8 +3983,8 @@ $.wn.foundation.element.removeClass(selectedRow,'active')}this.disposeInspector(
 $.wn.foundation.element.addClass(row,'active')
 this.createInspectorForRow(row,inspectorContainer)}
 ObjectListEditor.prototype.createInspectorForRow=function(row,inspectorContainer){var dataStr=row.getAttribute('data-inspector-values')
-if(dataStr===undefined||typeof dataStr!=='string'){throw new Error('Values not found for the selected row.')}var properties=this.propertyDefinition.itemProperties,values=JSON.parse(dataStr),options={enableExternalParameterEditor:false,onChange:this.proxy(this.onInspectorDataChange),inspectorClass:this.inspector.options.inspectorClass}
-this.currentRowInspector=new $.wn.inspector.surface(inspectorContainer,properties,values,$.wn.inspector.helpers.generateElementUniqueId(inspectorContainer),options)}
+if(dataStr===undefined||typeof dataStr!=='string'){throw new Error('Values not found for the selected row.')}var properties=this.propertyDefinition.itemProperties,values=JSON.parse(dataStr),options={enableExternalParameterEditor:false,onChange:this.proxy(this.onInspectorDataChange),inspectorClass:this.inspector.options.inspectorClass,parentContainer:this.getRootSurface(),}
+this.currentRowInspector=new $.wn.inspector.surface(inspectorContainer,properties,values,$.wn.inspector.helpers.generateElementUniqueId(inspectorContainer),options,null,null,this.propertyDefinition.property)}
 ObjectListEditor.prototype.disposeInspector=function(){$.wn.foundation.controlUtils.disposeControls(this.popup.querySelector('[data-inspector-container]'))
 this.currentRowInspector=null}
 ObjectListEditor.prototype.applyDataToRow=function(row){if(this.currentRowInspector===null){return}var data=this.currentRowInspector.getValues()


### PR DESCRIPTION
This PR corrects the following problems:

`object` inspector type: properties using `depends` do not refresh.

`objectList` inspector type: `itemProperties` using `depends` do not work.
