### PR TITLE
Add support for custom disk uploads purging

### DIFF
--- a/modules/system/console/WinterUtil.php
+++ b/modules/system/console/WinterUtil.php
@@ -3,6 +3,7 @@
 use Lang;
 use File;
 use Config;
+use Storage;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -299,59 +300,44 @@ class WinterUtil extends Command
         }
 
         $uploadsDisk = Config::get('cms.storage.uploads.disk', 'local');
-        if ($uploadsDisk !== 'local') {
-            $this->error("Purging uploads is only supported on the 'local' disk, current uploads disk is $uploadsDisk");
-            return;
-        }
+
+        $uploadsFolder = Config::get('cms.storage.uploads.folder', 'uploads');
 
         $totalCount = 0;
+
         $validFiles = FileModel::pluck('disk_name')->all();
-        $uploadsPath = Config::get('filesystems.disks.local.root', storage_path('app')) . '/' . Config::get('cms.storage.uploads.folder', 'uploads');
 
-        // Recursive function to scan the directory for files and ensure they exist in system_files.
-        $purgeFunc = function ($targetDir) use (&$purgeFunc, &$totalCount, $uploadsPath, $validFiles) {
-            if ($files = File::glob($targetDir.'/*')) {
-                if ($dirs = File::directories($targetDir)) {
-                    foreach ($dirs as $dir) {
-                        $purgeFunc($dir);
+        foreach (Storage::disk($uploadsDisk)->allFiles($uploadsFolder) as $filePath) {
+            $fileName = basename($filePath);
 
-                        if (File::isDirectoryEmpty($dir) && is_writeable($dir)) {
-                            rmdir($dir);
-                            $this->info('Removed folder: '. str_replace($uploadsPath, '', $dir));
-                        }
-                    }
-                }
-
-                foreach ($files as $file) {
-                    if (!is_file($file)) {
-                        continue;
-                    }
-
-                    // Skip .gitignore files
-                    if ($file === '.gitignore') {
-                        continue;
-                    }
-
-                    // Skip files unable to be purged
-                    if (!is_writeable($file)) {
-                        $this->warn('Unable to purge file: ' . str_replace($uploadsPath, '', $file));
-                        continue;
-                    }
-
-                    // Skip valid files
-                    if (in_array(basename($file), $validFiles)) {
-                        $this->warn('Skipped file in use: '. str_replace($uploadsPath, '', $file));
-                        continue;
-                    }
-
-                    unlink($file);
-                    $this->info('Purged: '. str_replace($uploadsPath, '', $file));
-                    $totalCount++;
-                }
+            // Skip .gitignore files
+            if ($fileName === '.gitignore') {
+                continue;
             }
-        };
-
-        $purgeFunc($uploadsPath);
+            // Purge invalid files
+            if (!in_array($fileName, $validFiles)) {
+                // Purge invalid upload file
+                Storage::disk($uploadsDisk)->delete($filePath);
+                $this->info('Purged: ' . $filePath);
+                // Purge parent directories
+                $currentDir = dirname($filePath);
+                while ($currentDir !== $uploadsFolder) {
+                    // Get parent directory children
+                    $children = Storage::disk($uploadsDisk)->allDirectories($currentDir);
+                    // Parent directory is empty
+                    if (count($children) === 0) {
+                        Storage::disk($uploadsDisk)->deleteDirectory($currentDir);
+                        $this->info('Removed folder: ' . $currentDir);
+                    } else {
+                        // Parent directory is not empty
+                        // stop the iteration
+                        break;
+                    }
+                    $currentDir = basename($currentDir);
+                }
+                $totalCount++;
+            }
+        }
 
         if ($totalCount > 0) {
             $this->comment(sprintf('Successfully deleted %d invalid file(s), leaving %d valid files', $totalCount, count($validFiles)));


### PR DESCRIPTION
The command to delete files in the uploads directory that do not exist in the "system_files" table only supports local disk.

This PR adds support for custom disk. This is especially useful when you want to use S3 disk.

The artisan command signature does not change : `php artisan winter:util purge uploads`.

I use the `Storage` facade to achieve the purge.