### PR TITLE
Pass element's maxlength to slugify and toCamel to respect field definition

### DIFF
--- a/modules/system/assets/ui/js/input.preset.js
+++ b/modules/system/assets/ui/js/input.preset.js
@@ -35,12 +35,12 @@
         'U', 'Ứ': 'U', 'Ừ': 'U', 'Ử': 'U', 'Ữ': 'U', 'Ự': 'U', 'Ý': 'Y', 'Ỳ': 'Y',
         'Ỷ': 'Y', 'Ỹ': 'Y', 'Ỵ': 'Y', 'á': 'a', 'à': 'a', 'ã': 'a', 'ả': 'a', 'ạ':
         'a', 'ắ': 'a', 'ằ': 'a', 'ẵ': 'a', 'ẳ': 'a', 'ặ': 'a', 'ấ': 'a', 'ầ': 'a',
-        'ẫ': 'a', 'ẩ': 'a', 'ậ': 'a', 'đ': 'd', 'é': 'e', 'è': 'e', 'ẽ': 'e', 'ẻ': 
-        'e', 'ẹ': 'e', 'ế': 'e', 'ề': 'e', 'ễ': 'e', 'ể': 'e', 'ệ': 'e', 'ó': 'o', 
-        'ò': 'o', 'ỏ': 'o', 'õ': 'o', 'ọ': 'o', 'ố': 'o', 'ồ': 'o', 'ổ': 'o', 'ỗ': 
-        'o', 'ộ': 'o', 'ơ': 'o', 'ớ': 'o', 'ờ': 'o', 'ở': 'o', 'ỡ': 'o', 'ợ': 'o', 
-        'í': 'i', 'ì': 'i', 'ỉ': 'i', 'ĩ': 'i', 'ị': 'i', 'ú': 'u', 'ù': 'u', 'ủ': 
-        'u', 'ũ': 'u', 'ụ': 'u', 'ư': 'u', 'ứ': 'u', 'ừ': 'u', 'ử': 'u', 'ữ': 'u', 
+        'ẫ': 'a', 'ẩ': 'a', 'ậ': 'a', 'đ': 'd', 'é': 'e', 'è': 'e', 'ẽ': 'e', 'ẻ':
+        'e', 'ẹ': 'e', 'ế': 'e', 'ề': 'e', 'ễ': 'e', 'ể': 'e', 'ệ': 'e', 'ó': 'o',
+        'ò': 'o', 'ỏ': 'o', 'õ': 'o', 'ọ': 'o', 'ố': 'o', 'ồ': 'o', 'ổ': 'o', 'ỗ':
+        'o', 'ộ': 'o', 'ơ': 'o', 'ớ': 'o', 'ờ': 'o', 'ở': 'o', 'ỡ': 'o', 'ợ': 'o',
+        'í': 'i', 'ì': 'i', 'ỉ': 'i', 'ĩ': 'i', 'ị': 'i', 'ú': 'u', 'ù': 'u', 'ủ':
+        'u', 'ũ': 'u', 'ụ': 'u', 'ư': 'u', 'ứ': 'u', 'ừ': 'u', 'ử': 'u', 'ữ': 'u',
         'ự': 'u', 'ý': 'y', 'ỳ': 'y', 'ỷ': 'y', 'ỹ': 'y', 'ỵ': 'y'
     },
     LATIN_MAP = {
@@ -195,7 +195,7 @@
         }
     }
 
-    
+
 
     var InputPreset = function (element, options) {
         var $el = this.$el = $(element)
@@ -222,26 +222,26 @@
 
         this.$src = $(options.inputPreset, parent)
 
-        this.$src.on('input paste', function(event) { 
-            if (self.cancelled) 
-                return 
- 
-            var timeout = event.type === 'paste' ? 100 : 0 
-            var updateValue = function(self, el, prefix) { 
+        this.$src.on('input paste', function(event) {
+            if (self.cancelled)
+                return
+
+            var timeout = event.type === 'paste' ? 100 : 0
+            var updateValue = function(self, el, prefix) {
                 if (el.data('update') === false) {
                     return
                 }
-                el   
-                    .val(prefix + self.formatValue()) 
-                    .trigger('oc.inputPreset.afterUpdate') 
-            } 
- 
-            var src = $(this) 
-            setTimeout(function() { 
-                $el.trigger('oc.inputPreset.beforeUpdate', [src]) 
-                setTimeout(updateValue, 100, self, $el, prefix) 
-            }, timeout) 
-        }) 
+                el
+                    .val(prefix + self.formatValue())
+                    .trigger('oc.inputPreset.afterUpdate')
+            }
+
+            var src = $(this)
+            setTimeout(function() {
+                $el.trigger('oc.inputPreset.beforeUpdate', [src])
+                setTimeout(updateValue, 100, self, $el, prefix)
+            }, timeout)
+        })
 
         this.$el.on('change', function() {
             self.cancelled = true
@@ -263,10 +263,10 @@
         }
 
         if (this.options.inputPresetType == 'camel') {
-            var value = this.toCamel(this.$src.val())
+            var value = this.toCamel(this.$src.val(), this.$el.attr('maxlength'))
         }
         else {
-            var value = this.slugify(this.$src.val())
+            var value = this.slugify(this.$src.val(), this.$el.attr('maxlength'))
         }
 
         if (this.options.inputPresetType == 'url') {

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -2562,7 +2562,7 @@ setTimeout(updateValue,100,self,$el,prefix)},timeout)})
 this.$el.on('change',function(){self.cancelled=true})}
 InputPreset.prototype.formatNamespace=function(){var value=this.toCamel(this.$src.val())
 return value.substr(0,1).toUpperCase()+value.substr(1)}
-InputPreset.prototype.formatValue=function(){if(this.options.inputPresetType=='exact'){return this.$src.val();}else if(this.options.inputPresetType=='namespace'){return this.formatNamespace()}if(this.options.inputPresetType=='camel'){var value=this.toCamel(this.$src.val())}else{var value=this.slugify(this.$src.val())}if(this.options.inputPresetType=='url'){value='/'+value}return value.replace(/\s/gi,"-")}
+InputPreset.prototype.formatValue=function(){if(this.options.inputPresetType=='exact'){return this.$src.val();}else if(this.options.inputPresetType=='namespace'){return this.formatNamespace()}if(this.options.inputPresetType=='camel'){var value=this.toCamel(this.$src.val(),this.$el.attr('maxlength'))}else{var value=this.slugify(this.$src.val(),this.$el.attr('maxlength'))}if(this.options.inputPresetType=='url'){value='/'+value}return value.replace(/\s/gi,"-")}
 InputPreset.prototype.toCamel=function(slug,numChars){Downcoder.Initialize()
 slug=slug.replace(Downcoder.regex,function(m){return Downcoder.map[m]})
 slug=this.removeStopWords(slug);slug=slug.toLowerCase()


### PR DESCRIPTION
When using a preset of slug or camel on form elements, if the target element has a maxlength attribute defined it was not being passed along to the JS, despite the method actually allowing a second parameter for length.

This PR resolved that. See below screenshot of a field `code` with a `maxlength` of 13 characters an preset of `slug`.
![image](https://user-images.githubusercontent.com/9019306/200896589-e34fe78b-2592-4973-8330-4de8255dcbdb.png)

As shown, the source element is 17 characters long but the target element respects the max length.

Also my IDE did some linting on the whitespace in the file.