### PR TITLE
Limit the default amount of returned records

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -62,7 +62,7 @@ class Lists extends WidgetBase
     /**
      * @var int Maximum rows to display for each page.
      */
-    public $recordsPerPage;
+    public $recordsPerPage = 20;
 
     /**
      * @var array Options for number of items per page.


### PR DESCRIPTION
Makes sure that there is pagination and thus prevents all records being fetched and rendered at once in a single list

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->