### PR TITLE
Save / Restore initial list showTree config value

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -1489,10 +1489,19 @@ class Lists extends WidgetBase
     public function setSearchTerm($term, $resetPagination = false)
     {
         if (
-            strlen($this->searchTerm) !== 0
-            && trim($this->searchTerm) !== ''
+            strlen($term) !== 0
+            && trim($term) !== ''
         ) {
+            if ($this->showTree === true) {
+                // save initial list config showTree value
+                $this->putSession('showTree', true);
+            }
             $this->showTree = false;
+        } else {
+            if ($this->getSession('showTree')) {
+                // restore initial list config showTree value
+                $this->showTree = true;
+            }
         }
 
         if ($resetPagination) {


### PR DESCRIPTION
Without this, Lists with showTree=true lose their Tree view when the search term is cleared.

This can easily be reproduced in the Winter.Test plugin under the Trees controller.