### PR TITLE
Re-calculate new sort order values.

### DIFF
--- a/modules/backend/behaviors/reordercontroller/assets/js/winter.reorder.js
+++ b/modules/backend/behaviors/reordercontroller/assets/js/winter.reorder.js
@@ -69,8 +69,8 @@
         this.initSortingSimple = function () {
             var sortOrders = []
 
-            $('#reorderTreeList li').each(function(){
-                sortOrders.push($(this).data('recordSortOrder'))
+            $('#reorderTreeList li').each(function(i) {
+                sortOrders.push(i);
             })
 
             this.simpleSortOrders = sortOrders


### PR DESCRIPTION
Fixes https://github.com/wintercms/winter/issues/881

Re-calculate new sort order values so we no longer have an issue with duplicate sort order values causing records not to be sorted correctly.

This probably needs to be fixed in v1.2 as well, but I haven't tested that version yet.