### PR TITLE
Remove empty widget width option

### DIFF
--- a/modules/backend/widgets/reportcontainer/partials/_new_widget_popup.php
+++ b/modules/backend/widgets/reportcontainer/partials/_new_widget_popup.php
@@ -21,7 +21,6 @@
         <div class="form-group">
             <label><?= e(trans('backend::lang.dashboard.widget_width')) ?></label>
             <select class="form-control custom-select" name="size">
-                <option></option>
                 <?php foreach ($sizes as $size => $name):?>
                     <option value="<?= e($size) ?>" <?= $size == 12 ? 'selected' : null ?>><?= e($name) ?></option>
                 <?php endforeach ?>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9019306/203363581-7fdd459f-5e2b-4a1f-ac4d-5f69c943bf37.png)

Extra empty option at the top. The source of this line is the start of the project in 2014.

The width should never not have values as this comes from:
![image](https://user-images.githubusercontent.com/9019306/203363898-d6701914-f59e-43bf-a379-11452ae08d67.png)
