### PR TITLE
Share variables shared via View::share() with Twig templates

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -324,10 +324,9 @@ class Controller
          */
         $globalVars = ViewHelper::getGlobalVars();
         if (!empty($globalVars)) {
-            $specified = array_keys($this->getTwig()->getGlobals());
-
+            $existingGlobals = array_keys($this->getTwig()->getGlobals());
             foreach ($globalVars as $key => $value) {
-                if (!in_array($key, $specified)) {
+                if (!in_array($key, $existingGlobals)) {
                     $this->getTwig()->addGlobal($key, $value);
                 }
             }

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -320,6 +320,20 @@ class Controller
         ]);
 
         /*
+         * Add global vars defined by View::share() into Twig, only if they have yet to be specified.
+         */
+        $globalVars = ViewHelper::getGlobalVars();
+        if (!empty($globalVars)) {
+            $specified = array_keys($this->getTwig()->getGlobals());
+
+            foreach ($globalVars as $key => $value) {
+                if (!in_array($key, $specified)) {
+                    $this->getTwig()->addGlobal($key, $value);
+                }
+            }
+        }
+
+        /*
          * Check for the presence of validation errors in the session.
          */
         $this->vars['errors'] = (Config::get('session.driver') && Session::has('errors'))

--- a/modules/cms/tests/classes/CmsObjectQueryTest.php
+++ b/modules/cms/tests/classes/CmsObjectQueryTest.php
@@ -84,6 +84,8 @@ class CmsObjectQueryTest extends TestCase
             "no-soft-component-class",
             "optional-full-php-tags",
             "optional-short-php-tags",
+            "shared-variable",
+            "shared-variable-override",
             "throw-php",
             "with-component",
             "with-components",

--- a/modules/cms/tests/fixtures/themes/test/pages/shared-variable-override.htm
+++ b/modules/cms/tests/fixtures/themes/test/pages/shared-variable-override.htm
@@ -1,0 +1,10 @@
+url = '/shared-variable-override'
+==
+<?php
+function onStart() {
+    $this['winterStatus'] = 'Is Coming';
+}
+==
+<p>Winter {{ winterStatus }}</p>
+
+<p>{{ this.page.url }}</p>

--- a/modules/cms/tests/fixtures/themes/test/pages/shared-variable.htm
+++ b/modules/cms/tests/fixtures/themes/test/pages/shared-variable.htm
@@ -1,0 +1,5 @@
+url = '/shared-variable'
+==
+<p>Winter {{ winterStatus }}</p>
+
+<p>{{ this.page.url }}</p>

--- a/modules/system/helpers/View.php
+++ b/modules/system/helpers/View.php
@@ -37,4 +37,14 @@ class View
 
         return static::$globalVarCache = $vars;
     }
+
+    /**
+     * Clears the static cache for global variables.
+     *
+     * @return void
+     */
+    public static function clearVarCache()
+    {
+        static::$globalVarCache = null;
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/wintercms/winter/issues/630

This allows global variables populated by the `View::share('name', 'value')` method to be used in Twig templates. The values will only be populated if they have not been specified as a global previously, to prevent overriding system globals such as `this.page`. It will also allow the pages themselves to still override the values if need be.