### PR TITLE
Prevent previous relations from being unlinked

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1394,7 +1394,7 @@ class RelationController extends ControllerBehavior
             $foreignIds = (array) $this->foreignId;
             $saveData = $this->pivotWidget->getSaveData();
             $foreignModels = $this->relationModel->whereIn($this->relationModel->getKeyName(), $foreignIds)->get();
-            $this->relationObject->syncWithPivotValues($foreignModels, $saveData['pivot'] ?? []);
+            $this->relationObject->syncWithPivotValues($foreignModels, $saveData['pivot'] ?? [], false);
 
             /*
              * Save data to models


### PR DESCRIPTION
When adding a `$belongsToMany` relation with pivot date (without a custom pivot model), the previous pivot records get lost.

This fixes the issue.

The issue was introduced in e9739361bb5aac9ad85865ae6037a86b3b9946fa