### PR TITLE
Manually register system class aliases in test bootstrap

### DIFF
--- a/modules/system/tests/bootstrap/app.php
+++ b/modules/system/tests/bootstrap/app.php
@@ -26,6 +26,15 @@ foreach (glob($baseDir . '/modules/*', GLOB_ONLYDIR) as $modulePath) {
 }
 
 /*
+ * Manually register System aliases
+ */
+foreach (require(__DIR__ . '/../../aliases.php') as $alias => $class) {
+    if (!class_exists($alias)) {
+        class_alias($class, $alias);
+    }
+}
+
+/*
  * Manually register all plugin classes for autoloading
  */
 $dirPath = $baseDir . '/plugins';


### PR DESCRIPTION
We register backwards compatible aliases for test cases, however the aliases are not registered in the test bootstrapping.
```php
// modules/system/aliases.php
'TestCase'       => System\Tests\Bootstrap\TestCase::class,
'PluginTestCase' => System\Tests\Bootstrap\PluginTestCase::class,
```
This PR registers the aliases ahead of time allowing tests to use:
```php
class MyTestCase extends \TestCase
```
Which will allow for the same test cases to work in both `v1.1.9` & >`v1.2.0`
