### PR TITLE
Set pivot data when initially syncing the relationship

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1392,14 +1392,15 @@ class RelationController extends ControllerBehavior
              * Add the checked IDs to the pivot table
              */
             $foreignIds = (array) $this->foreignId;
-            $this->relationObject->sync($foreignIds, false);
+            $saveData = $this->pivotWidget->getSaveData();
+            $foreignModels = $this->relationModel->whereIn($this->relationModel->getKeyName(), $foreignIds)->get();
+            $this->relationObject->syncWithPivotValues($foreignModels, $saveData['pivot'] ?? []);
 
             /*
              * Save data to models
              */
             $foreignKeyName = $this->relationModel->getQualifiedKeyName();
             $hydratedModels = $this->relationObject->whereIn($foreignKeyName, $foreignIds)->get();
-            $saveData = $this->pivotWidget->getSaveData();
 
             foreach ($hydratedModels as $hydratedModel) {
                 $modelsToSave = $this->prepareModelsToSave($hydratedModel, $saveData);


### PR DESCRIPTION
Also performs the sync with model instances rather than just raw IDs to support relationships with a custom relatedKey set (the key on the related model's table that is stored on the pivot table to connect the relationship, normally just the primary key but can be anything).