### PR TITLE
Add support for extending head block on dashboard

### DIFF
--- a/modules/backend/controllers/index/index.php
+++ b/modules/backend/controllers/index/index.php
@@ -20,4 +20,4 @@ Snowboard.ready(() => {
     });
 });
 </script>
-<?php Block::endPut(); ?>
+<?php Block::endPut(true); ?>


### PR DESCRIPTION
By default, `Block::put('key')` & `Block::endPut()` defaults to overwriting instead of appending.

This change means calls to `Block::append('head', $content)` will function correctly for the dashboard.