### PR TITLE
[FIX] Resolve pathing issues when running mix via php

### DIFF
--- a/modules/system/console/MixCompile.php
+++ b/modules/system/console/MixCompile.php
@@ -207,10 +207,9 @@ class MixCompile extends Command
         $command = $this->argument('webpackArgs') ?? [];
         array_unshift(
             $command,
-            'npx',
-            'webpack',
+            $basePath . sprintf('%1$snode_modules%1$s.bin%1$swebpack', DIRECTORY_SEPARATOR),
             'build',
-            '--progress',
+            $this->option('silent') ? '--stats=none' : '--progress',
             '--config=' . $this->getWebpackJsPath($mixJsPath)
         );
         return $command;


### PR DESCRIPTION
While running the `MixCompileTest` this error was being thrown for all tests:
```txt
ERROR in /tests/fixtures/plugins/mix/testa/assets/dist/app
Module not found: Error: Can't resolve '/var/www/vhosts/winter.com/modules/system/assets/src/app.js' in '/var/www/vhosts/winter.com/modules/system'
```
After debugging, the issue appeared to be:
```js
mix.js('assets/src/app.js', 'assets/dist/app.js');
```
resolving to: `/var/www/vhosts/winter.com/modules/system/assets/src/app.js`

Inside the mix object, the `publicPath` as being correctly set:
```json
"publicPath": "/var/www/vhosts/winter.com/modules/system/tests/fixtures/plugins/mix/testa",
```
However, when mix created `File` objects, the absolute path of the file was being passed to `path.resolve()` which uses `process.cwd()`, this should be set by the `$cwd` arg passed to `Process` however because process was calling `npx` instead of the webpack bin directly, the cwd was being overwritten. This lead to:

```json
{
    "js": {
      "passive": false,
      "requiresReload": false,
      "caller": "js",
      "toCompile": [
        {
          "entry": [
            {
              "absolutePath": "/var/www/vhosts/winter.com/modules/system/assets/src/app.js",
              "filePath": "assets/src/app.js",
              "segments": {
                "path": "assets/src/app.js",
                "absolutePath": "/var/www/vhosts/winter.com/modules/system/assets/src/app.js",
                "pathWithoutExt": "/var/www/vhosts/winter.com/modules/system/assets/src/app",
                "isDir": false,
                "isFile": true,
                "name": "app",
                "ext": ".js",
                "file": "app.js",
                "base": "/var/www/vhosts/winter.com/modules/system/assets/src"
              }
            }
          ],
          "output": {
            "absolutePath": "/var/www/vhosts/winter.com/modules/system/assets/dist/app.js",
            "filePath": "assets/dist/app.js",
            "segments": {
              "path": "assets/dist/app.js",
              "absolutePath": "/var/www/vhosts/winter.com/modules/system/assets/dist/app.js",
              "pathWithoutExt": "/var/www/vhosts/winter.com/modules/system/assets/dist/app",
              "isDir": false,
              "isFile": true,
              "name": "app",
              "ext": ".js",
              "file": "app.js",
              "base": "/var/www/vhosts/winter.com/modules/system/assets/dist"
            }
          }
        }
      ],
      "activated": true
    },
}
```
This PR reverts the change using npx back to calling webpack's bin directly.

Linux host test:
![image](https://user-images.githubusercontent.com/31214002/194577345-b84843ba-91e3-4849-a0ea-20ccda090feb.png)

Windows host test:
![image](https://user-images.githubusercontent.com/31214002/194577484-139f726f-e2ac-486f-b07f-22afb7005d94.png)
