### PR TITLE
Add "Send password reset email" button to backend users update page

### DIFF
--- a/modules/backend/controllers/Users.php
+++ b/modules/backend/controllers/Users.php
@@ -242,8 +242,6 @@ class Users extends Controller
     {
         $user = $this->formFindModelObject($recordId);
 
-        //@todo::Force Trusted Host verification
-
         if ($user) {
             $code = $user->getResetPasswordCode();
             $link = Backend::url('backend/auth/reset/' . $user->id . '/' . $code);

--- a/modules/backend/controllers/Users.php
+++ b/modules/backend/controllers/Users.php
@@ -1,5 +1,6 @@
 <?php namespace Backend\Controllers;
 
+use Mail;
 use Lang;
 use Flash;
 use Backend;
@@ -232,5 +233,33 @@ class Users extends Controller
                 ]
             ]
         ];
+    }
+
+    /**
+     * Send password reset mail
+     */
+    public function update_onManualPasswordReset($recordId)
+    {
+        $user = $this->formFindModelObject($recordId);
+
+        //@todo::Force Trusted Host verification
+
+        if ($user) {
+            $code = $user->getResetPasswordCode();
+            $link = Backend::url('backend/auth/reset/' . $user->id . '/' . $code);
+
+            $data = [
+                'name' => $user->full_name,
+                'link' => $link,
+            ];
+
+            Mail::send('backend::mail.restore', $data, function ($message) use ($user) {
+                $message->to($user->email, $user->full_name)->subject(trans('backend::lang.account.password_reset'));
+            });
+        }
+
+        Flash::success(Lang::get('backend::lang.account.manual_password_reset_success'));
+
+        return Redirect::refresh();
     }
 }

--- a/modules/backend/controllers/users/_btn_password_reset.php
+++ b/modules/backend/controllers/users/_btn_password_reset.php
@@ -2,7 +2,7 @@
     <button
         type="button"
         data-request="onManualPasswordReset"
-        data-load-indicator="<?= e(trans('backend::lang.account.working')) ?>"
+        data-load-indicator="<?= e(trans('backend::lang.account.sending')) ?>"
         data-request-confirm="<?= e(trans('backend::lang.account.manual_password_reset_confirm')) ?>"
         class="btn btn-warning wn-icon-key"
         style="width: 100%; text-align: center"

--- a/modules/backend/controllers/users/_btn_password_reset.php
+++ b/modules/backend/controllers/users/_btn_password_reset.php
@@ -1,0 +1,12 @@
+<div class="loading-indicator-container">
+    <button
+        type="button"
+        data-request="onManualPasswordReset"
+        data-load-indicator="<?= e(trans('backend::lang.account.working')) ?>"
+        data-request-confirm="<?= e(trans('backend::lang.account.manual_password_reset_confirm')) ?>"
+        class="btn btn-warning wn-icon-key"
+        style="width: 100%; text-align: center"
+    >
+        <?= e(trans('backend::lang.account.password_reset_email')) ?>
+    </button>
+</div>

--- a/modules/backend/controllers/users/_btn_password_reset.php
+++ b/modules/backend/controllers/users/_btn_password_reset.php
@@ -2,9 +2,9 @@
     <button
         type="button"
         data-request="onManualPasswordReset"
-        data-load-indicator="<?= e(trans('backend::lang.account.working')) ?>"
+        data-load-indicator="<?= e(trans('backend::lang.account.sending')) ?>"
         data-request-confirm="<?= e(trans('backend::lang.account.manual_password_reset_confirm')) ?>"
-        class="btn btn-warning wn-icon-key"
+        class="btn btn-primary wn-icon-envelope"
         style="width: 100%; text-align: center"
     >
         <?= e(trans('backend::lang.account.password_reset_email')) ?>

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -75,10 +75,10 @@ return [
         'cancel' => 'Cancel',
         'delete' => 'Delete',
         'ok' => 'OK',
-        'working' => 'Working...',
+        'sending' => 'Sending...',
         'password_reset_email' => 'Send password reset email',
-        'manual_password_reset_confirm' => 'Are you sure you want to send password reset mail for this user?',
-        'manual_password_reset_success' => 'An email has been sent to user with reset instructions.',
+        'manual_password_reset_confirm' => 'Are you sure you want to send a password reset email to this user?',
+        'manual_password_reset_success' => 'An email has been sent to the user with instructions to reset their password.',
     ],
     'dashboard' => [
         'menu_label' => 'Dashboard',

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -75,6 +75,10 @@ return [
         'cancel' => 'Cancel',
         'delete' => 'Delete',
         'ok' => 'OK',
+        'working' => 'Working...',
+        'password_reset_email' => 'Send password reset email',
+        'manual_password_reset_confirm' => 'Are you sure you want to send password reset mail for this user?',
+        'manual_password_reset_success' => 'An email has been sent to user with reset instructions.',
     ],
     'dashboard' => [
         'menu_label' => 'Dashboard',

--- a/modules/backend/models/user/fields.yaml
+++ b/modules/backend/models/user/fields.yaml
@@ -68,11 +68,15 @@ tabs:
 secondaryTabs:
     fields:
         btn_impersonate:
-            label: ''
+            label: ""
             context: [update]
             type: partial
         btn_unsuspend:
-            label: ''
+            label: ""
+            context: [update]
+            type: partial
+        btn_password_reset:
+            label: ""
             context: [update]
             type: partial
         avatar:


### PR DESCRIPTION
Fix for issue #654 

Added "Send password reset email" button to backend users update page.

@LukeTowers I have re-used the existing Password reset logic present in `modules/backend/controllers/Auth.php` file. Should I create a helper function to remove code duplication ?