### PR TITLE
[WIP] Plugin management Composer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ composer.lock
 .env.php
 selenium.php
 /bootstrap/compiled.php
+/storage/framework/packages.json
 .phpunit.result.cache
 
 # Hosting ignores

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,9 @@
         "winter/wn-backend-module": "dev-develop",
         "winter/wn-cms-module": "dev-develop",
         "laravel/framework": "^9.1",
-        "wikimedia/composer-merge-plugin": "~2.1.0"
+        "winter/packager": "*",
+        "wikimedia/composer-merge-plugin": "~2.1.0",
+        "jaxwilko/composer-winter-plugin": "dev-main"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.8",
@@ -82,7 +84,8 @@
     "config": {
         "allow-plugins": {
             "composer/installers": true,
-            "wikimedia/composer-merge-plugin": true
+            "wikimedia/composer-merge-plugin": true,
+            "jaxwilko/composer-winter-plugin": true
         }
     }
 }

--- a/modules/system/classes/PluginBase.php
+++ b/modules/system/classes/PluginBase.php
@@ -54,6 +54,11 @@ class PluginBase extends ServiceProviderBase
     public $disabled = false;
 
     /**
+     * @var ?string The composer package a plugin belongs to.
+     */
+    public readonly ?string $package;
+
+    /**
      * Returns information about this plugin, including plugin name and developer name.
      *
      * @return array
@@ -475,6 +480,11 @@ class PluginBase extends ServiceProviderBase
         }
 
         return $versions;
+    }
+
+    public function setComposerPackage(?string $package): void
+    {
+        $this->package = $package;
     }
 
     /**

--- a/modules/system/classes/PluginBase.php
+++ b/modules/system/classes/PluginBase.php
@@ -54,9 +54,9 @@ class PluginBase extends ServiceProviderBase
     public $disabled = false;
 
     /**
-     * @var ?string The composer package a plugin belongs to.
+     * @var ?array The composer package details for this plugin.
      */
-    public readonly ?string $package;
+    protected ?array $composerPackage = null;
 
     /**
      * Returns information about this plugin, including plugin name and developer name.
@@ -482,9 +482,28 @@ class PluginBase extends ServiceProviderBase
         return $versions;
     }
 
-    public function setComposerPackage(?string $package): void
+    /**
+     * Set the composer package property for the plugin
+     */
+    public function setComposerPackage(?array $package): void
     {
-        $this->package = $package;
+        $this->composerPackage = $package;
+    }
+
+    /**
+     * Get the composer package details
+     */
+    public function getComposerPackage(): ?array
+    {
+        return $this->composerPackage;
+    }
+
+    /**
+     * Get the composer package name
+     */
+    public function getComposerPackageName(): ?string
+    {
+        return $this->composerPackage['name'] ?? null;
     }
 
     /**

--- a/modules/system/classes/packager/Composer.php
+++ b/modules/system/classes/packager/Composer.php
@@ -3,6 +3,7 @@
 namespace System\Classes\Packager;
 
 use System\Classes\Packager\Commands\RemoveCommand;
+use System\Classes\Packager\Commands\SearchCommand;
 use System\Classes\Packager\Commands\ShowCommand;
 use System\Classes\Packager\Commands\UpdateCommand;
 use System\Classes\Packager\Commands\RequireCommand;
@@ -34,10 +35,11 @@ class Composer
         static::$composer = new PackagerComposer();
         static::$composer->setWorkDir(base_path());
 
-        static::$composer->setCommand('show', new ShowCommand(static::$composer));
-        static::$composer->setCommand('update', new UpdateCommand(static::$composer));
         static::$composer->setCommand('remove', new RemoveCommand(static::$composer));
         static::$composer->setCommand('require', new RequireCommand(static::$composer));
+        static::$composer->setCommand('search', new SearchCommand(static::$composer));
+        static::$composer->setCommand('show', new ShowCommand(static::$composer));
+        static::$composer->setCommand('update', new UpdateCommand(static::$composer));
 
         return static::$composer;
     }

--- a/modules/system/classes/packager/Composer.php
+++ b/modules/system/classes/packager/Composer.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace System\Classes\Packager;
+
+use System\Classes\Packager\Commands\RemoveCommand;
+use System\Classes\Packager\Commands\ShowCommand;
+use System\Classes\Packager\Commands\UpdateCommand;
+use System\Classes\Packager\Commands\RequireCommand;
+use Winter\Packager\Composer as PackagerComposer;
+
+/**
+ * @class Composer
+ * @method static i(): array
+ * @method static install(): array
+ * @method static search(string $query, ?string $type = null, bool $onlyNames = false, bool $onlyVendors = false): \Winter\Packager\Commands\Search
+ * @method static show(?string $mode = 'installed', string $package = null, bool $noDev = false, bool $path = false): object
+ * @method static update(bool $includeDev = true, bool $lockFileOnly = false, bool $ignorePlatformReqs = false, string $installPreference = 'none', bool $ignoreScripts = false, bool $dryRun = false, ?string $package = null): \Winter\Packager\Commands\Update
+ * @method static remove(?string $package = null, bool $dryRun = false): array
+ * @method static require(?string $package = null, bool $dryRun = false, bool $dev = false): array
+ * @method static version(string $detail = 'version'): array<string, string>|string
+ */
+class Composer
+{
+    public const COMPOSER_CACHE_KEY = 'winter.system.composer';
+
+    protected static PackagerComposer $composer;
+
+    public static function make(bool $fresh = false): PackagerComposer
+    {
+        if (!$fresh && isset(static::$composer)) {
+            return static::$composer;
+        }
+
+        static::$composer = new PackagerComposer();
+        static::$composer->setWorkDir(base_path());
+
+        static::$composer->setCommand('show', new ShowCommand(static::$composer));
+        static::$composer->setCommand('update', new UpdateCommand(static::$composer));
+        static::$composer->setCommand('remove', new RemoveCommand(static::$composer));
+        static::$composer->setCommand('require', new RequireCommand(static::$composer));
+
+        return static::$composer;
+    }
+
+    public static function __callStatic(string $name, array $args = []): mixed
+    {
+        if (!isset(static::$composer)) {
+            static::make();
+        }
+
+        return static::$composer->{$name}(...$args);
+    }
+}

--- a/modules/system/classes/packager/commands/RemoveCommand.php
+++ b/modules/system/classes/packager/commands/RemoveCommand.php
@@ -3,7 +3,7 @@
 namespace System\Classes\Packager\Commands;
 
 use Cache;
-use System\Classes\Packager\ComposerFactory;
+use System\Classes\Packager\Composer;
 use Winter\Packager\Commands\BaseCommand;
 use Winter\Packager\Exceptions\CommandException;
 
@@ -55,7 +55,7 @@ class RemoveCommand extends BaseCommand
             throw new CommandException($message);
         }
 
-        Cache::forget(ComposerFactory::COMPOSER_CACHE_KEY);
+        Cache::forget(Composer::COMPOSER_CACHE_KEY);
 
         return $message;
     }

--- a/modules/system/classes/packager/commands/RemoveCommand.php
+++ b/modules/system/classes/packager/commands/RemoveCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace System\Classes\Packager\Commands;
+
+use Cache;
+use System\Classes\Packager\ComposerFactory;
+use Winter\Packager\Commands\BaseCommand;
+use Winter\Packager\Exceptions\CommandException;
+
+class RemoveCommand extends BaseCommand
+{
+    protected ?string $package = null;
+    protected bool $dryRun = false;
+
+    /**
+     * Command handler.
+     *
+     * @param string|null $package
+     * @param boolean $dryRun
+     * @return void
+     * @throws CommandException
+     */
+    public function handle(?string $package = null, bool $dryRun = false): void
+    {
+        if (!$package) {
+            throw new CommandException('Must provide a package');
+        }
+
+        $this->package = $package;
+        $this->dryRun = $dryRun;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function arguments(): array
+    {
+        $arguments = [];
+
+        if ($this->dryRun) {
+            $arguments['--dry-run'] = true;
+        }
+
+        $arguments['packages'] = [$this->package];
+
+        return $arguments;
+    }
+
+    public function execute()
+    {
+        $output = $this->runComposerCommand();
+        $message = implode(PHP_EOL, $output['output']);
+
+        if ($output['code'] !== 0) {
+            throw new CommandException($message);
+        }
+
+        Cache::forget(ComposerFactory::COMPOSER_CACHE_KEY);
+
+        return $message;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCommandName(): string
+    {
+        return 'remove';
+    }
+}

--- a/modules/system/classes/packager/commands/RequireCommand.php
+++ b/modules/system/classes/packager/commands/RequireCommand.php
@@ -3,7 +3,7 @@
 namespace System\Classes\Packager\Commands;
 
 use Cache;
-use System\Classes\Packager\ComposerFactory;
+use System\Classes\Packager\Composer;
 use Winter\Packager\Commands\BaseCommand;
 use Winter\Packager\Exceptions\CommandException;
 
@@ -62,7 +62,7 @@ class RequireCommand extends BaseCommand
             throw new CommandException($message);
         }
 
-        Cache::forget(ComposerFactory::COMPOSER_CACHE_KEY);
+        Cache::forget(Composer::COMPOSER_CACHE_KEY);
 
         return $message;
     }

--- a/modules/system/classes/packager/commands/RequireCommand.php
+++ b/modules/system/classes/packager/commands/RequireCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace System\Classes\Packager\Commands;
+
+use Cache;
+use System\Classes\Packager\ComposerFactory;
+use Winter\Packager\Commands\BaseCommand;
+use Winter\Packager\Exceptions\CommandException;
+
+class RequireCommand extends BaseCommand
+{
+    protected ?string $package = null;
+    protected bool $dryRun = false;
+    protected bool $dev = false;
+
+    /**
+     * Command handler.
+     *
+     * @param string|null $package
+     * @param boolean $dryRun
+     * @param boolean $dev
+     * @return void
+     * @throws CommandException
+     */
+    public function handle(?string $package = null, bool $dryRun = false, bool $dev = false): void
+    {
+        if (!$package) {
+            throw new CommandException('Must provide a package');
+        }
+
+        $this->package = $package;
+        $this->dryRun = $dryRun;
+        $this->dev = $dev;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function arguments(): array
+    {
+        $arguments = [];
+
+        if ($this->dryRun) {
+            $arguments['--dry-run'] = true;
+        }
+
+        if ($this->dev) {
+            $arguments['--dev'] = true;
+        }
+
+        $arguments['packages'] = [$this->package];
+
+        return $arguments;
+    }
+
+    public function execute()
+    {
+        $output = $this->runComposerCommand();
+        $message = implode(PHP_EOL, $output['output']);
+
+        if ($output['code'] !== 0) {
+            throw new CommandException($message);
+        }
+
+        Cache::forget(ComposerFactory::COMPOSER_CACHE_KEY);
+
+        return $message;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCommandName(): string
+    {
+        return 'require';
+    }
+}

--- a/modules/system/classes/packager/commands/SearchCommand.php
+++ b/modules/system/classes/packager/commands/SearchCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace System\Classes\Packager\Commands;
+
+use Cache;
+use Winter\Packager\Commands\Search;
+use Winter\Packager\Exceptions\CommandException;
+
+class SearchCommand extends Search
+{
+    public function execute()
+    {
+        $output = $this->runComposerCommand();
+
+        if ($output['code'] !== 0) {
+            throw new CommandException(implode(PHP_EOL, $output['output']));
+        }
+
+        $this->results = json_decode(implode(PHP_EOL, $output['output']), true) ?? [];
+
+        return $this;
+    }
+}

--- a/modules/system/classes/packager/commands/ShowCommand.php
+++ b/modules/system/classes/packager/commands/ShowCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace System\Classes\Packager\Commands;
+
+use Winter\Packager\Commands\Show;
+use Winter\Packager\Exceptions\CommandException;
+
+class ShowCommand extends Show
+{
+    protected bool $path = false;
+
+    /**
+     * Command handler.
+     *
+     * The mode can be one of the following:
+     *  - `installed`: Show installed packages
+     *  - `locked`: Show locked packages
+     *  - `platform`: Show platform requirements
+     *  - `available`: Show all available packages
+     *  - `self`: Show the current package
+     *  - `path`: Show the package path
+     *  - `tree`: Show packages in a dependency tree
+     *  - `outdated`: Show only outdated packages
+     *  - `direct`: Show only direct dependencies
+     *
+     * @param string|null $mode
+     * @param string|null $package
+     * @param boolean $noDev
+     * @param boolean $path
+     * @return void
+     */
+    public function handle(?string $mode = 'installed', string $package = null, bool $noDev = false, bool $path = false): void
+    {
+        parent::handle($mode, $package, $noDev);
+
+        $this->path = $path;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function arguments(): array
+    {
+        $arguments = [];
+
+        if (!empty($this->package)) {
+            $arguments['package'] = $this->package;
+        }
+
+        if ($this->mode !== 'installed') {
+            $arguments['--' . $this->mode] = true;
+        }
+
+        if ($this->noDev) {
+            $arguments['--no-dev'] = true;
+        }
+
+        if ($this->path) {
+            $arguments['--path'] = true;
+        }
+
+        $arguments['--format'] = 'json';
+
+        return $arguments;
+    }
+}

--- a/modules/system/classes/packager/commands/UpdateCommand.php
+++ b/modules/system/classes/packager/commands/UpdateCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace System\Classes\Packager\Commands;
+
+use Cache;
+use System\Classes\Packager\ComposerFactory;
+use Winter\Packager\Commands\Update;
+
+class UpdateCommand extends Update
+{
+    protected ?string $package = null;
+
+    /**
+     * Handle options before execution.
+     *
+     * @param boolean $includeDev Include "require-dev" dependencies in the update.
+     * @param boolean $lockFileOnly Do a lockfile update only, do not install dependencies.
+     * @param boolean $ignorePlatformReqs Ignore platform reqs when running the update.
+     * @param string $installPreference Set an install preference - must be one of "none", "dist", "source"
+     * @param boolean $ignoreScripts Ignores scripts that run after Composer events.
+     * @return void
+     */
+    public function handle(
+        bool $includeDev = true,
+        bool $lockFileOnly = false,
+        bool $ignorePlatformReqs = false,
+        string $installPreference = 'none',
+        bool $ignoreScripts = false,
+        bool $dryRun = false,
+        ?string $package = null
+    ) {
+        if ($this->executed) {
+            return;
+        }
+
+        $this->includeDev = $includeDev;
+        $this->lockFileOnly = $lockFileOnly;
+        $this->ignorePlatformReqs = $ignorePlatformReqs;
+        $this->ignoreScripts = $ignoreScripts;
+        $this->dryRun = $dryRun;
+        $this->package = $package;
+
+        if (in_array($installPreference, [self::PREFER_NONE, self::PREFER_DIST, self::PREFER_SOURCE])) {
+            $this->installPreference = $installPreference;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function arguments(): array
+    {
+        $arguments = [];
+
+        if ($this->dryRun) {
+            $arguments['--dry-run'] = true;
+        }
+
+        if ($this->lockFileOnly) {
+            $arguments['--no-install'] = true;
+        }
+
+        if ($this->ignorePlatformReqs) {
+            $arguments['--ignore-platform-reqs'] = true;
+        }
+
+        if ($this->ignoreScripts) {
+            $arguments['--no-scripts'] = true;
+        }
+
+        if (in_array($this->installPreference, [self::PREFER_DIST, self::PREFER_SOURCE])) {
+            $arguments['--prefer-' . $this->installPreference] = true;
+        }
+
+        if ($this->package) {
+            $arguments['--'] = true;
+            $arguments[$this->package] = true;
+        }
+
+        return $arguments;
+    }
+
+    public function execute()
+    {
+        Cache::forget(ComposerFactory::COMPOSER_CACHE_KEY);
+        return parent::execute();
+    }
+}

--- a/modules/system/classes/packager/commands/UpdateCommand.php
+++ b/modules/system/classes/packager/commands/UpdateCommand.php
@@ -3,7 +3,7 @@
 namespace System\Classes\Packager\Commands;
 
 use Cache;
-use System\Classes\Packager\ComposerFactory;
+use System\Classes\Packager\Composer;
 use Winter\Packager\Commands\Update;
 
 class UpdateCommand extends Update
@@ -82,7 +82,7 @@ class UpdateCommand extends Update
 
     public function execute()
     {
-        Cache::forget(ComposerFactory::COMPOSER_CACHE_KEY);
+        Cache::forget(Composer::COMPOSER_CACHE_KEY);
         return parent::execute();
     }
 }

--- a/modules/system/console/PluginList.php
+++ b/modules/system/console/PluginList.php
@@ -2,6 +2,7 @@
 
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
+use System\Classes\PluginManager;
 use System\Models\PluginVersion;
 use Winter\Storm\Console\Command;
 
@@ -34,24 +35,25 @@ class PluginList extends Command
      */
     public function handle()
     {
-        $allPlugins  = PluginVersion::all();
-        $pluginsCount = count($allPlugins);
+        $plugins = PluginManager::instance()->getAllPlugins();
+        $pluginVersions = PluginVersion::all()->keyBy('code');
 
-        if ($pluginsCount <= 0) {
+        if (count($plugins) <= 0) {
             $this->info('No plugin found');
             return;
         }
 
         $rows = [];
-        foreach ($allPlugins as $plugin) {
+        foreach ($plugins as $plugin) {
             $rows[] = [
-                $plugin->code,
-                $plugin->version,
-                (!$plugin->is_frozen) ? '<info>Yes</info>': '<fg=red>No</>',
-                (!$plugin->is_disabled) ? '<info>Yes</info>': '<fg=red>No</>',
+                $plugin->getPluginIdentifier(),
+                $plugin->package,
+                $plugin->getPluginVersion(),
+                (!$pluginVersions[$plugin->getPluginIdentifier()]->is_frozen) ? '<info>Yes</info>': '<fg=red>No</>',
+                (!$pluginVersions[$plugin->getPluginIdentifier()]->is_disabled) ? '<info>Yes</info>': '<fg=red>No</>',
             ];
         }
 
-        $this->table(['Plugin name', 'Version', 'Updates enabled', 'Plugin enabled'], $rows);
+        $this->table(['Plugin name', 'Composer Package', 'Version', 'Updates enabled', 'Plugin enabled'], $rows);
     }
 }

--- a/modules/system/console/PluginRemove.php
+++ b/modules/system/console/PluginRemove.php
@@ -1,6 +1,7 @@
 <?php namespace System\Console;
 
 use File;
+use System\Classes\Packager\Composer;
 use Winter\Storm\Console\Command;
 use System\Classes\UpdateManager;
 use System\Classes\PluginManager;
@@ -68,6 +69,17 @@ class PluginRemove extends Command
             */
             $manager = UpdateManager::instance()->setNotesOutput($this->output);
             $manager->rollbackPlugin($pluginName);
+        }
+
+        $plugin = $pluginManager->findByIdentifier($pluginName);
+
+        /**
+         * Uninstall composer package
+         */
+        if ($package = $plugin->getComposerPackageName()) {
+            $this->output->writeln(sprintf('<info>Removing composer package: %s</info>', $package));
+            $this->output->write(Composer::remove($package) . PHP_EOL);
+            return 0;
         }
 
         /*


### PR DESCRIPTION
This is very much a WIP, the idea is to fully support plugin management via Composer.

So far I've added the usage to `plugin:list`, see:
![image](https://github.com/wintercms/winter/assets/31214002/497226dd-ac8d-43da-bf39-0fcdfaad0b73)

> Notice: you'll need to manually install `winter/packager` as I've not commit my `composer.json` as it's a mess

### TODO:
- [x] Add better support for package detection which isn't super slow, see: https://github.com/wintercms/winter/pull/967/files#diff-cb5276616360a228a987825e5c85cd0b545d8be4eca49a9f4bf534d413bb7987R131
- [x] Formalise a internal format for composer packages, i.e. an object consumed by a plugin during registration which can be used by the rest of the system.
- [x] Speed improvements, without caching it's currently taking ~10s per page load due to having to manually scrape package types and run multiple `show` commands.
- [ ] Add support for displaying when a package has a upgrade that can be performed.
- [ ] Either merge or properly handle the `\System\Classes\Packager\Composer` as it's currently just overriding the `Composer` class provided by `winter/packager`.
- [ ] Add support for the following commands
    - [x] PluginInstall
    - [ ] PluginRefresh
    - [x] PluginRemove
    - [ ] PluginRollback
    - [x] PluginList

