### PR TITLE
Use localization strings for dropdown-like field options.

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1343,7 +1343,7 @@ class Form extends WidgetBase
                     }
                     return $result;
                 } else {
-                    // see if there is a localization string that returns an array
+                    // Handle localization keys that return arrays
                     if (is_array($options = Lang::get($fieldOptions))) {
                         return $options;
                     }

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1342,6 +1342,11 @@ class Form extends WidgetBase
                         ]));
                     }
                     return $result;
+                } else {
+                    // see if there is a localization string that returns an array
+                    if (is_array($options = Lang::get($fieldOptions))) {
+                        return $options;
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR makes the dropdown field options even more flexible by allowing a string localization to be specified to return the field's options:

```yaml
fields:
    department:
        label: Departments
        type: dropdown
        options: author.plugin::lang.departments
```

author.plugin/lang/en/lang.php:
```php
<?php
return [
    'departments' => [
        'customer_service' => 'Customer Service',
        'admin' => 'Administration',
        'dev' => 'Development',
    ],
];
```
author.plugin/lang/fr/lang.php:
```php
<?php
return [
    'departments' => [
        'customer_service' => "Service à la clientèle",
        'admin' => "Administration",
        'dev' => 'Développement',
    ],
];
```