### PR TITLE
Add inputmode attribute to datepicker formwidget

### DIFF
--- a/modules/backend/formwidgets/DatePicker.php
+++ b/modules/backend/formwidgets/DatePicker.php
@@ -102,6 +102,14 @@ class DatePicker extends FormWidgetBase
                 ? Carbon::createFromTimestamp($this->maxDate)
                 : Carbon::parse($this->maxDate);
         }
+
+        // Add inputmode attribute (can still be overriden in field config)
+        $fieldAttributes = array_merge(
+            ['inputmode' => 'none'],
+            $this->formField->getAttributes('field', false),
+        );
+
+        $this->formField->attributes($fieldAttributes, 'field');
     }
 
     /**

--- a/modules/backend/formwidgets/DatePicker.php
+++ b/modules/backend/formwidgets/DatePicker.php
@@ -102,14 +102,6 @@ class DatePicker extends FormWidgetBase
                 ? Carbon::createFromTimestamp($this->maxDate)
                 : Carbon::parse($this->maxDate);
         }
-
-        // Add inputmode attribute (can still be overriden in field config)
-        $fieldAttributes = array_merge(
-            ['inputmode' => 'none'],
-            $this->formField->getAttributes('field', false),
-        );
-
-        $this->formField->attributes($fieldAttributes, 'field');
     }
 
     /**

--- a/modules/system/assets/ui/js/datepicker.js
+++ b/modules/system/assets/ui/js/datepicker.js
@@ -136,6 +136,10 @@
         }
 
         this.$datePicker.pikaday(pikadayOptions)
+
+		if (!this.$datePicker.attr('inputmode')) {
+			this.$datePicker.attr('inputmode', 'none')
+		}
     }
 
     DatePicker.prototype.onSelectDatePicker = function(pickerMoment) {
@@ -195,6 +199,10 @@
         })
 
         this.$timePicker.val(this.getDataLockerValue(this.getTimeFormat()))
+
+		if (!this.$timePicker.attr('inputmode')) {
+			this.$timePicker.attr('inputmode', 'none')
+		}
     }
 
     DatePicker.prototype.onSelectTimePicker = function() {

--- a/modules/system/assets/ui/js/datepicker.js
+++ b/modules/system/assets/ui/js/datepicker.js
@@ -137,9 +137,10 @@
 
         this.$datePicker.pikaday(pikadayOptions)
 
-		if (!this.$datePicker.attr('inputmode')) {
-			this.$datePicker.attr('inputmode', 'none')
-		}
+        // Avoid displaying keyboards on mobile when the widget is displayed
+        if (!this.$datePicker.attr('inputmode')) {
+            this.$datePicker.attr('inputmode', 'none')
+        }
     }
 
     DatePicker.prototype.onSelectDatePicker = function(pickerMoment) {
@@ -200,9 +201,10 @@
 
         this.$timePicker.val(this.getDataLockerValue(this.getTimeFormat()))
 
-		if (!this.$timePicker.attr('inputmode')) {
-			this.$timePicker.attr('inputmode', 'none')
-		}
+        // Avoid displaying keyboards on mobile when the widget is displayed
+        if (!this.$timePicker.attr('inputmode')) {
+            this.$timePicker.attr('inputmode', 'none')
+        }
     }
 
     DatePicker.prototype.onSelectTimePicker = function() {

--- a/modules/system/assets/ui/storm-min.js
+++ b/modules/system/assets/ui/storm-min.js
@@ -1442,7 +1442,8 @@ var pikadayOptions={yearRange:this.options.yearRange,firstDay:this.options.first
 $(this.el).css({left:'auto',right:$(window).width()-$field.offset().left-$field.outerWidth()})},onSelect:function(){self.onSelectDatePicker.call(self,this.getMoment())}}
 var lang=this.getLang('datepicker',false)
 if(lang){pikadayOptions.i18n=lang}this.$datePicker.val(this.getDataLockerValue(dateFormat))
-if(this.options.minDate){pikadayOptions.minDate=new Date(this.options.minDate)}if(this.options.maxDate){pikadayOptions.maxDate=new Date(this.options.maxDate)}this.$datePicker.pikaday(pikadayOptions)}
+if(this.options.minDate){pikadayOptions.minDate=new Date(this.options.minDate)}if(this.options.maxDate){pikadayOptions.maxDate=new Date(this.options.maxDate)}this.$datePicker.pikaday(pikadayOptions)
+if(!this.$datePicker.attr('inputmode')){this.$datePicker.attr('inputmode','none')}}
 DatePicker.prototype.onSelectDatePicker=function(pickerMoment){var pickerValue=pickerMoment.format(this.dbDateFormat)
 var timeValue=this.options.mode==='date'?'00:00:00':this.getTimePickerValue()
 var momentObj=moment.tz(pickerValue+' '+timeValue,this.dbDateTimeFormat,this.timezone).tz(this.appTimezone)
@@ -1453,7 +1454,8 @@ if(!this.hasDate||!value){return moment.tz(this.appTimezone).tz(this.timezone).f
 DatePicker.prototype.getDateFormat=function(){var format='YYYY-MM-DD'
 if(this.options.format){format=this.options.format}else if(this.locale){format=moment().locale(this.locale).localeData().longDateFormat('l')}return format}
 DatePicker.prototype.initTimePicker=function(){this.$timePicker.clockpicker({autoclose:'true',placement:'auto',align:'right',twelvehour:this.isTimeTwelveHour(),afterDone:this.proxy(this.onChangeTimePicker)})
-this.$timePicker.val(this.getDataLockerValue(this.getTimeFormat()))}
+this.$timePicker.val(this.getDataLockerValue(this.getTimeFormat()))
+if(!this.$timePicker.attr('inputmode')){this.$timePicker.attr('inputmode','none')}}
 DatePicker.prototype.onSelectTimePicker=function(){var pickerValue=this.$timePicker.val()
 var timeValue=moment(pickerValue,this.getTimeFormat()).format(this.dbTimeFormat)
 var dateValue=this.getDatePickerValue()


### PR DESCRIPTION
On mobile, when the DatePicker formwidget opens, you don't want the keyboard to popup.

In order to prevent this behavior, we add inputmode=none to the input field. (ref. https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/#aa-none)

This can still be overriden in the field config like this:
```
date:
    type: datepicker
    attributes:
      inputmode: text
```
