### PR TITLE
Support trigger actions for dropdown fields in preview mode

### DIFF
--- a/modules/backend/widgets/form/partials/_field_dropdown.php
+++ b/modules/backend/widgets/form/partials/_field_dropdown.php
@@ -9,12 +9,7 @@ $emptyOption = $field->getConfig('emptyOption', $field->placeholder);
     <div class="form-control" <?= $field->readOnly ? 'disabled="disabled"' : ''; ?>>
         <?= (isset($fieldOptions[$field->value])) ? e(trans($fieldOptions[$field->value])) : '' ?>
     </div>
-    <?php if ($field->readOnly): ?>
-        <input
-             type="hidden"
-             name="<?= $field->getName() ?>"
-             value="<?= $field->value ?>">
-    <?php endif; ?>
+    <input name="<?= $field->getName() ?>" value="<?= $field->value ?>">
 <?php else: ?>
     <select
         id="<?= $field->getId() ?>"

--- a/modules/backend/widgets/form/partials/_field_dropdown.php
+++ b/modules/backend/widgets/form/partials/_field_dropdown.php
@@ -9,7 +9,7 @@ $emptyOption = $field->getConfig('emptyOption', $field->placeholder);
     <div class="form-control" <?= $field->readOnly ? 'disabled="disabled"' : ''; ?>>
         <?= (isset($fieldOptions[$field->value])) ? e(trans($fieldOptions[$field->value])) : '' ?>
     </div>
-    <input name="<?= $field->getName() ?>" value="<?= $field->value ?>">
+    <input type="hidden" name="<?= $field->getName() ?>" value="<?= $field->value ?>">
 <?php else: ?>
     <select
         id="<?= $field->getId() ?>"


### PR DESCRIPTION
When in preview mode, if a dropdown field is used as another field's trigger, the trigger won't happen because the js code does not find the trigger field.

Fix #845