### PR TITLE
Add Mediafinder Modes

### DIFF
--- a/modules/backend/assets/js/winter-min.js
+++ b/modules/backend/assets/js/winter-min.js
@@ -146,7 +146,7 @@ MediaManagerPopup.prototype.registerHandlers=function(){this.$popupRootElement.o
 this.$popupRootElement.one('shown.oc.popup',this.proxy(this.onPopupShown))}
 MediaManagerPopup.prototype.unregisterHandlers=function(){this.$popupElement.off('popupcommand',this.proxy(this.onPopupCommand))
 this.$popupRootElement.off('popupcommand',this.proxy(this.onPopupCommand))}
-MediaManagerPopup.prototype.show=function(){var data={bottomToolbar:this.options.bottomToolbar?1:0,cropAndInsertButton:this.options.cropAndInsertButton?1:0}
+MediaManagerPopup.prototype.show=function(){var data={bottomToolbar:this.options.bottomToolbar?1:0,cropAndInsertButton:this.options.cropAndInsertButton?1:0,mode:this.options.mode||'everything',}
 this.$popupRootElement.popup({extraData:data,size:'adaptive',adaptiveHeight:true,handler:this.options.alias+'::onLoadPopup'})}
 MediaManagerPopup.prototype.hide=function(){if(this.$popupElement)this.$popupElement.trigger('close.oc.popup')}
 MediaManagerPopup.prototype.getMediaManagerElement=function(){return this.$popupElement.find('[data-control="media-manager"]')}

--- a/modules/backend/assets/js/winter-min.js
+++ b/modules/backend/assets/js/winter-min.js
@@ -146,7 +146,7 @@ MediaManagerPopup.prototype.registerHandlers=function(){this.$popupRootElement.o
 this.$popupRootElement.one('shown.oc.popup',this.proxy(this.onPopupShown))}
 MediaManagerPopup.prototype.unregisterHandlers=function(){this.$popupElement.off('popupcommand',this.proxy(this.onPopupCommand))
 this.$popupRootElement.off('popupcommand',this.proxy(this.onPopupCommand))}
-MediaManagerPopup.prototype.show=function(){var data={bottomToolbar:this.options.bottomToolbar?1:0,cropAndInsertButton:this.options.cropAndInsertButton?1:0,mode:this.options.mode||'everything',}
+MediaManagerPopup.prototype.show=function(){var data={bottomToolbar:this.options.bottomToolbar?1:0,cropAndInsertButton:this.options.cropAndInsertButton?1:0,mode:this.options.mode||'all',}
 this.$popupRootElement.popup({extraData:data,size:'adaptive',adaptiveHeight:true,handler:this.options.alias+'::onLoadPopup'})}
 MediaManagerPopup.prototype.hide=function(){if(this.$popupElement)this.$popupElement.trigger('close.oc.popup')}
 MediaManagerPopup.prototype.getMediaManagerElement=function(){return this.$popupElement.find('[data-control="media-manager"]')}

--- a/modules/backend/formwidgets/mediafinder/assets/js/mediafinder.js
+++ b/modules/backend/formwidgets/mediafinder/assets/js/mediafinder.js
@@ -42,7 +42,7 @@
         }
 
         if (this.options.mode === null) {
-            this.options.mode = this.$el.data("mediafinder-mode") || "all";
+            this.options.mode = this.$el.data('mediafinder-mode') || 'all';
         }
 
         this.$el.one('dispose-control', this.proxy(this.dispose))

--- a/modules/backend/formwidgets/mediafinder/assets/js/mediafinder.js
+++ b/modules/backend/formwidgets/mediafinder/assets/js/mediafinder.js
@@ -99,7 +99,7 @@
 
         new $.wn.mediaManager.popup({
             alias: 'ocmediamanager',
-            cropAndInsertButton: ["image", "all"].indexOf(self.options.mode) > -1,
+            cropAndInsertButton: ['image', 'all'].includes(self.options.mode),
             mode: self.options.mode,
             onInsert: function(items) {
                 if (!items.length) {

--- a/modules/backend/formwidgets/mediafinder/assets/js/mediafinder.js
+++ b/modules/backend/formwidgets/mediafinder/assets/js/mediafinder.js
@@ -41,6 +41,10 @@
             this.options.isImage = this.$el.hasClass('is-image')
         }
 
+        if (this.options.mode === null) {
+            this.options.mode = this.$el.data("mediafinder-mode") || "everything";
+        }
+
         this.$el.one('dispose-control', this.proxy(this.dispose))
 
         if (this.options.thumbnailWidth > 0) {
@@ -95,7 +99,8 @@
 
         new $.wn.mediaManager.popup({
             alias: 'ocmediamanager',
-            cropAndInsertButton: true,
+            cropAndInsertButton: ["image", "everything"].indexOf(self.options.mode) > -1,
+            mode: self.options.mode,
             onInsert: function(items) {
                 if (!items.length) {
                     alert('Please select image(s) to insert.')
@@ -136,7 +141,8 @@
     MediaFinder.DEFAULTS = {
         isMulti: null,
         isPreview: null,
-        isImage: null
+        isImage: null,
+        mode: null
     }
 
     // PLUGIN DEFINITION

--- a/modules/backend/formwidgets/mediafinder/assets/js/mediafinder.js
+++ b/modules/backend/formwidgets/mediafinder/assets/js/mediafinder.js
@@ -42,7 +42,7 @@
         }
 
         if (this.options.mode === null) {
-            this.options.mode = this.$el.data("mediafinder-mode") || "everything";
+            this.options.mode = this.$el.data("mediafinder-mode") || "all";
         }
 
         this.$el.one('dispose-control', this.proxy(this.dispose))
@@ -99,7 +99,7 @@
 
         new $.wn.mediaManager.popup({
             alias: 'ocmediamanager',
-            cropAndInsertButton: ["image", "everything"].indexOf(self.options.mode) > -1,
+            cropAndInsertButton: ["image", "all"].indexOf(self.options.mode) > -1,
             mode: self.options.mode,
             onInsert: function(items) {
                 if (!items.length) {

--- a/modules/backend/formwidgets/mediafinder/partials/_file_single.php
+++ b/modules/backend/formwidgets/mediafinder/partials/_file_single.php
@@ -11,7 +11,7 @@
         <?php endif ?>
     "
     data-control="mediafinder"
-    data-mediafinder-mode="<?= $mode ?? 'everything' ?>"
+    data-mediafinder-mode="<?= $mode ?? 'all' ?>"
     <?= $field->getAttributes() ?>
 >
 

--- a/modules/backend/formwidgets/mediafinder/partials/_file_single.php
+++ b/modules/backend/formwidgets/mediafinder/partials/_file_single.php
@@ -11,6 +11,7 @@
         <?php endif ?>
     "
     data-control="mediafinder"
+    data-mediafinder-mode="<?= $mode ?? 'everything' ?>"
     <?= $field->getAttributes() ?>
 >
 

--- a/modules/backend/formwidgets/mediafinder/partials/_image_single.php
+++ b/modules/backend/formwidgets/mediafinder/partials/_image_single.php
@@ -12,6 +12,7 @@
         <?php endif ?>
     "
     data-control="mediafinder"
+    data-mediafinder-mode="image"
     data-thumbnail-width="<?= $imageWidth ?: '0' ?>"
     data-thumbnail-height="<?= $imageHeight ?: '0' ?>"
     <?= $field->getAttributes() ?>

--- a/modules/backend/formwidgets/mediafinder/partials/_mediafinder.php
+++ b/modules/backend/formwidgets/mediafinder/partials/_mediafinder.php
@@ -5,20 +5,20 @@
 <?php else: ?>
 
     <?php
-        switch ($mode) {
-            case 'image':
-                echo $this->makePartial('image_single');
-                break;
-            case 'video':
-            case 'audio':
-            case 'document':
-                echo $this->makePartial('file_single', ['mode' => $mode]);
-                break;
-            case 'file':
-            case 'all':
-            default:
-                echo $this->makePartial('file_single', ['mode' => 'all']);
-        }
+    switch ($mode) {
+        case 'image':
+            echo $this->makePartial('image_single');
+            break;
+        case 'video':
+        case 'audio':
+        case 'document':
+            echo $this->makePartial('file_single', ['mode' => $mode]);
+            break;
+        case 'file':
+        case 'all':
+        default:
+            echo $this->makePartial('file_single', ['mode' => 'all']);
+    }
     ?>
 
 <?php endif ?>

--- a/modules/backend/formwidgets/mediafinder/partials/_mediafinder.php
+++ b/modules/backend/formwidgets/mediafinder/partials/_mediafinder.php
@@ -15,9 +15,9 @@
                 echo $this->makePartial('file_single', ['mode' => $mode]);
                 break;
             case 'file':
-            case 'everything':
+            case 'all':
             default:
-                echo $this->makePartial('file_single', ['mode' => 'everything']);
+                echo $this->makePartial('file_single', ['mode' => 'all']);
         }
     ?>
 

--- a/modules/backend/formwidgets/mediafinder/partials/_mediafinder.php
+++ b/modules/backend/formwidgets/mediafinder/partials/_mediafinder.php
@@ -4,16 +4,21 @@
 
 <?php else: ?>
 
-    <?php switch ($mode):
-
-        case 'image': ?>
-            <?= $this->makePartial('image_single') ?>
-        <?php break ?>
-
-        <?php case 'file': ?>
-            <?= $this->makePartial('file_single') ?>
-        <?php break ?>
-
-    <?php endswitch ?>
+    <?php
+        switch ($mode) {
+            case 'image':
+                echo $this->makePartial('image_single');
+                break;
+            case 'video':
+            case 'audio':
+            case 'document':
+                echo $this->makePartial('file_single', ['mode' => $mode]);
+                break;
+            case 'file':
+            case 'everything':
+            default:
+                echo $this->makePartial('file_single', ['mode' => 'everything']);
+        }
+    ?>
 
 <?php endif ?>

--- a/modules/backend/lang/be/lang.php
+++ b/modules/backend/lang/be/lang.php
@@ -478,7 +478,7 @@ return [
         'add_folder' => "Дадаць каталог",
         'search' => "Пошук",
         'display' => "Паказаць",
-        'filter_everything' => "Усё",
+        'filter_all' => "Усё",
         'filter_images' => "Выявы",
         'filter_video' => "Відэа",
         'filter_audio' => "Аўдыё",

--- a/modules/backend/lang/bg/lang.php
+++ b/modules/backend/lang/bg/lang.php
@@ -383,7 +383,7 @@ return [
         'add_folder' => 'Добави папка',
         'search' => 'Търсене',
         'display' => 'Показване',
-        'filter_everything' => 'Всичко',
+        'filter_all' => 'Всичко',
         'filter_images' => 'Изображения',
         'filter_video' => 'Видео',
         'filter_audio' => 'Аудио',

--- a/modules/backend/lang/ca/lang.php
+++ b/modules/backend/lang/ca/lang.php
@@ -537,7 +537,7 @@ return [
         'add_folder' => 'Afegir carpeta',
         'search' => 'Cercar',
         'display' => 'Mostrar',
-        'filter_everything' => 'Tot',
+        'filter_all' => 'Tot',
         'filter_images' => 'Imatges',
         'filter_video' => 'Vídeo',
         'filter_audio' => 'Àudio',

--- a/modules/backend/lang/cs/lang.php
+++ b/modules/backend/lang/cs/lang.php
@@ -504,7 +504,7 @@ return [
         'add_folder' => 'Přidat složku',
         'search' => 'Vyhledat',
         'display' => 'Zobrazit',
-        'filter_everything' => 'Vše',
+        'filter_all' => 'Vše',
         'filter_images' => 'Obrázky',
         'filter_video' => 'Video',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/da/lang.php
+++ b/modules/backend/lang/da/lang.php
@@ -489,7 +489,7 @@ return [
         'add_folder' => 'Tilføj mappe',
         'search' => 'Søg',
         'display' => 'Vis',
-        'filter_everything' => 'Alt',
+        'filter_all' => 'Alt',
         'filter_images' => 'Billeder',
         'filter_video' => 'Video',
         'filter_audio' => 'Lyd',

--- a/modules/backend/lang/de/lang.php
+++ b/modules/backend/lang/de/lang.php
@@ -596,7 +596,7 @@ return [
         'add_folder' => 'Ordner erstellen',
         'search' => 'Suchen',
         'display' => 'Anzeigen',
-        'filter_everything' => 'Alles',
+        'filter_all' => 'Alles',
         'filter_images' => 'Bilder',
         'filter_video' => 'Video',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/el/lang.php
+++ b/modules/backend/lang/el/lang.php
@@ -495,7 +495,7 @@ return [
         'add_folder' => 'Προσθήκη καταλόγου',
         'search' => 'Αναζήτηση',
         'display' => 'Εμφάνιση',
-        'filter_everything' => 'Όλα',
+        'filter_all' => 'Όλα',
         'filter_images' => 'Εικόνες',
         'filter_video' => 'Βίντεο',
         'filter_audio' => 'Ήχος',

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -600,7 +600,7 @@ return [
         'add_folder' => 'Add folder',
         'search' => 'Search',
         'display' => 'Display',
-        'filter_everything' => 'Everything',
+        'filter_all' => 'Everything',
         'filter_images' => 'Images',
         'filter_video' => 'Video',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/es/lang.php
+++ b/modules/backend/lang/es/lang.php
@@ -486,7 +486,7 @@ return [
         'add_folder' => 'Nueva carpeta',
         'search' => 'Buscar',
         'display' => 'Mostrar',
-        'filter_everything' => 'Todo',
+        'filter_all' => 'Todo',
         'filter_images' => 'Imágenes',
         'filter_video' => 'Vídeo',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/et/lang.php
+++ b/modules/backend/lang/et/lang.php
@@ -505,7 +505,7 @@ return [
         'add_folder' => 'Add folder',
         'search' => 'Search',
         'display' => 'Display',
-        'filter_everything' => 'Everything',
+        'filter_all' => 'Everything',
         'filter_images' => 'Images',
         'filter_video' => 'Video',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/fa/lang.php
+++ b/modules/backend/lang/fa/lang.php
@@ -595,7 +595,7 @@ return [
         'add_folder' => 'پوشه جدید',
         'search' => 'جستجو',
         'display' => 'نمایش',
-        'filter_everything' => 'همه',
+        'filter_all' => 'همه',
         'filter_images' => 'تصاویر',
         'filter_video' => 'ویدیو',
         'filter_audio' => 'صوتی',

--- a/modules/backend/lang/fi/lang.php
+++ b/modules/backend/lang/fi/lang.php
@@ -525,7 +525,7 @@ return [
         'add_folder' => 'Lisää kansio',
         'search' => 'Etsi',
         'display' => 'Näytä',
-        'filter_everything' => 'Kaikki',
+        'filter_all' => 'Kaikki',
         'filter_images' => 'Kuvat',
         'filter_video' => 'Videot',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/fr/lang.php
+++ b/modules/backend/lang/fr/lang.php
@@ -558,7 +558,7 @@ return [
         'add_folder' => 'Ajouter un répertoire',
         'search' => 'Rechercher',
         'display' => 'Affichage',
-        'filter_everything' => 'Tout',
+        'filter_all' => 'Tout',
         'filter_images' => 'Images',
         'filter_video' => 'Vidéo',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/hu/lang.php
+++ b/modules/backend/lang/hu/lang.php
@@ -587,7 +587,7 @@ return [
         'add_folder' => 'Könyvtár létrehozása',
         'search' => 'Keresés...',
         'display' => 'Megjelenítés',
-        'filter_everything' => 'Összes',
+        'filter_all' => 'Összes',
         'filter_images' => 'Kép',
         'filter_video' => 'Videó',
         'filter_audio' => 'Audió',

--- a/modules/backend/lang/it/lang.php
+++ b/modules/backend/lang/it/lang.php
@@ -538,7 +538,7 @@ return [
         'add_folder' => 'Aggiungi cartella',
         'search' => 'Cerca',
         'display' => 'Visualizza',
-        'filter_everything' => 'Tutto',
+        'filter_all' => 'Tutto',
         'filter_images' => 'Immagini',
         'filter_video' => 'Video',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/ja/lang.php
+++ b/modules/backend/lang/ja/lang.php
@@ -597,7 +597,7 @@ return [
         'add_folder' => 'フォルダの追加',
         'search' => '検索',
         'display' => '表示',
-        'filter_everything' => 'すべて',
+        'filter_all' => 'すべて',
         'filter_images' => '画像',
         'filter_video' => 'ビデオ',
         'filter_audio' => 'オーディオ',

--- a/modules/backend/lang/kr/lang.php
+++ b/modules/backend/lang/kr/lang.php
@@ -504,7 +504,7 @@ return [
         'add_folder' => '폴더 추가',
         'search' => '검색',
         'display' => '표시방법',
-        'filter_everything' => '전체표시',
+        'filter_all' => '전체표시',
         'filter_images' => '이미지',
         'filter_video' => '동영상',
         'filter_audio' => '소리',

--- a/modules/backend/lang/lt/lang.php
+++ b/modules/backend/lang/lt/lang.php
@@ -502,7 +502,7 @@ return [
         'add_folder' => 'Pridėti katalogą',
         'search' => 'Ieškoti',
         'display' => 'Rodyti',
-        'filter_everything' => 'Viskas',
+        'filter_all' => 'Viskas',
         'filter_images' => 'Paveiksliukai',
         'filter_video' => 'Video',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/lv/lang.php
+++ b/modules/backend/lang/lv/lang.php
@@ -596,7 +596,7 @@ return [
         'add_folder' => 'Pievienot mapi',
         'search' => 'Meklēt',
         'display' => 'Attēlot',
-        'filter_everything' => 'Visi',
+        'filter_all' => 'Visi',
         'filter_images' => 'Attēli',
         'filter_video' => 'Video',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/nb-no/lang.php
+++ b/modules/backend/lang/nb-no/lang.php
@@ -492,7 +492,7 @@ return [
         'add_folder' => 'Ny mappe',
         'search' => 'Søk',
         'display' => 'Vis',
-        'filter_everything' => 'Alle filer',
+        'filter_all' => 'Alle filer',
         'filter_images' => 'Bilder',
         'filter_video' => 'Video',
         'filter_audio' => 'Lyd',

--- a/modules/backend/lang/nl/lang.php
+++ b/modules/backend/lang/nl/lang.php
@@ -587,7 +587,7 @@ return [
         'add_folder' => 'Map toevoegen',
         'search' => 'Zoeken',
         'display' => 'Weergeven',
-        'filter_everything' => 'Alles',
+        'filter_all' => 'Alles',
         'filter_images' => 'Afbeeldingen',
         'filter_video' => 'Video\'s',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/pl/lang.php
+++ b/modules/backend/lang/pl/lang.php
@@ -568,7 +568,7 @@
         'add_folder' => 'Dodaj folder',
         'search' => 'Szukaj',
         'display' => 'Pokaż',
-        'filter_everything' => 'Wszystko',
+        'filter_all' => 'Wszystko',
         'filter_images' => 'Obrazki',
         'filter_video' => 'Filmy',
         'filter_audio' => 'Dźwięki',

--- a/modules/backend/lang/pt-br/lang.php
+++ b/modules/backend/lang/pt-br/lang.php
@@ -587,7 +587,7 @@ return [
         'add_folder' => 'Adicionar pasta',
         'search' => 'Buscar',
         'display' => 'Exibir',
-        'filter_everything' => 'Tudo',
+        'filter_all' => 'Tudo',
         'filter_images' => 'Imagens',
         'filter_video' => 'Vídeos',
         'filter_audio' => 'Áudios',

--- a/modules/backend/lang/pt-pt/lang.php
+++ b/modules/backend/lang/pt-pt/lang.php
@@ -568,7 +568,7 @@ return [
         'add_folder' => 'Adicionar pasta',
         'search' => 'Procurar',
         'display' => 'Mostrar',
-        'filter_everything' => 'Tudo',
+        'filter_all' => 'Tudo',
         'filter_images' => 'Imagens',
         'filter_video' => 'Vídeos',
         'filter_audio' => 'Áudios',

--- a/modules/backend/lang/ro/lang.php
+++ b/modules/backend/lang/ro/lang.php
@@ -589,7 +589,7 @@ return [
         'add_folder' => 'Adăugați dosar',
         'search' => 'Căutare',
         'display' => 'Afișare',
-        'filter_everything' => 'Toate fișierele',
+        'filter_all' => 'Toate fișierele',
         'filter_images' => 'Imagini',
         'filter_video' => 'Video',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/rs/lang.php
+++ b/modules/backend/lang/rs/lang.php
@@ -580,7 +580,7 @@ return [
         'add_folder' => 'Dodaj direktorijum',
         'search' => 'Traži',
         'display' => 'Prikaži',
-        'filter_everything' => 'Sve',
+        'filter_all' => 'Sve',
         'filter_images' => 'Slike',
         'filter_video' => 'Video zapisi',
         'filter_audio' => 'Audio zapisi',

--- a/modules/backend/lang/ru/lang.php
+++ b/modules/backend/lang/ru/lang.php
@@ -600,7 +600,7 @@ return [
         'add_folder' => 'Создать папку',
         'search' => 'Поиск',
         'display' => 'Отобразить',
-        'filter_everything' => 'Все файлы',
+        'filter_all' => 'Все файлы',
         'filter_images' => 'Изображения',
         'filter_video' => 'Видео',
         'filter_audio' => 'Музыка',

--- a/modules/backend/lang/sk/lang.php
+++ b/modules/backend/lang/sk/lang.php
@@ -533,7 +533,7 @@ return [
         'add_folder' => 'Pridať priečinok',
         'search' => 'Hľadať',
         'display' => 'Zobraziť',
-        'filter_everything' => 'Všetko',
+        'filter_all' => 'Všetko',
         'filter_images' => 'Obrázky',
         'filter_video' => 'Video',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/sl/lang.php
+++ b/modules/backend/lang/sl/lang.php
@@ -586,7 +586,7 @@ return [
         'add_folder'                 => 'Dodaj mapo',
         'search'                     => 'Iskanje',
         'display'                    => 'Prikaz',
-        'filter_everything'          => 'Vse',
+        'filter_all'          => 'Vse',
         'filter_images'              => 'Slike',
         'filter_video'               => 'Video',
         'filter_audio'               => 'Audio',

--- a/modules/backend/lang/sv/lang.php
+++ b/modules/backend/lang/sv/lang.php
@@ -326,7 +326,7 @@ return [
         'add_folder' => 'Ny mapp',
         'search' => 'Sök',
         'display' => 'Visa',
-        'filter_everything' => 'Allt',
+        'filter_all' => 'Allt',
         'filter_images' => 'Bilder',
         'filter_video' => 'Videor',
         'filter_audio' => 'Ljud',

--- a/modules/backend/lang/th/lang.php
+++ b/modules/backend/lang/th/lang.php
@@ -454,7 +454,7 @@ return [
         'add_folder' => 'เพิ่มโฟลเดอร์',
         'search' => 'ค้นหา',
         'display' => 'แสดงผล',
-        'filter_everything' => 'ทุกอย่าง',
+        'filter_all' => 'ทุกอย่าง',
         'filter_images' => 'รูปภาพ',
         'filter_video' => 'วิดีโอ',
         'filter_audio' => 'เสียง',

--- a/modules/backend/lang/tr/lang.php
+++ b/modules/backend/lang/tr/lang.php
@@ -545,7 +545,7 @@ return [
         'add_folder' => 'Yeni Klasör',
         'search' => 'Ara',
         'display' => 'Görüntüle',
-        'filter_everything' => 'Her şey',
+        'filter_all' => 'Her şey',
         'filter_images' => 'Resimler',
         'filter_video' => 'Video',
         'filter_audio' => 'Ses',

--- a/modules/backend/lang/uk/lang.php
+++ b/modules/backend/lang/uk/lang.php
@@ -600,7 +600,7 @@ return [
         'add_folder' => 'Створити папку',
         'search' => 'Пошук',
         'display' => 'Показати',
-        'filter_everything' => 'Всі файли',
+        'filter_all' => 'Всі файли',
         'filter_images' => 'Зображення',
         'filter_video' => 'Відео',
         'filter_audio' => 'Музика',

--- a/modules/backend/lang/vn/lang.php
+++ b/modules/backend/lang/vn/lang.php
@@ -526,7 +526,7 @@ return [
         'add_folder' => 'Thêm folder',
         'search' => 'Tìm kiếm',
         'display' => 'Hiển thị',
-        'filter_everything' => 'Mọi thứ',
+        'filter_all' => 'Mọi thứ',
         'filter_images' => 'Images',
         'filter_video' => 'Video',
         'filter_audio' => 'Audio',

--- a/modules/backend/lang/zh-cn/lang.php
+++ b/modules/backend/lang/zh-cn/lang.php
@@ -557,7 +557,7 @@ return [
         'add_folder' => '增加文件夹',
         'search' => '搜索',
         'display' => '显示',
-        'filter_everything' => '所有',
+        'filter_all' => '所有',
         'filter_images' => '图片',
         'filter_video' => '视频',
         'filter_audio' => '音频',

--- a/modules/backend/lang/zh-tw/lang.php
+++ b/modules/backend/lang/zh-tw/lang.php
@@ -322,7 +322,7 @@ return [
         'add_folder' => '增加檔案夾',
         'search' => '搜尋',
         'display' => '顯示',
-        'filter_everything' => '所有',
+        'filter_all' => '所有',
         'filter_images' => '圖片',
         'filter_video' => '影片',
         'filter_audio' => '音訊',

--- a/modules/backend/widgets/MediaManager.php
+++ b/modules/backend/widgets/MediaManager.php
@@ -50,6 +50,11 @@ class MediaManager extends WidgetBase
     public $cropAndInsertButton = false;
 
     /**
+     * @var boolean Determines whether the Display filters are visible.
+     */
+    public bool $filterDisplay = true;
+
+    /**
      * Constructor.
      */
     public function __construct($controller, $alias, $readOnly = false)
@@ -663,6 +668,13 @@ class MediaManager extends WidgetBase
 
         $this->cropAndInsertButton = Input::get('cropAndInsertButton', $this->cropAndInsertButton);
 
+        if ($mode = Input::get('mode')) {
+            $this->setFilter($mode);
+            if ($mode !== static::FILTER_EVERYTHING) {
+                $this->setFilterDisplay(false);
+            }
+        }
+
         return $this->makePartial('popup-body');
     }
 
@@ -932,6 +944,22 @@ class MediaManager extends WidgetBase
         }
 
         $this->putSession('media_filter', $filter);
+    }
+
+    /**
+     * Sets the filter display option for the request
+     */
+    protected function setFilterDisplay(bool $status): void
+    {
+        $this->filterDisplay = $status;
+    }
+
+    /**
+     * Gets the filter display option for the request
+     */
+    protected function getFilterDisplay(): bool
+    {
+        return $this->filterDisplay;
     }
 
     /**

--- a/modules/backend/widgets/MediaManager.php
+++ b/modules/backend/widgets/MediaManager.php
@@ -32,7 +32,7 @@ class MediaManager extends WidgetBase
     const SELECTION_MODE_FIXED_RATIO = 'fixed-ratio';
     const SELECTION_MODE_FIXED_SIZE = 'fixed-size';
 
-    const FILTER_EVERYTHING = 'everything';
+    const FILTER_ALL = 'all';
 
     /**
      * @var boolean Determines whether the widget is in readonly mode or not.
@@ -670,7 +670,7 @@ class MediaManager extends WidgetBase
 
         if ($mode = Input::get('mode')) {
             $this->setFilter($mode);
-            if ($mode !== static::FILTER_EVERYTHING) {
+            if ($mode !== static::FILTER_ALL) {
                 $this->setFilterDisplay(false);
             }
         }
@@ -883,7 +883,7 @@ class MediaManager extends WidgetBase
      */
     protected function listFolderItems($folder, $filter, $sortBy)
     {
-        $filter = $filter !== self::FILTER_EVERYTHING ? $filter : null;
+        $filter = $filter !== self::FILTER_ALL ? $filter : null;
 
         return MediaLibrary::instance()->listFolderContents($folder, $sortBy, $filter);
     }
@@ -899,7 +899,7 @@ class MediaManager extends WidgetBase
      */
     protected function findFiles($searchTerm, $filter, $sortBy)
     {
-        $filter = $filter !== self::FILTER_EVERYTHING ? $filter : null;
+        $filter = $filter !== self::FILTER_ALL ? $filter : null;
 
         return MediaLibrary::instance()->findFiles($searchTerm, $sortBy, $filter);
     }
@@ -934,7 +934,7 @@ class MediaManager extends WidgetBase
     protected function setFilter($filter): void
     {
         if (!in_array($filter, [
-            self::FILTER_EVERYTHING,
+            self::FILTER_ALL,
             MediaLibraryItem::FILE_TYPE_IMAGE,
             MediaLibraryItem::FILE_TYPE_AUDIO,
             MediaLibraryItem::FILE_TYPE_DOCUMENT,
@@ -969,7 +969,7 @@ class MediaManager extends WidgetBase
      */
     protected function getFilter()
     {
-        return $this->getSession('media_filter', self::FILTER_EVERYTHING);
+        return $this->getSession('media_filter', self::FILTER_ALL);
     }
 
     /**

--- a/modules/backend/widgets/mediamanager/assets/js/mediamanager.popup.js
+++ b/modules/backend/widgets/mediamanager/assets/js/mediamanager.popup.js
@@ -54,7 +54,8 @@
     MediaManagerPopup.prototype.show = function() {
         var data = {
             bottomToolbar: this.options.bottomToolbar ? 1 : 0,
-            cropAndInsertButton: this.options.cropAndInsertButton ? 1 : 0
+            cropAndInsertButton: this.options.cropAndInsertButton ? 1 : 0,
+            mode: this.options.mode || 'everything',
         }
 
         this.$popupRootElement.popup({

--- a/modules/backend/widgets/mediamanager/assets/js/mediamanager.popup.js
+++ b/modules/backend/widgets/mediamanager/assets/js/mediamanager.popup.js
@@ -55,7 +55,7 @@
         var data = {
             bottomToolbar: this.options.bottomToolbar ? 1 : 0,
             cropAndInsertButton: this.options.cropAndInsertButton ? 1 : 0,
-            mode: this.options.mode || 'everything',
+            mode: this.options.mode || 'all',
         }
 
         this.$popupRootElement.popup({

--- a/modules/backend/widgets/mediamanager/partials/_filters.php
+++ b/modules/backend/widgets/mediamanager/partials/_filters.php
@@ -3,14 +3,14 @@
 <ul class="nav nav-stacked selector-group">
     <li
         role="presentation"
-        <?php if ($currentFilter == Backend\Widgets\MediaManager::FILTER_EVERYTHING): ?>
+        <?php if ($currentFilter == Backend\Widgets\MediaManager::FILTER_ALL): ?>
             class="active"
         <?php endif ?>
     >
-        <a href="#" data-command="set-filter" data-filter="<?= Backend\Widgets\MediaManager::FILTER_EVERYTHING ?>">
+        <a href="#" data-command="set-filter" data-filter="<?= Backend\Widgets\MediaManager::FILTER_ALL ?>">
             <i class="icon-recycle"></i>
 
-            <?= e(trans('backend::lang.media.filter_everything')) ?>
+            <?= e(trans('backend::lang.media.filter_all')) ?>
         </a>
     </li>
     <li

--- a/modules/backend/widgets/mediamanager/partials/_left-sidebar.php
+++ b/modules/backend/widgets/mediamanager/partials/_left-sidebar.php
@@ -1,5 +1,7 @@
-<div id="<?= $this->getId('filters') ?>">
-    <?= $this->makePartial('filters') ?>
-</div>
+<?php if ($this->getFilterDisplay()): ?>
+    <div id="<?= $this->getId('filters') ?>">
+        <?= $this->makePartial('filters') ?>
+    </div>
+<?php endif; ?>
 
 <?= $this->makePartial('sorting') ?>


### PR DESCRIPTION
This PR introduces support for all mediamanager filters as modes for the mediafinder formwidget.

This means that the following `mode` values would be available:
- image
- file
- document
- audio
- video
- everything (default)