### PR TITLE
[Fix] TagList type error

### DIFF
--- a/modules/backend/formwidgets/TagList.php
+++ b/modules/backend/formwidgets/TagList.php
@@ -121,7 +121,7 @@ class TagList extends FormWidgetBase
      * Returns an array suitable for saving against a relation (array of keys).
      * This method also creates non-existent tags.
      */
-    protected function hydrateRelationSaveValue($names): array
+    protected function hydrateRelationSaveValue($names): ?array
     {
         if (!$names) {
             return $names;


### PR DESCRIPTION
This is causing an error when using relation mode and you have an empty relation and try to save. the method expects an array, but is null so we either put the null value in an array or we can change the type to a nullable type hint. I'm fine with either and will change accordingly.