### PR TITLE
Trigger a change event on repeater item remove

### DIFF
--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -140,6 +140,7 @@
 
         $target.closest('[data-field-name]').trigger('change.oc.formwidget')
         $target.closest('.field-repeater-item').remove()
+        this.$el.trigger('change.oc.formwidget')
         this.togglePrompt()
     }
 


### PR DESCRIPTION
Currently when an item is removed from a repeater widget, no change event is triggered, this means that anything watching for changes is not informed of item removals. This PR implements a change trigger on the repeater when an item is removed.