### PR TITLE
Hide toolbar when no content available

### DIFF
--- a/modules/backend/widgets/toolbar/partials/_toolbar.php
+++ b/modules/backend/widgets/toolbar/partials/_toolbar.php
@@ -1,17 +1,21 @@
+<?php if ($controlPanel || $search): ?>
 <div class="toolbar-widget <?= $cssClasses ?>" id="<?= $this->getId() ?>">
     <div class="control-toolbar">
 
+    <?php if ($controlPanel): ?>
         <!-- Control Panel -->
         <div class="toolbar-item toolbar-primary">
-            <?= ($controlPanel) ?: '&nbsp;' ?>
+            <?= ($controlPanel) ?>
         </div>
+    <?php endif ?>
 
+    <?php if ($search): ?>
         <!-- List Search -->
-        <?php if ($search): ?>
-            <div class="toolbar-item" data-calculate-width>
-                <?= $search ?>
-            </div>
-        <?php endif ?>
+        <div class="toolbar-item" data-calculate-width>
+            <?= $search ?>
+        </div>
+    <?php endif ?>
 
     </div>
 </div>
+<?php endif ?>


### PR DESCRIPTION
This PR gives more flexibility to the Toolbar widget by hiding missing sections completely or hiding the whole Toolbar if neither the controlPanel nor the search sections are defined.

So, for example, if no buttons are defined for the toolbar but a search is defined, it would look something like this:
![image](https://github.com/wintercms/winter/assets/2013630/bcfdad1e-3714-47d2-99ce-95930d914016)

If both are defined, it looks like this (current behavior):
![image](https://github.com/wintercms/winter/assets/2013630/2f595eb9-9998-4a75-b580-f9918981d47d)

And if none are defined:
![image](https://github.com/wintercms/winter/assets/2013630/6a9dbdd1-9896-47ec-a37a-d26c1db5bbc4)
