### PR TITLE
Apply filterFields before saving the form

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1177,6 +1177,7 @@ class Form extends WidgetBase
     public function getSaveData()
     {
         $this->defineFormFields();
+        $this->applyFiltersFromModel();
 
         $result = [];
 

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -488,6 +488,8 @@ class Form extends WidgetBase
      */
     protected function defineFormFields()
     {
+        $this->applyFiltersFromModel();
+
         if ($this->fieldsDefined) {
             return;
         }
@@ -677,7 +679,6 @@ class Form extends WidgetBase
         }
 
         $this->fieldsDefined = true;
-        $this->applyFiltersFromModel();
     }
 
     /**

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -306,7 +306,6 @@ class Form extends WidgetBase
     protected function prepareVars()
     {
         $this->defineFormFields();
-        $this->applyFiltersFromModel();
         $this->vars['sessionKey'] = $this->getSessionKey();
         $this->vars['outsideTabs'] = $this->allTabs->outside;
         $this->vars['primaryTabs'] = $this->allTabs->primary;
@@ -678,6 +677,7 @@ class Form extends WidgetBase
         }
 
         $this->fieldsDefined = true;
+        $this->applyFiltersFromModel();
     }
 
     /**
@@ -1177,7 +1177,6 @@ class Form extends WidgetBase
     public function getSaveData()
     {
         $this->defineFormFields();
-        $this->applyFiltersFromModel();
 
         $result = [];
 

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -488,8 +488,6 @@ class Form extends WidgetBase
      */
     protected function defineFormFields()
     {
-        $this->applyFiltersFromModel();
-
         if ($this->fieldsDefined) {
             return;
         }
@@ -679,6 +677,7 @@ class Form extends WidgetBase
         }
 
         $this->fieldsDefined = true;
+        $this->applyFiltersFromModel();
     }
 
     /**

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -306,6 +306,7 @@ class Form extends WidgetBase
     protected function prepareVars()
     {
         $this->defineFormFields();
+        $this->applyFiltersFromModel();
         $this->vars['sessionKey'] = $this->getSessionKey();
         $this->vars['outsideTabs'] = $this->allTabs->outside;
         $this->vars['primaryTabs'] = $this->allTabs->primary;
@@ -677,7 +678,6 @@ class Form extends WidgetBase
         }
 
         $this->fieldsDefined = true;
-        $this->applyFiltersFromModel();
     }
 
     /**
@@ -1177,6 +1177,7 @@ class Form extends WidgetBase
     public function getSaveData()
     {
         $this->defineFormFields();
+        $this->applyFiltersFromModel();
 
         $result = [];
 


### PR DESCRIPTION
Fixes #950

Restore form fields as they were before saving the form in case hidden/disabled fields were modified in `filterFields()` / `model.form.filterFields` event handler.

In Forms::getSaveData() hidden/disabled fields are skipped:
 ```php
foreach ($this->allFields as $field) {
    /*
     * Disabled and hidden should be omitted from data set
     */
    if ($field->disabled || $field->hidden) {
        continue;
    }
    ...
```