### PR TITLE
Added alias to list of configs to transfer from ListController to List widget

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -151,6 +151,7 @@ class ListController extends ControllerBehavior
             'showTree',
             'treeExpanded',
             'customViewPath',
+            'alias',
         ];
 
         foreach ($configFieldsToTransfer as $field) {


### PR DESCRIPTION
This allows you to specify a list widget alias when defining the config for the list controller.

In my use case it would be useful as I'm using one list with different columns dependant upon scopes, and this change allows me to modify the alias to include the scope key, meaning that the user preferences stored against the alias are unique to each scope.

Very open to thoughts on this.