### PR TITLE
Add sizeBytes & lastModified to mediamanager.js getItems()

### DIFF
--- a/modules/backend/widgets/mediamanager/assets/js/mediamanager.js
+++ b/modules/backend/widgets/mediamanager/assets/js/mediamanager.js
@@ -99,6 +99,7 @@
                     path: item.getAttribute('data-path'),
                     title: item.getAttribute('data-title'),
                     sizeBytes: item.getAttribute('data-size-bytes'),
+                    lastModified: item.getAttribute('data-last-modified-ts'),
                     documentType: item.getAttribute('data-document-type'),
                     folder: item.getAttribute('data-folder'),
                     publicUrl: item.getAttribute('data-public-url')

--- a/modules/backend/widgets/mediamanager/assets/js/mediamanager.js
+++ b/modules/backend/widgets/mediamanager/assets/js/mediamanager.js
@@ -98,6 +98,7 @@
                     itemType: item.getAttribute('data-item-type'),
                     path: item.getAttribute('data-path'),
                     title: item.getAttribute('data-title'),
+                    sizeBytes: item.getAttribute('data-size-bytes'),
                     documentType: item.getAttribute('data-document-type'),
                     folder: item.getAttribute('data-folder'),
                     publicUrl: item.getAttribute('data-public-url')

--- a/modules/backend/widgets/mediamanager/partials/_generic-list.php
+++ b/modules/backend/widgets/mediamanager/partials/_generic-list.php
@@ -24,6 +24,7 @@
                 data-path="<?= e($item->path) ?>"
                 data-title="<?= e(basename($item->path)) ?>"
                 data-size="<?= e($item->sizeToString()) ?>"
+                data-size-bytes="<?= $item->size ?>"
                 data-last-modified="<?= e($item->lastModifiedAsString()) ?>"
                 data-last-modified-ts="<?= $item->lastModified ?>"
                 data-public-url="<?= e($item->publicUrl) ?>"

--- a/modules/backend/widgets/mediamanager/partials/_list-grid.php
+++ b/modules/backend/widgets/mediamanager/partials/_list-grid.php
@@ -26,6 +26,7 @@
                     data-path="<?= e($item->path) ?>"
                     data-title="<?= e(basename($item->path)) ?>"
                     data-size="<?= e($item->sizeToString()) ?>"
+                    data-size-bytes="<?= $item->size ?>"
                     data-last-modified="<?= e($item->lastModifiedAsString()) ?>"
                     data-last-modified-ts="<?= $item->lastModified ?>"
                     data-public-url="<?= e($item->publicUrl) ?>"


### PR DESCRIPTION
This exposes additional file metadata to the Media Manager popup `onInsert()` callback.

#### Possible Use Case

WYSIWYG editor plugin that inserts links to files which display the file size.

![image](https://user-images.githubusercontent.com/5186921/233822017-bdf9f8da-ae4a-438d-bfcb-02fb306600fc.png)


#### Example JavaScript

```js
function onInsertMedia() {
    new $.wn.mediaManager.popup({
        alias: 'wnmediamanager',
        mode: 'all', // all | image | video | audio | document
        bottomToolbar: true,
        cropAndInsertButton: false,
        onInsert: function (items) {
            if (!items.length) {
                $.wn.alert($.wn.lang.get('mediamanager.invalid_file_empty_insert'))
                return
            }

            if (items.length > 1) {
                $.wn.alert($.wn.lang.get('mediamanager.invalid_file_single_insert'))
                return
            }

            const {
                // itemType,     // file | folder
                // path,         // path relative to media library root
                // title,        // file name

                /* Additional attributes */
                sizeBytes,
                lastModified,

                // documentType, // image | video | audio | document
                // folder,
                // publicUrl,
            } = item[0];

            this.hide();
        },
        onClose: function () {},
    }
}
```