### PR TITLE
Add 'themes.' prefix to let work backend theme localization again

### DIFF
--- a/modules/cms/classes/Theme.php
+++ b/modules/cms/classes/Theme.php
@@ -581,7 +581,7 @@ class Theme extends CmsObject
         $langPath = $this->getPath() . '/lang';
 
         if (File::isDirectory($langPath)) {
-            Lang::addNamespace($this->getDirName(), $langPath);
+            Lang::addNamespace('themes.' . $this->getDirName(), $langPath);
         }
 
         // Check the parent theme if present


### PR DESCRIPTION
The `themes.` prefix is missing, so backend theme localization can't work anymore