### PR TITLE
[FIX] Multiple assets in combiner url

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -1394,7 +1394,7 @@ class Controller
                     $asset = $source . DIRECTORY_SEPARATOR . $file;
                     if (File::exists($asset)) {
                         $assets[] = $asset;
-                        break 2;
+                        break;
                     }
                 }
 

--- a/modules/cms/tests/classes/ControllerTest.php
+++ b/modules/cms/tests/classes/ControllerTest.php
@@ -639,4 +639,34 @@ ESC;
             $response
         );
     }
+
+    public function testThemeCombineAssets(): void
+    {
+        $theme = Theme::load('test');
+        $controller = new Controller($theme);
+
+        // Generate a url
+        $url = $controller->themeUrl(['assets/css/style1.css', 'assets/css/style2.css']);
+        $this->assertIsString($url);
+
+        // Grab the cache key from the url
+        $cacheKey = 'combiner.' . str_before(basename($url), '-');
+
+        // Load the cached config
+        $combinerConfig = \Cache::get($cacheKey);
+        $this->assertIsString($combinerConfig);
+
+        // Decode the config
+        $combinerConfig = unserialize(base64_decode($combinerConfig));
+
+        // Assert the result is an array and includes files
+        $this->assertIsArray($combinerConfig);
+        $this->assertArrayHasKey('files', $combinerConfig);
+        $this->assertCount(2, $combinerConfig['files']);
+
+        // Check our input file names against our output file names
+        $files = array_map('basename', $combinerConfig['files']);
+        $this->assertTrue(in_array('style1.css', $files));
+        $this->assertTrue(in_array('style2.css', $files));
+    }
 }


### PR DESCRIPTION
Added fix to ensure multiple assets are included in combination url.

Reported by @mjauvin 

Test case:
```twig
{% set styleAssets = [
  'assets/css/test1.css',
  'assets/css/test2.css',
] %}

<link rel="stylesheet" href="{{ styleAssets | theme }}">
```

Result, only the first file was included.