### PR TITLE
[FIX] iconpicker not being registered after load

### DIFF
--- a/modules/backend/formwidgets/iconpicker/assets/src/iconpicker.js
+++ b/modules/backend/formwidgets/iconpicker/assets/src/iconpicker.js
@@ -1,20 +1,28 @@
 import { createApp } from 'vue'
 import IconPicker from './components/IconPicker.vue'
 
-window.addEventListener('load', () => {
-    const elements = document.querySelectorAll("[data-control='iconpicker']:not([data-v-app])");
-    elements.forEach(element => {
-        element.querySelector(".input-group").addEventListener("click", () => {
-            snowboard.request(null, element.dataset.alias + "::onLoadIconLibrary", {
-                success: (data) => {
-                    let iconPicker = createApp(IconPicker, {
-                        ...element.dataset,
-                        fontLibraries: JSON.parse(data.result)
-                    }).mount(element);
+(() => {
+    const init = () => {
+        const elements = document.querySelectorAll("[data-control='iconpicker']:not([data-v-app])");
+        elements.forEach(element => {
+            element.querySelector(".input-group").addEventListener("click", () => {
+                snowboard.request(element.querySelector("input")?.form || null, element.dataset.alias + "::onLoadIconLibrary", {
+                    success: (data) => {
+                        let iconPicker = createApp(IconPicker, {
+                            ...element.dataset,
+                            fontLibraries: JSON.parse(data.result)
+                        }).mount(element);
 
-                    iconPicker.togglePicker();
-                },
-            })
+                        iconPicker.togglePicker();
+                    },
+                })
+            });
         });
-    });
-});
+    };
+
+    window.addEventListener('load', init);
+
+    if (document.readyState === "complete") {
+        init();
+    }
+})();


### PR DESCRIPTION
This PR changes how the icon picker is inited to ensure it can be used after page load, i.e. on static pages. There is also a fix here to provide the elements form to the snowboard request if available 