### PR TITLE
Add migrate to list of protected commands

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -136,7 +136,7 @@ class ServiceProvider extends ModuleServiceProvider
     protected function registerPrivilegedActions()
     {
         $requests = ['/combine/', '@/system/updates', '@/system/install', '@/backend/auth'];
-        $commands = ['winter:up', 'winter:update', 'winter:env', 'winter:version', 'winter:manifest'];
+        $commands = ['migrate', 'winter:up', 'winter:update', 'winter:env', 'winter:version', 'winter:manifest'];
 
         /*
          * Requests


### PR DESCRIPTION
Prevents issues with unelevated plugins that expect the database to exist always.