### PR TITLE
Fix typehint

### DIFF
--- a/modules/cms/classes/Theme.php
+++ b/modules/cms/classes/Theme.php
@@ -666,7 +666,7 @@ class Theme extends CmsObject
     /**
      * Get the theme's datasource
      */
-    public function getDatasource(): AutoDatasource
+    public function getDatasource(): DatasourceInterface
     {
         $resolver = App::make('halcyon');
         return $resolver->datasource($this->getDirName());


### PR DESCRIPTION
This is a fix for https://github.com/wintercms/winter/issues/855

For efficency, if the theme only registers 1 `Datasource` we're now not injecting that `Datasource` into an `AutoDatasource` and instead registering the single `Datasource`.

This breaks the `AutoDatasource` type hinting, updating the return type to reference the `DatasourceInterface` should resolve the issue in all cases.