### PR TITLE
Prevent fancy layout styling from spilling over into nested forms

### DIFF
--- a/modules/backend/assets/css/winter.css
+++ b/modules/backend/assets/css/winter.css
@@ -1082,16 +1082,16 @@ body.breadcrumb-fancy .control-breadcrumb li:last-child:before,
 .fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .form-buttons .btn[class*=" oc-icon-"]:before,
 .fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .form-buttons .btn[class*=" oc-icon-"]:before{opacity:1}
 .fancy-layout form[class$="-data-changed"] *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .btn.save{opacity:1;filter:alpha(opacity=100)}
-.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-codeeditor{border:none !important;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
-.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-codeeditor .editor-code{-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
-.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-richeditor{border:none;border-left:1px solid #d1d6d9 !important}
-.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-richeditor,
-.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-richeditor .fr-toolbar,
-.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-richeditor .fr-wrapper{-webkit-border-radius:0;-moz-border-radius:0;border-radius:0;border-top-right-radius:0;border-top-left-radius:0}
-.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-content-tabs .field-richeditor .fr-toolbar{background:white}
-body.side-panel-not-fixed .fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-richeditor,
-body.side-panel-not-fixed.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-richeditor{border-left:none}
-html.cssanimations .fancy-layout .form-tabless-fields .loading-indicator-container .loading-indicator>span{-webkit-animation:spin 1s linear infinite;animation:spin 1s linear infinite;background-image:url('../../../system/assets/ui/images/loader-white.svg');background-size:20px 20px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs>.tab-content>.tab-pane>.form-group>.field-codeeditor{border:none !important;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs>.tab-content>.tab-pane>.form-group>.field-codeeditor .editor-code{-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs>.tab-content>.tab-pane>.form-group>.field-richeditor{border:none;border-left:1px solid #d1d6d9 !important}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs>.tab-content>.tab-pane>.form-group>.field-richeditor,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs>.tab-content>.tab-pane>.form-group>.field-richeditor .fr-toolbar,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs>.tab-content>.tab-pane>.form-group>.field-richeditor .fr-wrapper{-webkit-border-radius:0;-moz-border-radius:0;border-radius:0;border-top-right-radius:0;border-top-left-radius:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-content-tabs>.tab-content>.tab-pane>.form-group>.field-richeditor .fr-toolbar{background:white}
+body.side-panel-not-fixed .fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs>.tab-content>.tab-pane>.form-group>.field-richeditor,
+body.side-panel-not-fixed.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs>.tab-content>.tab-pane>.form-group>.field-richeditor{border-left:none}
+html.cssanimations .fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .loading-indicator-container .loading-indicator>span{-webkit-animation:spin 1s linear infinite;animation:spin 1s linear infinite;background-image:url('../../../system/assets/ui/images/loader-white.svg');background-size:20px 20px}
 .flyout-container>.flyout{overflow:hidden;width:0;left:0 !important;-webkit-transition:width 0.1s;transition:width 0.1s}
 .flyout-overlay{width:100%;height:100%;top:0;z-index:5000;position:absolute;background-color:rgba(0,0,0,0);-webkit-transition:background-color 0.3s;transition:background-color 0.3s}
 .flyout-toggle{position:absolute;top:20px;left:0;width:23px;height:25px;background:#2b3e50;cursor:pointer;border-bottom-right-radius:4px;border-top-right-radius:4px;color:#bdc3c7;font-size:10px}

--- a/modules/backend/assets/css/winter.css
+++ b/modules/backend/assets/css/winter.css
@@ -874,6 +874,181 @@ body.outer .layout>.layout-row>.layout-cell .outer-form-container .forgot-passwo
 html.csstransitions body.outer .outer-form-container{-webkit-transition:all 0.5s ease-out;transition:all 0.5s ease-out;-webkit-transform:scale(1,1);-moz-transform:scale(1,1);-ms-transform:scale(1,1);-o-transform:scale(1,1);transform:scale(1,1)}
 html.csstransitions body.outer.preload .outer-form-container{-webkit-transform:scale(0.2,0.2);-moz-transform:scale(0.2,0.2);-ms-transform:scale(0.2,0.2);-o-transform:scale(0.2,0.2);transform:scale(0.2,0.2)}
 @media (max-width:768px){body.outer .layout>.layout-row.layout-head>.layout-cell{padding:50px 20px}body.outer .layout>.layout-row>.layout-cell .outer-form-container{width:auto;padding:40px}body.outer .layout>.layout-row>.layout-cell .outer-form-container .horizontal-form{display:block}body.outer .layout>.layout-row>.layout-cell .outer-form-container .horizontal-form input{display:block;width:100% !important;margin-bottom:20px}}
+body.fancy-layout .master-tabs.control-tabs,
+.master-tabs.control-tabs.fancy-layout{overflow:hidden}
+body.fancy-layout .master-tabs.control-tabs:before,
+.master-tabs.control-tabs.fancy-layout:before,
+body.fancy-layout .master-tabs.control-tabs:after,
+.master-tabs.control-tabs.fancy-layout:after{top:13px;font-size:14px;color:rgba(255,255,255,0.35)}
+body.fancy-layout .master-tabs.control-tabs:before,
+.master-tabs.control-tabs.fancy-layout:before{left:8px}
+body.fancy-layout .master-tabs.control-tabs:after,
+.master-tabs.control-tabs.fancy-layout:after{right:8px}
+body.fancy-layout .master-tabs.control-tabs.scroll-before:before,
+.master-tabs.control-tabs.fancy-layout.scroll-before:before{color:#fff}
+body.fancy-layout .master-tabs.control-tabs.scroll-after:after,
+.master-tabs.control-tabs.fancy-layout.scroll-after:after{color:#fff}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container{background:#d35400;padding-left:20px;padding-right:20px}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs{margin-left:-8px}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li{margin-left:-5px;top:1px;padding-top:3px}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li span.tab-close,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li span.tab-close{top:14px;right:-3px;left:auto;z-index:110;font-family:sans-serif}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li span.tab-close i,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li span.tab-close i{top:4px;right:1px;color:rgba(255,255,255,0.3) !important;font-style:normal;font-weight:bold;font-size:16px}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li span.tab-close i:hover,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li span.tab-close i:hover{color:#fff !important}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li a,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li a{border-bottom:none;background:transparent;font-size:14px;color:rgba(255,255,255,0.35);padding:6px 0 0 24px!important;overflow:visible}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li a>span.title{position:relative;display:inline-block;padding:12px 5px 0 5px;height:38px;font-size:14px;z-index:100;background-color:#b9530f}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title:before,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li a>span.title:before,
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title:after,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li a>span.title:after{content:' ';position:absolute;width:20px;display:block;height:37px;top:0;z-index:100;background-color:#b9530f}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title:before,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li a>span.title:before{left:-14px;-webkit-border-radius:8px 0 0 0;-moz-border-radius:8px 0 0 0;border-radius:8px 0 0 0;-webkit-transform:skewX(-20deg);-ms-transform:skewX(-20deg);transform:skewX(-20deg)}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title:after,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li a>span.title:after{right:-14px;-webkit-border-radius:0 8px 0 0;-moz-border-radius:0 8px 0 0;border-radius:0 8px 0 0;-webkit-transform:skewX(20deg);-ms-transform:skewX(20deg);transform:skewX(20deg)}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title span,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li a>span.title span{border-top:none;padding:0;margin-top:0;overflow:visible}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li a:before,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li a:before{z-index:110;position:absolute;top:18px;left:22px}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li a[class*=icon]>span.title,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li a[class*=icon]>span.title{padding-left:18px}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li.active a,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li.active a{z-index:107;color:#fff}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li.active span.tab-close i,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li.active span.tab-close i{color:#fff}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li.active a>span.title,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li.active a>span.title{background-color:#e67e22;z-index:105}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li.active a>span.title:before,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li.active a>span.title:before{z-index:107;background-color:#e67e22}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li.active a>span.title:after,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li.active a>span.title:after{background-color:#e67e22;z-index:107}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li[data-modified] span.tab-close i,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li[data-modified] span.tab-close i{top:5px;font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li[data-modified] span.tab-close i:before,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li[data-modified] span.tab-close i:before{font-family:"Font Awesome 6 Free";font-weight:900;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;font-style:normal;font-variant:normal;text-rendering:auto;content:"\f111";font-size:9px}
+body.fancy-layout .master-tabs.control-tabs>div>div.tabs-container>ul.nav-tabs>li:first-child,
+.master-tabs.control-tabs.fancy-layout>div>div.tabs-container>ul.nav-tabs>li:first-child{margin-left:0}
+body.fancy-layout .master-tabs.control-tabs[data-closable]>div>div.tabs-container>ul.nav-tabs>li a>span.title,
+.master-tabs.control-tabs.fancy-layout[data-closable]>div>div.tabs-container>ul.nav-tabs>li a>span.title{padding-right:10px}
+body.fancy-layout .master-tabs.control-tabs.has-tabs:before,
+.master-tabs.control-tabs.fancy-layout.has-tabs:before,
+body.fancy-layout .master-tabs.control-tabs.has-tabs:after,
+.master-tabs.control-tabs.fancy-layout.has-tabs:after{display:block}
+body.fancy-layout .master-tabs.control-tabs.has-tabs>div.tab-content,
+.master-tabs.control-tabs.fancy-layout.has-tabs>div.tab-content{background:#f9f9f9}
+body.fancy-layout .master-tabs.control-tabs>.tab-content>.tab-pane,
+.master-tabs.control-tabs.fancy-layout>.tab-content>.tab-pane{padding:0}
+body.fancy-layout .master-tabs.control-tabs>.tab-content>.tab-pane.padded-pane,
+.master-tabs.control-tabs.fancy-layout>.tab-content>.tab-pane.padded-pane{padding:20px 20px 0 20px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs.master-area>div>ul.nav-tabs,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs.master-area>div>ul.nav-tabs{-webkit-transition:background-color 0.5s;transition:background-color 0.5s;background:#e67e22}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs{background:#7f8c8d;margin-left:0 !important;margin-right:0 !important}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs:before,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs:before{display:none}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li{background:transparent;border-right:none;margin-right:-8px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li:first-child,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li:first-child{margin-left:-5px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li a,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li a{background:transparent;border:none;padding:12px 16px 0;font-size:14px;font-weight:400;color:#95a5a6}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li a span.title{background:#d5d9d8;border-top:none;padding:5px 5px 3px 5px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title:before,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li a span.title:before,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title:after,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li a span.title:after{background:#d5d9d8;border-width:0;top:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title:before,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li a span.title:before{left:-20px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title:after,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li a span.title:after{right:-20px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title span,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li a span.title span{border-width:0;vertical-align:top}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li.active a,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li.active a{color:#808c8d}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li.active a:before,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li.active a:before{display:none}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li.active a span.title,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li.active a span.title{background:#fafafa}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li.active a span.title:before,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li.active a span.title:before,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>div>ul.nav-tabs>li.active a span.title:after,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>div>ul.nav-tabs>li.active a span.title:after{background:#fafafa}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>.tab-content>.tab-pane,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>.tab-content>.tab-pane{padding:20px 20px 0 20px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs>.tab-content>.tab-pane.pane-compact,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs>.tab-content>.tab-pane.pane-compact{padding:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs.collapsed,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs.collapsed{display:none}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.primary-tabs.has-tabs>div.tab-content,
+*:not(.nested-form)>.form-widget>.layout-row>.control-tabs.fancy-layout.primary-tabs.has-tabs>div.tab-content{background:#f9f9f9}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs:before{left:5px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs:after{right:5px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs>div>ul.nav-tabs{background:#475354}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs>div>ul.nav-tabs>li{border-right:none;padding-right:0;margin-right:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs>div>ul.nav-tabs>li a{background:transparent;border:none;padding:12px 10px 13px 10px;font-size:14px;font-weight:normal;line-height:14px;color:#919898}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs>div>ul.nav-tabs>li a span span{overflow:visible;border-top:none;margin-top:0;padding-top:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs>div>ul.nav-tabs>li:first-child{padding-left:15px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs>div>ul.nav-tabs>li.active a{color:#fff}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs .tab-collapse-icon{position:absolute;display:block;text-decoration:none;outline:none;opacity:0.6;filter:alpha(opacity=60);-webkit-transition:all 0.3s;transition:all 0.3s;font-size:12px;color:#fff;right:11px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs .tab-collapse-icon:hover{text-decoration:none;opacity:1;filter:alpha(opacity=100)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs .tab-collapse-icon.primary{color:#fff;top:12px;right:11px;bottom:auto;z-index:100;-webkit-transform:scale(1,-1);-moz-transform:scale(1,-1);-ms-transform:scale(1,-1);-o-transform:scale(1,-1);transform:scale(1,-1)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs .tab-collapse-icon.primary i{position:relative;display:block}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.primary-collapsed .tab-collapse-icon.primary{-webkit-transform:scale(1,1);-moz-transform:scale(1,1);-ms-transform:scale(1,1);-o-transform:scale(1,1);transform:scale(1,1)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs{background:#f9f9f9}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li{margin-left:-19px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li:first-child{margin-left:0;padding-left:8px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a{padding:8px 16px 0 16px;font-weight:400;height:36px;color:#2b3e50;opacity:0.6;filter:alpha(opacity=60)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title{position:relative;display:inline-block;padding:8px 5px 9px 5px;font-size:14px;z-index:100;height:27px !important;background-color:transparent}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title:before,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title:after{content:' ';position:absolute;background-color:white;width:15px;height:28px;top:0;z-index:100;display:none}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title:before{left:-11px;-webkit-border-radius:8px 0 0 0;-moz-border-radius:8px 0 0 0;border-radius:8px 0 0 0;-webkit-transform:skewX(-20deg);-ms-transform:skewX(-20deg);transform:skewX(-20deg)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title:after{right:-11px;-webkit-border-radius:0 8px 0 0;-moz-border-radius:0 8px 0 0;border-radius:0 8px 0 0;-webkit-transform:skewX(20deg);-ms-transform:skewX(20deg);transform:skewX(20deg)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title span{height:18px;font-size:14px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li.active a{opacity:1;filter:alpha(opacity=100)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li.active a>span.title{background-color:white}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li.active a>span.title:before,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li.active a>span.title:after{display:block}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs .tab-collapse-icon.primary{color:#808c8d}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed .tab-collapse-icon.primary{color:white}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs{background:#e67e22}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs>li a{color:white}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs>li a>span.title:before,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs>li a>span.title:after{background-color:white}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs>li.active a{color:#2b3e50}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs.has-tabs>div.tab-content{background:#f9f9f9}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs>.tab-content>.tab-pane{padding:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-tabs>.tab-content>.tab-pane.padded-pane{padding:20px 20px 0 20px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields{position:relative;background:#e67e22;padding:18px 23px 0 23px;-webkit-transition:all 0.5s;transition:all 0.5s}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields:before,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields:after{content:" ";display:table}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields:after{clear:both}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields label{text-transform:uppercase;color:rgba(255,255,255,0.5);margin-bottom:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields input[type=text]{background:transparent;border:none;color:#fff;font-size:35px;font-weight:100;height:auto;padding:0;-webkit-box-shadow:none;box-shadow:none}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields input[type=text]::-moz-placeholder{color:rgba(255,255,255,0.5);opacity:1}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields input[type=text]:-ms-input-placeholder{color:rgba(255,255,255,0.5)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields input[type=text]::-webkit-input-placeholder{color:rgba(255,255,255,0.5)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields input[type=text]:focus,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields input[type=text]:hover{background-color:rgba(255,255,255,0.1)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .form-group{padding-bottom:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .form-group.is-required>label:after{display:none}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .tab-collapse-icon{position:absolute;display:block;text-decoration:none;outline:none;opacity:0.6;filter:alpha(opacity=60);-webkit-transition:all 0.3s;transition:all 0.3s;font-size:12px;color:#fff;right:11px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .tab-collapse-icon:hover{text-decoration:none;opacity:1;filter:alpha(opacity=100)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .tab-collapse-icon.primary{color:#fff;top:12px;right:11px;bottom:auto;z-index:100;-webkit-transform:scale(1,-1);-moz-transform:scale(1,-1);-ms-transform:scale(1,-1);-o-transform:scale(1,-1);transform:scale(1,-1)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .tab-collapse-icon.primary i{position:relative;display:block}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .tab-collapse-icon.tabless{top:14px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields.collapsed{padding:5px 23px 0 10px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields.collapsed .tab-collapse-icon.tabless{-webkit-transform:scale(1,-1);-moz-transform:scale(1,-1);-ms-transform:scale(1,-1);-o-transform:scale(1,-1);transform:scale(1,-1)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields.collapsed .form-group:not(.collapse-visible){display:none}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields.collapsed .form-buttons{margin-left:10px;padding-bottom:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .loading-indicator-container .loading-indicator{background-color:#e67e22;padding:0 0 0 30px;color:rgba(255,255,255,0.5);margin-top:1px;height:90%;font-size:12px;line-height:100%}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .loading-indicator-container .loading-indicator>span{left:-10px;top:18px}
 body.breadcrumb-fancy .control-breadcrumb,
 .control-breadcrumb.breadcrumb-fancy{margin-bottom:0;background-color:#e67e22}
 body.breadcrumb-fancy .control-breadcrumb li,
@@ -890,236 +1065,33 @@ body.breadcrumb-fancy .control-breadcrumb li:last-child,
 .control-breadcrumb.breadcrumb-fancy li:last-child{background-color:#d35400}
 body.breadcrumb-fancy .control-breadcrumb li:last-child:before,
 .control-breadcrumb.breadcrumb-fancy li:last-child:before{opacity:1;border-left-color:#d35400}
-.fancy-layout .tab-collapse-icon{position:absolute;display:block;text-decoration:none;outline:none;opacity:0.6;filter:alpha(opacity=60);-webkit-transition:all 0.3s;transition:all 0.3s;font-size:12px;color:#fff;right:11px}
-.fancy-layout .tab-collapse-icon:hover{text-decoration:none;opacity:1;filter:alpha(opacity=100)}
-.fancy-layout .tab-collapse-icon.primary{color:#475354;bottom:-25px;z-index:100;-webkit-transform:scale(1,-1);-moz-transform:scale(1,-1);-ms-transform:scale(1,-1);-o-transform:scale(1,-1);transform:scale(1,-1)}
-.fancy-layout .tab-collapse-icon.primary i{position:relative;display:block}
-.fancy-layout .control-tabs.master-tabs,
-.fancy-layout.control-tabs.master-tabs{overflow:hidden}
-.fancy-layout .control-tabs.master-tabs:before,
-.fancy-layout.control-tabs.master-tabs:before,
-.fancy-layout .control-tabs.master-tabs:after,
-.fancy-layout.control-tabs.master-tabs:after{top:13px;font-size:14px;color:rgba(255,255,255,0.35)}
-.fancy-layout .control-tabs.master-tabs:before,
-.fancy-layout.control-tabs.master-tabs:before{left:8px}
-.fancy-layout .control-tabs.master-tabs:after,
-.fancy-layout.control-tabs.master-tabs:after{right:8px}
-.fancy-layout .control-tabs.master-tabs.scroll-before:before,
-.fancy-layout.control-tabs.master-tabs.scroll-before:before{color:#fff}
-.fancy-layout .control-tabs.master-tabs.scroll-after:after,
-.fancy-layout.control-tabs.master-tabs.scroll-after:after{color:#fff}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container{background:#d35400;padding-left:20px;padding-right:20px}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs{margin-left:-8px}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li{margin-left:-5px;top:1px;padding-top:3px}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li span.tab-close,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li span.tab-close{top:14px;right:-3px;left:auto;z-index:110;font-family:sans-serif}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li span.tab-close i,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li span.tab-close i{top:4px;right:1px;color:rgba(255,255,255,0.3) !important;font-style:normal;font-weight:bold;font-size:16px}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li span.tab-close i:hover,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li span.tab-close i:hover{color:#fff !important}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a{border-bottom:none;background:transparent;font-size:14px;color:rgba(255,255,255,0.35);padding:6px 0 0 24px!important;overflow:visible}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title{position:relative;display:inline-block;padding:12px 5px 0 5px;height:38px;font-size:14px;z-index:100;background-color:#b9530f}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title:before,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title:before,
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title:after,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title:after{content:' ';position:absolute;width:20px;display:block;height:37px;top:0;z-index:100;background-color:#b9530f}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title:before,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title:before{left:-14px;-webkit-border-radius:8px 0 0 0;-moz-border-radius:8px 0 0 0;border-radius:8px 0 0 0;-webkit-transform:skewX(-20deg);-ms-transform:skewX(-20deg);transform:skewX(-20deg)}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title:after,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title:after{right:-14px;-webkit-border-radius:0 8px 0 0;-moz-border-radius:0 8px 0 0;border-radius:0 8px 0 0;-webkit-transform:skewX(20deg);-ms-transform:skewX(20deg);transform:skewX(20deg)}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title span,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a>span.title span{border-top:none;padding:0;margin-top:0;overflow:visible}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a:before,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a:before{z-index:110;position:absolute;top:18px;left:22px}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a[class*=icon]>span.title,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li a[class*=icon]>span.title{padding-left:18px}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li.active a,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li.active a{z-index:107;color:#fff}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li.active span.tab-close i,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li.active span.tab-close i{color:#fff}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li.active a>span.title,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li.active a>span.title{background-color:#e67e22;z-index:105}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li.active a>span.title:before,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li.active a>span.title:before{z-index:107;background-color:#e67e22}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li.active a>span.title:after,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li.active a>span.title:after{background-color:#e67e22;z-index:107}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li[data-modified] span.tab-close i,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li[data-modified] span.tab-close i{top:5px;font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li[data-modified] span.tab-close i:before,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li[data-modified] span.tab-close i:before{font-family:"Font Awesome 6 Free";font-weight:900;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;font-style:normal;font-variant:normal;text-rendering:auto;content:"\f111";font-size:9px}
-.fancy-layout .control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li:first-child,
-.fancy-layout.control-tabs.master-tabs>div>div.tabs-container>ul.nav-tabs>li:first-child{margin-left:0}
-.fancy-layout .control-tabs.master-tabs[data-closable]>div>div.tabs-container>ul.nav-tabs>li a>span.title,
-.fancy-layout.control-tabs.master-tabs[data-closable]>div>div.tabs-container>ul.nav-tabs>li a>span.title{padding-right:10px}
-.fancy-layout .control-tabs.master-tabs.has-tabs:before,
-.fancy-layout.control-tabs.master-tabs.has-tabs:before,
-.fancy-layout .control-tabs.master-tabs.has-tabs:after,
-.fancy-layout.control-tabs.master-tabs.has-tabs:after{display:block}
-.fancy-layout .control-tabs.secondary-tabs:before,
-.fancy-layout.control-tabs.secondary-tabs:before{left:5px}
-.fancy-layout .control-tabs.secondary-tabs:after,
-.fancy-layout.control-tabs.secondary-tabs:after{right:5px}
-.fancy-layout .control-tabs.secondary-tabs>div>ul.nav-tabs,
-.fancy-layout.control-tabs.secondary-tabs>div>ul.nav-tabs{background:#475354}
-.fancy-layout .control-tabs.secondary-tabs>div>ul.nav-tabs>li,
-.fancy-layout.control-tabs.secondary-tabs>div>ul.nav-tabs>li{border-right:none;padding-right:0;margin-right:0}
-.fancy-layout .control-tabs.secondary-tabs>div>ul.nav-tabs>li a,
-.fancy-layout.control-tabs.secondary-tabs>div>ul.nav-tabs>li a{background:transparent;border:none;padding:12px 10px 13px 10px;font-size:14px;font-weight:normal;line-height:14px;color:#919898}
-.fancy-layout .control-tabs.secondary-tabs>div>ul.nav-tabs>li a span span,
-.fancy-layout.control-tabs.secondary-tabs>div>ul.nav-tabs>li a span span{overflow:visible;border-top:none;margin-top:0;padding-top:0}
-.fancy-layout .control-tabs.secondary-tabs>div>ul.nav-tabs>li:first-child,
-.fancy-layout.control-tabs.secondary-tabs>div>ul.nav-tabs>li:first-child{padding-left:15px}
-.fancy-layout .control-tabs.secondary-tabs>div>ul.nav-tabs>li.active a,
-.fancy-layout.control-tabs.secondary-tabs>div>ul.nav-tabs>li.active a{color:#fff}
-.fancy-layout .control-tabs.secondary-tabs .tab-collapse-icon,
-.fancy-layout.control-tabs.secondary-tabs .tab-collapse-icon{position:absolute;display:block;text-decoration:none;outline:none;opacity:0.6;filter:alpha(opacity=60);-webkit-transition:all 0.3s;transition:all 0.3s;font-size:12px;color:#fff;right:11px}
-.fancy-layout .control-tabs.secondary-tabs .tab-collapse-icon:hover,
-.fancy-layout.control-tabs.secondary-tabs .tab-collapse-icon:hover{text-decoration:none;opacity:1;filter:alpha(opacity=100)}
-.fancy-layout .control-tabs.secondary-tabs .tab-collapse-icon.primary,
-.fancy-layout.control-tabs.secondary-tabs .tab-collapse-icon.primary{color:#475354;bottom:-25px;z-index:100;-webkit-transform:scale(1,-1);-moz-transform:scale(1,-1);-ms-transform:scale(1,-1);-o-transform:scale(1,-1);transform:scale(1,-1)}
-.fancy-layout .control-tabs.secondary-tabs .tab-collapse-icon.primary i,
-.fancy-layout.control-tabs.secondary-tabs .tab-collapse-icon.primary i{position:relative;display:block}
-.fancy-layout .control-tabs.secondary-tabs .tab-collapse-icon.primary,
-.fancy-layout.control-tabs.secondary-tabs .tab-collapse-icon.primary{color:#fff;top:12px;right:11px;bottom:auto}
-.fancy-layout .control-tabs.secondary-tabs.primary-collapsed .tab-collapse-icon.primary,
-.fancy-layout.control-tabs.secondary-tabs.primary-collapsed .tab-collapse-icon.primary{-webkit-transform:scale(1,1);-moz-transform:scale(1,1);-ms-transform:scale(1,1);-o-transform:scale(1,1);transform:scale(1,1)}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs{background:#f9f9f9}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li{margin-left:-19px}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li:first-child,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li:first-child{margin-left:0;padding-left:8px}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a{padding:8px 16px 0 16px;font-weight:400;height:36px;color:#2b3e50;opacity:0.6;filter:alpha(opacity=60)}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title{position:relative;display:inline-block;padding:8px 5px 9px 5px;font-size:14px;z-index:100;height:27px !important;background-color:transparent}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title:before,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title:before,
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title:after,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title:after{content:' ';position:absolute;background-color:white;width:15px;height:28px;top:0;z-index:100;display:none}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title:before,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title:before{left:-11px;-webkit-border-radius:8px 0 0 0;-moz-border-radius:8px 0 0 0;border-radius:8px 0 0 0;-webkit-transform:skewX(-20deg);-ms-transform:skewX(-20deg);transform:skewX(-20deg)}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title:after,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title:after{right:-11px;-webkit-border-radius:0 8px 0 0;-moz-border-radius:0 8px 0 0;border-radius:0 8px 0 0;-webkit-transform:skewX(20deg);-ms-transform:skewX(20deg);transform:skewX(20deg)}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title span,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li a>span.title span{height:18px;font-size:14px}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li.active a,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li.active a{opacity:1;filter:alpha(opacity=100)}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li.active a>span.title,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li.active a>span.title{background-color:white}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li.active a>span.title:before,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li.active a>span.title:before,
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li.active a>span.title:after,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs>div>ul.nav-tabs>li.active a>span.title:after{display:block}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs .tab-collapse-icon.primary,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs .tab-collapse-icon.primary{color:#808c8d}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed .tab-collapse-icon.primary,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed .tab-collapse-icon.primary{color:white}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs{background:#e67e22}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs>li a,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs>li a{color:white}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs>li a>span.title:before,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs>li a>span.title:before,
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs>li a>span.title:after,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs>li a>span.title:after{background-color:white}
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs>li.active a,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed>div>ul.nav-tabs>li.active a{color:#2b3e50}
-.fancy-layout .control-tabs.primary-tabs.master-area>div>ul.nav-tabs,
-.fancy-layout.control-tabs.primary-tabs.master-area>div>ul.nav-tabs{-webkit-transition:background-color 0.5s;transition:background-color 0.5s;background:#e67e22}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs{background:#7f8c8d;margin-left:0 !important;margin-right:0 !important}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs:before,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs:before{display:none}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li{background:transparent;border-right:none;margin-right:-8px}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li:first-child,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li:first-child{margin-left:-5px}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li a,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li a{background:transparent;border:none;padding:12px 16px 0;font-size:14px;font-weight:400;color:#95a5a6}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title{background:#d5d9d8;border-top:none;padding:5px 5px 3px 5px}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title:before,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title:before,
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title:after,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title:after{background:#d5d9d8;border-width:0;top:0}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title:before,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title:before{left:-20px}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title:after,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title:after{right:-20px}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title span,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li a span.title span{border-width:0;vertical-align:top}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li.active a,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li.active a{color:#808c8d}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li.active a:before,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li.active a:before{display:none}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li.active a span.title,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li.active a span.title{background:#fafafa}
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li.active a span.title:before,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li.active a span.title:before,
-.fancy-layout .control-tabs.primary-tabs>div>ul.nav-tabs>li.active a span.title:after,
-.fancy-layout.control-tabs.primary-tabs>div>ul.nav-tabs>li.active a span.title:after{background:#fafafa}
-.fancy-layout .control-tabs.primary-tabs>.tab-content>.tab-pane,
-.fancy-layout.control-tabs.primary-tabs>.tab-content>.tab-pane{padding:20px 20px 0 20px}
-.fancy-layout .control-tabs.primary-tabs>.tab-content>.tab-pane.pane-compact,
-.fancy-layout.control-tabs.primary-tabs>.tab-content>.tab-pane.pane-compact{padding:0}
-.fancy-layout .control-tabs.primary-tabs.collapsed,
-.fancy-layout.control-tabs.primary-tabs.collapsed{display:none}
-.fancy-layout .control-tabs.has-tabs>div.tab-content,
-.fancy-layout.control-tabs.has-tabs>div.tab-content{background:#f9f9f9}
-.fancy-layout .control-tabs>div.tab-content>div.tab-pane,
-.fancy-layout.control-tabs>div.tab-content>div.tab-pane{padding:0}
-.fancy-layout .control-tabs>div.tab-content>div.tab-pane.padded-pane,
-.fancy-layout.control-tabs>div.tab-content>div.tab-pane.padded-pane{padding:20px 20px 0 20px}
-.fancy-layout .form-tabless-fields{position:relative;background:#e67e22;padding:18px 23px 0 23px;-webkit-transition:all 0.5s;transition:all 0.5s}
-.fancy-layout .form-tabless-fields:before,
-.fancy-layout .form-tabless-fields:after{content:" ";display:table}
-.fancy-layout .form-tabless-fields:after{clear:both}
-.fancy-layout .form-tabless-fields label{text-transform:uppercase;color:rgba(255,255,255,0.5);margin-bottom:0}
-.fancy-layout .form-tabless-fields input[type=text]{background:transparent;border:none;color:#fff;font-size:35px;font-weight:100;height:auto;padding:0;-webkit-box-shadow:none;box-shadow:none}
-.fancy-layout .form-tabless-fields input[type=text]::-moz-placeholder{color:rgba(255,255,255,0.5);opacity:1}
-.fancy-layout .form-tabless-fields input[type=text]:-ms-input-placeholder{color:rgba(255,255,255,0.5)}
-.fancy-layout .form-tabless-fields input[type=text]::-webkit-input-placeholder{color:rgba(255,255,255,0.5)}
-.fancy-layout .form-tabless-fields input[type=text]:focus,
-.fancy-layout .form-tabless-fields input[type=text]:hover{background-color:rgba(255,255,255,0.1)}
-.fancy-layout .form-tabless-fields .form-group{padding-bottom:0}
-.fancy-layout .form-tabless-fields .form-group.is-required>label:after{display:none}
-.fancy-layout .form-tabless-fields .tab-collapse-icon{position:absolute;display:block;text-decoration:none;outline:none;opacity:0.6;filter:alpha(opacity=60);-webkit-transition:all 0.3s;transition:all 0.3s;font-size:12px;color:#fff;right:11px}
-.fancy-layout .form-tabless-fields .tab-collapse-icon:hover{text-decoration:none;opacity:1;filter:alpha(opacity=100)}
-.fancy-layout .form-tabless-fields .tab-collapse-icon.primary{color:#475354;bottom:-25px;z-index:100;-webkit-transform:scale(1,-1);-moz-transform:scale(1,-1);-ms-transform:scale(1,-1);-o-transform:scale(1,-1);transform:scale(1,-1)}
-.fancy-layout .form-tabless-fields .tab-collapse-icon.primary i{position:relative;display:block}
-.fancy-layout .form-tabless-fields .tab-collapse-icon.tabless{top:14px}
-.fancy-layout .form-tabless-fields.collapsed{padding:5px 23px 0 10px}
-.fancy-layout .form-tabless-fields.collapsed .tab-collapse-icon.tabless{-webkit-transform:scale(1,-1);-moz-transform:scale(1,-1);-ms-transform:scale(1,-1);-o-transform:scale(1,-1);transform:scale(1,-1)}
-.fancy-layout .form-tabless-fields.collapsed .form-group:not(.collapse-visible){display:none}
-.fancy-layout .form-tabless-fields.collapsed .form-buttons{margin-left:10px;padding-bottom:0}
-.fancy-layout .form-tabless-fields .loading-indicator-container .loading-indicator{background-color:#e67e22;padding:0 0 0 30px;color:rgba(255,255,255,0.5);margin-top:1px;height:90%;font-size:12px;line-height:100%}
-.fancy-layout .form-tabless-fields .loading-indicator-container .loading-indicator>span{left:-10px;top:18px}
-.fancy-layout .form-buttons{-webkit-transition:all 0.5s;transition:all 0.5s;padding-top:14px;padding-bottom:5px}
-.fancy-layout .form-buttons .btn{padding:0;margin-right:5px;margin-top:-6px;margin-right:30px;background:transparent;color:#fff;font-weight:normal;-webkit-box-shadow:none;box-shadow:none;opacity:0.5;filter:alpha(opacity=50);-webkit-transition:all 0.3s ease;transition:all 0.3s ease}
-.fancy-layout .form-buttons .btn:hover{opacity:1;filter:alpha(opacity=100)}
-.fancy-layout .form-buttons .btn:last-child{margin-right:0}
-.fancy-layout .form-buttons .btn[class^="wn-icon-"]:before,
-.fancy-layout .form-buttons .btn[class*=" wn-icon-"]:before,
-.fancy-layout .form-buttons .btn[class^="oc-icon-"]:before,
-.fancy-layout .form-buttons .btn[class*=" oc-icon-"]:before{opacity:1}
-.fancy-layout form.oc-data-changed .btn.save,
-.fancy-layout form.wn-data-changed .btn.save{opacity:1;filter:alpha(opacity=100)}
-.fancy-layout .field-codeeditor{border:none !important;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
-.fancy-layout .field-codeeditor .editor-code{-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
-.fancy-layout .field-richeditor{border:none;border-left:1px solid #d1d6d9 !important}
-.fancy-layout .field-richeditor,
-.fancy-layout .field-richeditor .fr-toolbar,
-.fancy-layout .field-richeditor .fr-wrapper{-webkit-border-radius:0;-moz-border-radius:0;border-radius:0;border-top-right-radius:0;border-top-left-radius:0}
-.fancy-layout .secondary-content-tabs .field-richeditor .fr-toolbar{background:white}
-body.side-panel-not-fixed .fancy-layout .field-richeditor{border-left:none}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .form-buttons,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .form-buttons{-webkit-transition:all 0.5s;transition:all 0.5s;padding-top:14px;padding-bottom:5px}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .form-buttons .btn,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .form-buttons .btn{padding:0;margin-right:5px;margin-top:-6px;margin-right:30px;background:transparent;color:#fff;font-weight:normal;-webkit-box-shadow:none;box-shadow:none;opacity:0.5;filter:alpha(opacity=50);-webkit-transition:all 0.3s ease;transition:all 0.3s ease}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .form-buttons .btn:hover,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .form-buttons .btn:hover{opacity:1;filter:alpha(opacity=100)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .form-buttons .btn:last-child,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .form-buttons .btn:last-child{margin-right:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .form-buttons .btn[class^="wn-icon-"]:before,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .form-buttons .btn[class^="wn-icon-"]:before,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .form-buttons .btn[class*=" wn-icon-"]:before,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .form-buttons .btn[class*=" wn-icon-"]:before,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .form-buttons .btn[class^="oc-icon-"]:before,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .form-buttons .btn[class^="oc-icon-"]:before,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .form-buttons .btn[class*=" oc-icon-"]:before,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .form-buttons .btn[class*=" oc-icon-"]:before{opacity:1}
+.fancy-layout form[class$="-data-changed"] *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .btn.save{opacity:1;filter:alpha(opacity=100)}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-codeeditor{border:none !important;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-codeeditor .editor-code{-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-richeditor{border:none;border-left:1px solid #d1d6d9 !important}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-richeditor,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-richeditor .fr-toolbar,
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-richeditor .fr-wrapper{-webkit-border-radius:0;-moz-border-radius:0;border-radius:0;border-top-right-radius:0;border-top-left-radius:0}
+.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs.secondary-content-tabs .field-richeditor .fr-toolbar{background:white}
+body.side-panel-not-fixed .fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-richeditor,
+body.side-panel-not-fixed.fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .field-richeditor{border-left:none}
 html.cssanimations .fancy-layout .form-tabless-fields .loading-indicator-container .loading-indicator>span{-webkit-animation:spin 1s linear infinite;animation:spin 1s linear infinite;background-image:url('../../../system/assets/ui/images/loader-white.svg');background-size:20px 20px}
-html.gecko .fancy-layout .control-tabs.secondary-tabs>div>ul.nav-tabs>li.active a{padding-top:13px}
 .flyout-container>.flyout{overflow:hidden;width:0;left:0 !important;-webkit-transition:width 0.1s;transition:width 0.1s}
 .flyout-overlay{width:100%;height:100%;top:0;z-index:5000;position:absolute;background-color:rgba(0,0,0,0);-webkit-transition:background-color 0.3s;transition:background-color 0.3s}
 .flyout-toggle{position:absolute;top:20px;left:0;width:23px;height:25px;background:#2b3e50;cursor:pointer;border-bottom-right-radius:4px;border-top-right-radius:4px;color:#bdc3c7;font-size:10px}

--- a/modules/backend/assets/css/winter.css
+++ b/modules/backend/assets/css/winter.css
@@ -1050,21 +1050,21 @@ body.fancy-layout .master-tabs.control-tabs>.tab-content>.tab-pane.padded-pane,
 .fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .loading-indicator-container .loading-indicator{background-color:#e67e22;padding:0 0 0 30px;color:rgba(255,255,255,0.5);margin-top:1px;height:90%;font-size:12px;line-height:100%}
 .fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .loading-indicator-container .loading-indicator>span{left:-10px;top:18px}
 body.breadcrumb-fancy .control-breadcrumb,
-.control-breadcrumb.breadcrumb-fancy{margin-bottom:0;background-color:#e67e22}
+.control-breadcrumb.breadcrumb-fancy{margin-bottom:0;background-color:#d66908}
 body.breadcrumb-fancy .control-breadcrumb li,
-.control-breadcrumb.breadcrumb-fancy li{background-color:#d35400;color:rgba(255,255,255,0.5)}
+.control-breadcrumb.breadcrumb-fancy li{background-color:#b05606;color:rgba(255,255,255,0.5)}
 body.breadcrumb-fancy .control-breadcrumb li a,
 .control-breadcrumb.breadcrumb-fancy li a{opacity:.5;-webkit-transition:all 0.3s ease;transition:all 0.3s ease}
 body.breadcrumb-fancy .control-breadcrumb li a:hover,
 .control-breadcrumb.breadcrumb-fancy li a:hover{opacity:1}
-body.breadcrumb-fancy .control-breadcrumb li:before,
-.control-breadcrumb.breadcrumb-fancy li:before{border-left-color:#fff;opacity:.5}
+body.breadcrumb-fancy .control-breadcrumb li:not(:last-child)::before,
+.control-breadcrumb.breadcrumb-fancy li:not(:last-child)::before{border-left-color:#e67e22;opacity:.5}
 body.breadcrumb-fancy .control-breadcrumb li:after,
-.control-breadcrumb.breadcrumb-fancy li:after{border-left-color:#d35400}
+.control-breadcrumb.breadcrumb-fancy li:after{border-left-color:#b05606}
 body.breadcrumb-fancy .control-breadcrumb li:last-child,
-.control-breadcrumb.breadcrumb-fancy li:last-child{background-color:#d35400}
+.control-breadcrumb.breadcrumb-fancy li:last-child{background-color:#d66908}
 body.breadcrumb-fancy .control-breadcrumb li:last-child:before,
-.control-breadcrumb.breadcrumb-fancy li:last-child:before{opacity:1;border-left-color:#d35400}
+.control-breadcrumb.breadcrumb-fancy li:last-child:before{opacity:1;border-left-color:#d66908}
 .fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .form-buttons,
 .fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.form-tabless-fields .form-buttons{-webkit-transition:all 0.5s;transition:all 0.5s;padding-top:14px;padding-bottom:5px}
 .fancy-layout *:not(.nested-form)>.form-widget>.layout-row>.control-tabs .form-buttons .btn,

--- a/modules/backend/assets/less/layout/fancylayout.less
+++ b/modules/backend/assets/less/layout/fancylayout.less
@@ -688,7 +688,7 @@ body.breadcrumb-fancy .control-breadcrumb,
 //
 
 // Code editor
-.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs .field-codeeditor {
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs > .tab-content > .tab-pane > .form-group > .field-codeeditor {
     border: none !important;
     .border-radius(0);
 
@@ -698,7 +698,7 @@ body.breadcrumb-fancy .control-breadcrumb,
 }
 
 // Rich editor
-.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs .field-richeditor {
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs > .tab-content > .tab-pane > .form-group > .field-richeditor {
     border: none;
     border-left: 1px solid @color-form-field-border !important;
 
@@ -708,28 +708,22 @@ body.breadcrumb-fancy .control-breadcrumb,
     }
 }
 
-.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs.secondary-content-tabs .field-richeditor {
+// Rich editor in a secondary content tab
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs.secondary-content-tabs > .tab-content > .tab-pane > .form-group >  .field-richeditor {
     .fr-toolbar {
         background: white;
     }
 }
 
-
-body.side-panel-not-fixed .fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs .field-richeditor,
-body.side-panel-not-fixed.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs .field-richeditor {
+// Rich editor when the side panel is not fixed
+body.side-panel-not-fixed .fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs > .tab-content > .tab-pane > .form-group > .field-richeditor,
+body.side-panel-not-fixed.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs > .tab-content > .tab-pane > .form-group > .field-richeditor {
     border-left: none;
 }
 
-html.cssanimations {
-    .fancy-layout {
-        .form-tabless-fields {
-            .loading-indicator-container {
-                .loading-indicator > span {
-                    .animation(spin 1s linear infinite);
-                    background-image: url('../../../system/assets/ui/images/loader-white.svg');
-                    background-size: 20px 20px;
-                }
-            }
-        }
-    }
+// Loading indicator
+html.cssanimations .fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .form-tabless-fields .loading-indicator-container .loading-indicator > span {
+    .animation(spin 1s linear infinite);
+    background-image: url('../../../system/assets/ui/images/loader-white.svg');
+    background-size: 20px 20px;
 }

--- a/modules/backend/assets/less/layout/fancylayout.less
+++ b/modules/backend/assets/less/layout/fancylayout.less
@@ -1,3 +1,603 @@
+//
+// FANCY LAYOUT
+// Applies branding colours to the Backend UI.
+//
+
+//
+// --- TABS
+//
+
+// Master tabs
+body.fancy-layout .master-tabs.control-tabs,
+.master-tabs.control-tabs.fancy-layout {
+    overflow: hidden;
+
+    &:before, &:after {
+        top: 13px;
+        font-size: 14px;
+        color: @color-fancy-master-tabs-inactive-text;
+    }
+    &:before { left: 8px; }
+    &:after { right: 8px; }
+    &.scroll-before:before { color: @color-fancy-master-tabs-active-text; }
+    &.scroll-after:after { color: @color-fancy-master-tabs-active-text; }
+
+    > div > div.tabs-container {
+        background: @color-fancy-master-tabs-bg;
+        padding-left: 20px;
+        padding-right: 20px;
+
+        > ul.nav-tabs {
+            margin-left: -8px;
+            > li {
+                margin-left: -5px;
+                top: 1px;
+                padding-top: 3px;
+
+                span.tab-close {
+                    top: 14px;
+                    right: -3px;
+                    left: auto;
+                    z-index: 110;
+                    font-family: sans-serif;
+
+                    i {
+                        top: 4px;
+                        right: 1px;
+                        color: rgba(255, 255, 255, 0.3) !important;
+                        font-style: normal;
+                        font-weight: bold;
+                        font-size: 16px;
+
+                        &:hover { color: @color-fancy-master-tabs-active-text !important; }
+                    }
+                }
+
+                a {
+                    border-bottom: none;
+                    background: transparent;
+                    font-size: 14px;
+                    color: @color-fancy-master-tabs-inactive-text;
+                    padding: 6px 0 0 24px!important;
+                    overflow: visible;
+
+                    > span.title {
+                        position: relative;
+                        display: inline-block;
+                        padding: 12px 5px 0 5px;
+                        height: 38px;
+                        font-size: 14px;
+                        z-index: 100;
+                        background-color: @color-fancy-form-inactive-tab;
+
+                        &:before, &:after {
+                            content: ' ';
+                            position: absolute;
+                            width: 20px;
+                            display: block;
+                            height: 37px;
+                            top: 0;
+                            z-index: 100;
+                            background-color: @color-fancy-form-inactive-tab;
+                        }
+
+                        &:before {
+                            left: -14px;
+                            .border-radius(8px 0 0 0);
+                            .transform( ~'skewX(-20deg)');
+
+                        }
+
+                        &:after {
+                            right: -14px;
+                            .border-radius(0 8px 0 0);
+                            .transform( ~'skewX(20deg)');
+                        }
+
+                        span {
+                            border-top: none;
+                            padding: 0;
+                            margin-top: 0;
+                            overflow: visible;
+                        }
+                    }
+
+                    &:before {
+                        z-index: 110;
+                        position: absolute;
+                        top: 18px;
+                        left: 22px;
+                    }
+
+                    &[class*=icon] > span.title {
+                        padding-left: 18px;
+                    }
+                }
+
+                &.active {
+                    a {
+                        z-index: 107;
+                        color: @color-fancy-master-tabs-active-text;
+                    }
+                    span.tab-close i { color: @color-fancy-master-tabs-active-text; }
+
+                    a > span.title {
+                        background-color: @color-fancy-form-tabless-fields-bg;
+                        z-index: 105;
+                        &:before {
+                            z-index: 107;
+                            background-color: @color-fancy-form-tabless-fields-bg;
+                        }
+                        &:after {
+                            background-color: @color-fancy-form-tabless-fields-bg;
+                            z-index: 107;
+                        }
+                    }
+                }
+
+                &[data-modified] {
+                    span.tab-close i {
+                        top: 5px;
+                        .hide-text();
+
+                        &:before {
+                            .icon(@circle);
+                            font-size: 9px;
+                        }
+                    }
+                }
+
+                &:first-child {
+                    margin-left: 0;
+                }
+            }
+        }
+    }
+
+    &[data-closable] {
+        > div > div.tabs-container {
+            > ul.nav-tabs {
+                > li {
+                    a > span.title {
+                        padding-right: 10px;
+                    }
+                }
+            }
+        }
+    }
+
+    &.has-tabs {
+        &:before, &:after {display: block;}
+    }
+
+    &.has-tabs {
+        > div.tab-content {
+            background: @body-bg;
+        }
+    }
+
+    > .tab-content > .tab-pane {
+        padding: 0;
+
+        &.padded-pane {
+            padding: @padding-standard @padding-standard 0 @padding-standard;
+        }
+    }
+}
+
+// Primary Tabs
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs.primary-tabs,
+*:not(.nested-form) > .form-widget > .layout-row > .control-tabs.fancy-layout.primary-tabs {
+    &.master-area {
+        > div > ul.nav-tabs {
+            .transition(background-color 0.5s);
+            background: @color-fancy-form-tabless-fields-bg;
+        }
+    }
+
+    > div > ul.nav-tabs {
+        background: @color-fancy-primary-tabs-bg;
+        margin-left: 0!important;
+        margin-right: 0!important;
+
+        &:before {
+            display: none;
+        }
+
+        > li {
+            background: transparent;
+            border-right: none;
+            margin-right: -8px;
+
+            &:first-child {
+                margin-left: -5px;
+            }
+
+            a {
+                background: transparent;
+                border: none;
+                padding: 12px 16px 0px;
+                font-size: 14px;
+                font-weight: 400;
+                color: @color-fancy-primary-tabs-inactive-text;
+
+                span.title {
+                    background: @color-fancy-primary-tabs-inactive-bg;
+                    border-top: none;
+                    padding: 5px 5px 3px 5px;
+
+                    &:before, &:after {
+                        background: @color-fancy-primary-tabs-inactive-bg;
+                        border-width: 0;
+                        top: 0;
+                    }
+
+                    &:before {
+                        left: -20px;
+                    }
+
+                    &:after {
+                        right: -20px;
+                    }
+
+                    span {
+                        border-width: 0;
+                        vertical-align: top;
+                    }
+                }
+            }
+
+            &.active {
+                a {
+                    color: @color-fancy-primary-tabs-active-text;
+                    &:before {
+                        display: none;
+                    }
+
+                    span.title {
+                        background: @color-fancy-primary-tabs-active-bg;
+
+                        &:before, &:after {
+                            background: @color-fancy-primary-tabs-active-bg;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    > .tab-content > .tab-pane {
+        padding: @padding-standard @padding-standard 0 @padding-standard;
+
+        &.pane-compact {
+            padding: 0;
+        }
+    }
+
+    &.collapsed {
+        display: none;
+    }
+
+    &.has-tabs {
+        > div.tab-content {
+            background: @body-bg;
+        }
+    }
+}
+
+// Secondary tabs
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs.secondary-tabs {
+    // Target horizontal scroll indicators
+    &:before {
+        left: 5px;
+    }
+    &:after {
+        right: 5px;
+    }
+    > div > ul.nav-tabs {
+        background: @color-fancy-secondary-tabs-bg;
+        > li {
+            border-right: none;
+            padding-right: 0;
+            margin-right: 0;
+            a {
+                background: transparent;
+                border: none;
+                padding: 12px 10px 13px 10px;
+                font-size: 14px;
+                font-weight: normal;
+                line-height: 14px;
+                color: @color-fancy-secondary-tabs-inactive-text;
+
+                span {
+                    span {
+                        overflow: visible;
+                        border-top: none;
+                        margin-top: 0;
+                        padding-top: 0;
+                    }
+                }
+            }
+
+            &:first-child {
+                padding-left: 15px; // Will cause issues when first child is hidden
+            }
+
+            &.active {
+                a {color: @color-fancy-secondary-tabs-active-text;}
+            }
+        }
+    }
+
+    .tab-collapse-icon {
+        position: absolute;
+        display: block;
+        text-decoration: none;
+        outline: none;
+        .opacity(0.6);
+        .transition(all 0.3s);
+        font-size: 12px;
+        color: @color-fancy-master-tabs-active-text;
+        right: 11px;
+
+        &:hover {
+            text-decoration: none;
+            .opacity(1);
+        }
+
+        &.primary {
+            color: @color-fancy-master-tabs-active-text;
+            top: 12px;
+            right: 11px;
+            bottom: auto;
+            z-index: 100;
+            .scaleAxes(1, -1);
+
+            i {
+                position: relative;
+                display: block;
+            }
+        }
+    }
+
+    &.primary-collapsed {
+        .tab-collapse-icon.primary {
+            .scaleAxes(1, 1);
+        }
+    }
+
+    &.secondary-content-tabs {
+        > div > ul.nav-tabs {
+            background: @body-bg;
+
+            > li {
+                margin-left: -19px;
+
+                &:first-child {
+                    margin-left: 0;
+                    padding-left: 8px;
+                }
+
+                a {
+                    padding: 8px 16px 0 16px;
+                    font-weight: 400;
+                    height: 36px;
+                    color: #2b3e50;
+                    .opacity(0.6);
+
+                    > span.title {
+                        position: relative;
+                        display: inline-block;
+                        padding: 8px 5px 9px 5px;
+                        font-size: 14px;
+                        z-index: 100;
+                        height: 27px!important;
+                        background-color: transparent;
+
+                        &:before, &:after {
+                            content: ' ';
+                            position: absolute;
+                            background-color: white;
+                            width: 15px;
+                            height: 28px;
+                            top: 0;
+                            z-index: 100;
+                            display: none;
+                        }
+
+                        &:before {
+                            left: -11px;
+                            .border-radius(8px 0 0 0);
+                            .transform( ~'skewX(-20deg)');
+                        }
+
+                        &:after {
+                            right: -11px;
+                            .border-radius(0 8px 0 0);
+                            .transform( ~'skewX(20deg)');
+                        }
+
+                        span {
+                            height: 18px;
+                            font-size: 14px;
+                        }
+                    }
+                }
+
+                &.active a {
+                    .opacity(1);
+
+                    > span.title {
+                        background-color: white;
+                        &:before, &:after {
+                            display: block;
+                        }
+                    }
+                }
+            }
+        }
+
+        .tab-collapse-icon.primary {
+            color: #808c8d;
+        }
+
+        &.primary-collapsed {
+            .tab-collapse-icon.primary {
+                color: white;
+            }
+
+            > div > ul.nav-tabs {
+                background: @color-fancy-form-tabless-fields-bg;
+
+                > li {
+                    a {
+                        color: white;
+
+                        > span.title {
+                            &:before, &:after {
+                                background-color: white;
+                            }
+                        }
+                    }
+
+                    &.active a {
+                        color: #2b3e50;
+                    }
+                }
+            }
+        }
+    }
+
+    &.has-tabs {
+        > div.tab-content {
+            background: @body-bg;
+        }
+    }
+
+    > .tab-content > .tab-pane {
+        padding: 0;
+
+        &.padded-pane {
+            padding: @padding-standard @padding-standard 0 @padding-standard;
+        }
+    }
+}
+
+// Tabless (outside) fields
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .form-tabless-fields {
+    .clearfix();
+    position: relative;
+    background: @color-fancy-form-tabless-fields-bg;
+    padding: 18px 23px 0 23px;
+    .transition(all 0.5s);
+
+    label {
+        text-transform: uppercase;
+        color: @color-fancy-form-label;
+        margin-bottom: 0;
+    }
+
+    input[type=text] {
+        background: transparent;
+        border: none;
+        color: @color-fancy-form-text;
+        font-size: 35px;
+        font-weight: 100;
+        height: auto;
+        padding: 0;
+        .placeholder(@color-fancy-form-placeholder);
+        .box-shadow(none);
+
+        &:focus, &:hover {
+            background-color: rgba(255, 255, 255, 0.1);
+        }
+    }
+
+    .form-group {
+        padding-bottom: 0;
+
+        &.is-required {
+            > label:after {
+                display: none;
+            }
+        }
+    }
+
+    .tab-collapse-icon {
+        position: absolute;
+        display: block;
+        text-decoration: none;
+        outline: none;
+        .opacity(0.6);
+        .transition(all 0.3s);
+        font-size: 12px;
+        color: @color-fancy-master-tabs-active-text;
+        right: 11px;
+
+        &:hover {
+            text-decoration: none;
+            .opacity(1);
+        }
+
+        &.primary {
+            color: @color-fancy-master-tabs-active-text;
+            top: 12px;
+            right: 11px;
+            bottom: auto;
+            z-index: 100;
+            .scaleAxes(1, -1);
+
+            i {
+                position: relative;
+                display: block;
+            }
+        }
+
+        &.tabless {
+            top: 14px;
+        }
+    }
+
+    &.collapsed {
+        padding: 5px 23px 0 10px;
+
+        .tab-collapse-icon {
+            &.tabless {
+                .scaleAxes(1, -1);
+            }
+        }
+
+        .form-group:not(.collapse-visible) {
+            display: none;
+        }
+
+        .form-buttons {
+            margin-left: 10px;
+            padding-bottom: 0;
+        }
+    }
+
+    .loading-indicator-container {
+        .loading-indicator {
+            background-color: @color-fancy-form-tabless-fields-bg;
+            padding: 0 0 0 30px;
+            color: @color-fancy-form-label;
+            margin-top: 1px;
+            height: 90%;
+            font-size: 12px;
+            line-height: 100%;
+            > span {
+                left: -10px;
+                top: 18px;
+            }
+        }
+    }
+}
+
+//
+// --- FANCY BREADCRUMBS
+//
+
 body.breadcrumb-fancy .control-breadcrumb,
 .control-breadcrumb.breadcrumb-fancy {
     margin-bottom: 0;
@@ -37,646 +637,87 @@ body.breadcrumb-fancy .control-breadcrumb,
     }
 }
 
-.fancy-layout {
-    //
-    // Fancy form tabs
-    //
+//
+// --- FORM BUTTONS
+//
 
-    .tab-collapse-icon {
-        position: absolute;
-        display: block;
-        text-decoration: none;
-        outline: none;
-        .opacity(0.6);
-        .transition(all 0.3s);
-        font-size: 12px;
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs .form-buttons,
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .form-tabless-fields  .form-buttons {
+    .transition(all 0.5s);
+    padding-top: 14px;
+    padding-bottom: 5px;
+
+    .btn {
+        padding: 0;
+        margin-right: 5px;
+        margin-top: -6px;
+        margin-right: 30px;
+        background: transparent;
         color: @color-fancy-master-tabs-active-text;
-        right: 11px;
+        font-weight: normal;
+        .box-shadow(none);
+
+        .opacity(0.5);
+        .transition(all 0.3s ease);
 
         &:hover {
-            text-decoration: none;
             .opacity(1);
         }
 
-        &.primary {
-            color: @color-fancy-secondary-tabs-bg;
-            bottom: -25px;
-            z-index: 100;
-            .scaleAxes(1, -1);
-
-            i {
-                position: relative;
-                display: block;
-            }
-        }
-    }
-
-    .control-tabs, &.control-tabs {
-        &.master-tabs {
-            overflow: hidden;
-
-            &:before, &:after {
-                top: 13px;
-                font-size: 14px;
-                color: @color-fancy-master-tabs-inactive-text;
-            }
-            &:before { left: 8px; }
-            &:after { right: 8px; }
-            &.scroll-before:before { color: @color-fancy-master-tabs-active-text; }
-            &.scroll-after:after { color: @color-fancy-master-tabs-active-text; }
-
-            > div > div.tabs-container {
-                background: @color-fancy-master-tabs-bg;
-                padding-left: 20px;
-                padding-right: 20px;
-
-                > ul.nav-tabs {
-                    margin-left: -8px;
-                    > li {
-                        margin-left: -5px;
-                        top: 1px;
-                        padding-top: 3px;
-
-                        span.tab-close {
-                            top: 14px;
-                            right: -3px;
-                            left: auto;
-                            z-index: 110;
-                            font-family: sans-serif;
-
-                            i {
-                                top: 4px;
-                                right: 1px;
-                                color: rgba(255, 255, 255, 0.3) !important;
-                                font-style: normal;
-                                font-weight: bold;
-                                font-size: 16px;
-
-                                &:hover { color: @color-fancy-master-tabs-active-text !important; }
-                            }
-                        }
-
-                        a {
-                            border-bottom: none;
-                            background: transparent;
-                            font-size: 14px;
-                            color: @color-fancy-master-tabs-inactive-text;
-                            padding: 6px 0 0 24px!important;
-                            overflow: visible;
-
-                            > span.title {
-                                position: relative;
-                                display: inline-block;
-                                padding: 12px 5px 0 5px;
-                                height: 38px;
-                                font-size: 14px;
-                                z-index: 100;
-                                background-color: @color-fancy-form-inactive-tab;
-
-                                &:before, &:after {
-                                    content: ' ';
-                                    position: absolute;
-                                    width: 20px;
-                                    display: block;
-                                    height: 37px;
-                                    top: 0;
-                                    z-index: 100;
-                                    background-color: @color-fancy-form-inactive-tab;
-                                }
-
-                                &:before {
-                                    left: -14px;
-                                    .border-radius(8px 0 0 0);
-                                    .transform( ~'skewX(-20deg)');
-
-                                }
-
-                                &:after {
-                                    right: -14px;
-                                    .border-radius(0 8px 0 0);
-                                    .transform( ~'skewX(20deg)');
-                                }
-
-                                span {
-                                    border-top: none;
-                                    padding: 0;
-                                    margin-top: 0;
-                                    overflow: visible;
-                                }
-                            }
-
-                            &:before {
-                                z-index: 110;
-                                position: absolute;
-                                top: 18px;
-                                left: 22px;
-                            }
-
-                            &[class*=icon] > span.title {
-                                padding-left: 18px;
-                            }
-                        }
-
-                        &.active {
-                            a {
-                                z-index: 107;
-                                color: @color-fancy-master-tabs-active-text;
-                            }
-                            span.tab-close i { color: @color-fancy-master-tabs-active-text; }
-
-                            a > span.title {
-                                background-color: @color-fancy-form-tabless-fields-bg;
-                                z-index: 105;
-                                &:before {
-                                    z-index: 107;
-                                    background-color: @color-fancy-form-tabless-fields-bg;
-                                }
-                                &:after {
-                                    background-color: @color-fancy-form-tabless-fields-bg;
-                                    z-index: 107;
-                                }
-                            }
-                        }
-
-                        &[data-modified] {
-                            span.tab-close i {
-                                top: 5px;
-                                .hide-text();
-
-                                &:before {
-                                    .icon(@circle);
-                                    font-size: 9px;
-                                }
-                            }
-                        }
-
-                        &:first-child {
-                            margin-left: 0;
-                        }
-                    }
-                }
-            }
-
-            &[data-closable] {
-                > div > div.tabs-container {
-                    > ul.nav-tabs {
-                        > li {
-                            a > span.title {
-                                padding-right: 10px;
-                            }
-                        }
-                    }
-                }
-            }
-
-            &.has-tabs {
-                &:before, &:after {display: block;}
-            }
+        &:last-child {
+            margin-right: 0;
         }
 
-        &.secondary-tabs {
-            // Target horizontal scroll indicators
+        &[class^="wn-icon-"],
+        &[class*=" wn-icon-"],
+        &[class^="oc-icon-"],
+        &[class*=" oc-icon-"] {
             &:before {
-                left: 5px;
+                opacity: 1;
             }
-            &:after {
-                right: 5px;
-            }
-            > div > ul.nav-tabs {
-                background: @color-fancy-secondary-tabs-bg;
-                > li {
-                    border-right: none;
-                    padding-right: 0;
-                    margin-right: 0;
-                    a {
-                        background: transparent;
-                        border: none;
-                        padding: 12px 10px 13px 10px;
-                        font-size: 14px;
-                        font-weight: normal;
-                        line-height: 14px;
-                        color: @color-fancy-secondary-tabs-inactive-text;
-
-                        span {
-                            span {
-                                overflow: visible;
-                                border-top: none;
-                                margin-top: 0;
-                                padding-top: 0;
-                            }
-                        }
-                    }
-
-                    &:first-child {
-                        padding-left: 15px; // Will cause issues when first child is hidden
-                    }
-
-                    &.active {
-                        a {color: @color-fancy-secondary-tabs-active-text;}
-                    }
-                }
-            }
-
-            .tab-collapse-icon {
-                .tab-collapse-icon();
-
-                &.primary {
-                    color: @color-fancy-master-tabs-active-text;
-                    top: 12px;
-                    right: 11px;
-                    bottom: auto;
-                }
-            }
-
-            &.primary-collapsed {
-                .tab-collapse-icon.primary {
-                    .scaleAxes(1, 1);
-                }
-            }
-
-            &.secondary-content-tabs {
-                > div > ul.nav-tabs {
-                    background: @body-bg;
-
-                    > li {
-                        margin-left: -19px;
-
-                        &:first-child {
-                            margin-left: 0;
-                            padding-left: 8px;
-                        }
-
-                        a {
-                            padding: 8px 16px 0 16px;
-                            font-weight: 400;
-                            height: 36px;
-                            color: #2b3e50;
-                            .opacity(0.6);
-
-                            > span.title {
-                                position: relative;
-                                display: inline-block;
-                                padding: 8px 5px 9px 5px;
-                                font-size: 14px;
-                                z-index: 100;
-                                height: 27px!important;
-                                background-color: transparent;
-
-                                &:before, &:after {
-                                    content: ' ';
-                                    position: absolute;
-                                    background-color: white;
-                                    width: 15px;
-                                    height: 28px;
-                                    top: 0;
-                                    z-index: 100;
-                                    display: none;
-                                }
-
-                                &:before {
-                                    left: -11px;
-                                    .border-radius(8px 0 0 0);
-                                    .transform( ~'skewX(-20deg)');
-                                }
-
-                                &:after {
-                                    right: -11px;
-                                    .border-radius(0 8px 0 0);
-                                    .transform( ~'skewX(20deg)');
-                                }
-
-                                span {
-                                    height: 18px;
-                                    font-size: 14px;
-                                }
-                            }
-                        }
-
-                        &.active a {
-                            .opacity(1);
-
-                            > span.title {
-                                background-color: white;
-                                &:before, &:after {
-                                    display: block;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                .tab-collapse-icon.primary {
-                    color: #808c8d;
-                }
-
-                &.primary-collapsed {
-                    .tab-collapse-icon.primary {
-                        color: white;
-                    }
-
-                    > div > ul.nav-tabs {
-                        background: @color-fancy-form-tabless-fields-bg;
-
-                        > li {
-                            a {
-                                color: white;
-
-                                > span.title {
-                                    &:before, &:after {
-                                        background-color: white;
-                                    }
-                                }
-                            }
-
-                            &.active a {
-                                color: #2b3e50;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        &.primary-tabs {
-
-            &.master-area {
-                > div > ul.nav-tabs {
-                    .transition(background-color 0.5s);
-                    background: @color-fancy-form-tabless-fields-bg;
-                }
-            }
-
-            > div > ul.nav-tabs {
-                background: @color-fancy-primary-tabs-bg;
-                margin-left: 0!important;
-                margin-right: 0!important;
-
-                &:before {
-                    display: none;
-                }
-
-                > li {
-                    background: transparent;
-                    border-right: none;
-                    margin-right: -8px;
-
-                    &:first-child {
-                        margin-left: -5px;
-                    }
-
-                    a {
-                        background: transparent;
-                        border: none;
-                        padding: 12px 16px 0px;
-                        font-size: 14px;
-                        font-weight: 400;
-                        color: @color-fancy-primary-tabs-inactive-text;
-
-                        span.title {
-                            background: @color-fancy-primary-tabs-inactive-bg;
-                            border-top: none;
-                            padding: 5px 5px 3px 5px;
-
-                            &:before, &:after {
-                                background: @color-fancy-primary-tabs-inactive-bg;
-                                border-width: 0;
-                                top: 0;
-                            }
-
-                            &:before {
-                                left: -20px;
-                            }
-
-                            &:after {
-                                right: -20px;
-                            }
-
-                            span {
-                                border-width: 0;
-                                vertical-align: top;
-                            }
-                        }
-                    }
-
-                    &.active {
-                        a {
-                            color: @color-fancy-primary-tabs-active-text;
-                            &:before {
-                                display: none;
-                            }
-
-                            span.title {
-                                background: @color-fancy-primary-tabs-active-bg;
-
-                                &:before, &:after {
-                                    background: @color-fancy-primary-tabs-active-bg;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            > .tab-content > .tab-pane {
-                padding: @padding-standard @padding-standard 0 @padding-standard;
-
-                &.pane-compact {
-                    padding: 0;
-                }
-            }
-
-            &.collapsed {
-                display: none;
-            }
-        }
-
-        &.has-tabs {
-            > div.tab-content {
-                background: @body-bg;
-            }
-        }
-
-        > div.tab-content {
-            > div.tab-pane {
-                padding: 0;
-
-                &.padded-pane {
-                    padding: @padding-standard @padding-standard 0 @padding-standard;
-                }
-            }
-        }
-    }
-
-    //
-    // Forms and buttons
-    //
-
-    .form-tabless-fields {
-        .clearfix();
-        position: relative;
-        background: @color-fancy-form-tabless-fields-bg;
-        padding: 18px 23px 0 23px;
-        .transition(all 0.5s);
-
-        label {
-            text-transform: uppercase;
-            color: @color-fancy-form-label;
-            margin-bottom: 0;
-        }
-
-        input[type=text] {
-            background: transparent;
-            border: none;
-            color: @color-fancy-form-text;
-            font-size: 35px;
-            font-weight: 100;
-            height: auto;
-            padding: 0;
-            .placeholder(@color-fancy-form-placeholder);
-            .box-shadow(none);
-
-            &:focus, &:hover {
-                background-color: rgba(255, 255, 255, 0.1);
-            }
-        }
-
-        .form-group {
-            padding-bottom: 0;
-
-            &.is-required {
-                > label:after {
-                    display: none;
-                }
-            }
-        }
-
-        .tab-collapse-icon {
-            .tab-collapse-icon();
-            &.tabless {
-                top: 14px;
-            }
-        }
-
-        &.collapsed {
-            padding: 5px 23px 0 10px;
-
-            .tab-collapse-icon {
-                &.tabless {
-                    .scaleAxes(1, -1);
-                }
-            }
-
-            .form-group:not(.collapse-visible) {
-                display: none;
-            }
-
-            .form-buttons {
-                margin-left: 10px;
-                padding-bottom: 0;
-            }
-        }
-
-        .loading-indicator-container {
-            .loading-indicator {
-                background-color: @color-fancy-form-tabless-fields-bg;
-                padding: 0 0 0 30px;
-                color: @color-fancy-form-label;
-                margin-top: 1px;
-                height: 90%;
-                font-size: 12px;
-                line-height: 100%;
-                > span {
-                    left: -10px;
-                    top: 18px;
-                }
-            }
-        }
-    }
-
-    .form-buttons {
-        .transition(all 0.5s);
-        padding-top: 14px;
-        padding-bottom: 5px;
-
-        .btn {
-            padding: 0;
-            margin-right: 5px;
-            margin-top: -6px;
-            margin-right: 30px;
-            background: transparent;
-            color: @color-fancy-master-tabs-active-text;
-            font-weight: normal;
-            .box-shadow(none);
-
-            .opacity(0.5);
-            .transition(all 0.3s ease);
-
-            &:hover {
-                .opacity(1);
-            }
-
-            &:last-child {
-                margin-right: 0;
-            }
-
-            &[class^="wn-icon-"],
-            &[class*=" wn-icon-"],
-            &[class^="oc-icon-"],
-            &[class*=" oc-icon-"] {
-                &:before {
-                    opacity: 1;
-                }
-            }
-        }
-    }
-
-    form.oc-data-changed,
-    form.wn-data-changed {
-        .btn.save {
-            .opacity(1);
-        }
-    }
-
-    //
-    // Code editor
-    //
-
-    .field-codeeditor {
-        border: none !important;
-        .border-radius(0);
-
-        .editor-code {
-            .border-radius(0);
-        }
-    }
-
-    //
-    // Rich editor
-    //
-
-    .field-richeditor {
-        border: none;
-        border-left: 1px solid @color-form-field-border !important;
-
-        &, .fr-toolbar, .fr-wrapper {
-            .border-radius(0);
-            .border-top-radius(0);
-        }
-    }
-
-    .secondary-content-tabs .field-richeditor {
-        .fr-toolbar {
-            background: white;
         }
     }
 }
 
-body.side-panel-not-fixed {
-    .fancy-layout {
-        .field-richeditor {
-            border-left: none;
-        }
+.fancy-layout form[class$="-data-changed"] *:not(.nested-form) > .form-widget > .layout-row > .control-tabs .btn.save {
+    .opacity(1);
+}
+
+//
+// --- FIELDS AND WIDGETS
+//
+
+// Code editor
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs .field-codeeditor {
+    border: none !important;
+    .border-radius(0);
+
+    .editor-code {
+        .border-radius(0);
     }
+}
+
+// Rich editor
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs .field-richeditor {
+    border: none;
+    border-left: 1px solid @color-form-field-border !important;
+
+    &, .fr-toolbar, .fr-wrapper {
+        .border-radius(0);
+        .border-top-radius(0);
+    }
+}
+
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs.secondary-content-tabs .field-richeditor {
+    .fr-toolbar {
+        background: white;
+    }
+}
+
+
+body.side-panel-not-fixed .fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs .field-richeditor,
+body.side-panel-not-fixed.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs .field-richeditor {
+    border-left: none;
 }
 
 html.cssanimations {
@@ -690,11 +731,5 @@ html.cssanimations {
                 }
             }
         }
-    }
-}
-
-html.gecko {
-    .fancy-layout .control-tabs.secondary-tabs > div > ul.nav-tabs > li.active a {
-        padding-top: 13px;
     }
 }

--- a/modules/backend/assets/less/layout/fancylayout.less
+++ b/modules/backend/assets/less/layout/fancylayout.less
@@ -602,10 +602,10 @@ body.breadcrumb-fancy .control-breadcrumb,
 .control-breadcrumb.breadcrumb-fancy {
     margin-bottom: 0;
 
-    background-color: @color-fancy-form-tabless-fields-bg;
+    background-color: mix(black, saturate(@color-fancy-form-tabless-fields-bg, 20%), 16%);
 
     li {
-        background-color: @color-fancy-master-tabs-bg;
+        background-color: mix(black, saturate(@color-fancy-form-tabless-fields-bg, 20%), 31%);
         color: rgba(255,255,255, .5);
 
         a {
@@ -617,21 +617,21 @@ body.breadcrumb-fancy .control-breadcrumb,
             }
         }
 
-        &:before {
-            border-left-color: @color-fancy-form-text;
+        &:not(:last-child)::before {
+            border-left-color: @color-fancy-form-tabless-fields-bg;
             opacity: .5;
         }
 
         &:after {
-            border-left-color: @color-fancy-master-tabs-bg;
+            border-left-color: mix(black, saturate(@color-fancy-form-tabless-fields-bg, 20%), 31%);
         }
 
         &:last-child {
-            background-color: @color-fancy-master-tabs-bg;
+            background-color: mix(black, saturate(@color-fancy-form-tabless-fields-bg, 20%), 16%);
 
             &:before {
                 opacity: 1;
-                border-left-color: @color-fancy-master-tabs-bg;
+                border-left-color: mix(black, saturate(@color-fancy-form-tabless-fields-bg, 20%), 16%);
             }
         }
     }

--- a/modules/backend/models/brandsetting/custom.less
+++ b/modules/backend/models/brandsetting/custom.less
@@ -51,6 +51,10 @@
 #layout-side-panel {
     .sidepanel-content-header {
         background: @custom-dark-secondary;
+
+        &::after {
+            border-top-color: @custom-dark-secondary;
+        }
     }
 }
 
@@ -117,7 +121,7 @@ table.table.data {
 // Fancy Layout
 //
 
-.fancy-layout .form-tabless-fields {
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .form-tabless-fields {
     background: @brand-secondary;
 
     .loading-indicator-container .loading-indicator {
@@ -125,8 +129,8 @@ table.table.data {
     }
 }
 
-.fancy-layout .control-tabs.master-tabs,
-.fancy-layout.control-tabs.master-tabs {
+body.fancy-layout .master-tabs.control-tabs,
+.master-tabs.control-tabs.fancy-layout {
     > div > div.tabs-container > ul.nav-tabs > li.active a > span.title {
         &, &:before, &:after {
             background: @brand-secondary;
@@ -144,15 +148,14 @@ table.table.data {
     }
 }
 
-.fancy-layout .control-tabs.primary-tabs,
-.fancy-layout.control-tabs.primary-tabs {
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs.primary-tabs,
+*:not(.nested-form) > .form-widget > .layout-row > .control-tabs.fancy-layout.primary-tabs {
     &.master-area > div > ul.nav-tabs {
         background: @brand-secondary;
     }
 }
 
-.fancy-layout .control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed,
-.fancy-layout.control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed {
+.fancy-layout *:not(.nested-form) > .form-widget > .layout-row > .control-tabs.secondary-tabs.secondary-content-tabs.primary-collapsed {
     > div > ul.nav-tabs {
         background: @brand-secondary;
     }


### PR DESCRIPTION
Fixes https://github.com/wintercms/winter/issues/758.

The edits made to the `fancylayout.less` should more directly target just the root elements of the UI, and not spill over into nested forms.

Test case in the Test plugin: https://github.com/wintercms/wn-test-plugin/commit/eaebfae12d5d25994287008205b4c958227e2c53
Accessible in the **Pages** section.