### PR TITLE
Show checkboxlist options when in preview / disabled

### DIFF
--- a/modules/backend/widgets/form/partials/_field_checkboxlist.php
+++ b/modules/backend/widgets/form/partials/_field_checkboxlist.php
@@ -41,7 +41,7 @@ $quickselectEnabled = $field->getConfig('quickselect', $isScrollable);
         <?php endforeach ?>
     </div>
 
-<?php elseif (!$readOnly && count($fieldOptions)): ?>
+<?php elseif (count($fieldOptions)): ?>
 
     <div class="field-checkboxlist <?= $isScrollable ? 'is-scrollable' : '' ?>">
         <?php if ($quickselectEnabled): ?>
@@ -89,6 +89,7 @@ $quickselectEnabled = $field->getConfig('quickselect', $isScrollable);
                         id="<?= $checkboxId ?>"
                         name="<?= $field->getName() ?>[]"
                         value="<?= e($value) ?>"
+                        <?= $readOnly ? 'disabled="disabled"' : '' ?>
                         <?= in_array($value, $checkedValues) ? 'checked="checked"' : '' ?>>
 
                     <label for="<?= $checkboxId ?>">


### PR DESCRIPTION
Previously, the condition `elseif (!$readOnly && count($fieldOptions))` would prevent valid options being rendered when the `$readOnly` var is `true` (`$readOnly = $this->previewMode || $field->readOnly || $field->disabled;`).

This seems to be incorrect, the correct approach should be to show all options but mark them all as disabled.

This changes:

![image](https://user-images.githubusercontent.com/31214002/199976933-8630936c-b25b-4cc4-a971-53f28f3f8636.png)

To:

![image](https://user-images.githubusercontent.com/31214002/199977010-1c662811-abb1-4cd9-b423-c9a8eded8fc5.png)
