### PR TITLE
Fix install error for some paths

### DIFF
--- a/modules/system/classes/FileManifest.php
+++ b/modules/system/classes/FileManifest.php
@@ -166,7 +166,7 @@ class FileManifest
      */
     protected function getFilename(string $file): string
     {
-        return str_replace($this->root, '', $file);
+        return substr($file, strlen($this->root));
     }
 
     /**

--- a/modules/system/tests/classes/FileManifestTest.php
+++ b/modules/system/tests/classes/FileManifestTest.php
@@ -73,6 +73,6 @@ class FileManifestTest extends TestCase
         $class = new ReflectionClass('System\Classes\FileManifest');
         $method = $class->getMethod('getFilename');
 
-        $this->assertEquals('/test', $method->invoke($fileManifest, '/test/test'));
+        $this->assertEquals('/test', $method->invoke($fileManifest, '/modules/test/file1.php'));
     }
 }

--- a/modules/system/tests/classes/FileManifestTest.php
+++ b/modules/system/tests/classes/FileManifestTest.php
@@ -13,14 +13,15 @@ class FileManifestTest extends TestCase
     /** @var FileManifest instance */
     protected $fileManifest;
 
+    /** @var root path */
+    protected $root;
+
     public function setUp(): void
     {
         parent::setUp();
 
-        $this->fileManifest = new FileManifest(
-            base_path('modules/system/tests/fixtures/manifest/1_0_1'),
-            ['test', 'test2']
-        );
+        $this->root = base_path('modules/system/tests/fixtures/manifest/1_0_1');
+        $this->fileManifest = new FileManifest($this->root, ['test', 'test2']);
     }
 
     public function testGetFiles()
@@ -66,13 +67,11 @@ class FileManifestTest extends TestCase
 
     public function testGetFilename()
     {
-        link(base_path('modules/system/tests/fixtures/manifest/1_0_1'), '/test');
-
-        $fileManifest = new FileManifest('/test', ['test', 'test2']);
-
         $class = new ReflectionClass('System\Classes\FileManifest');
         $method = $class->getMethod('getFilename');
 
-        $this->assertEquals('/test', $method->invoke($fileManifest, '/modules/test/file1.php'));
+        $filename = '/modules/test/file1.php';
+
+        $this->assertEquals($filename, $method->invoke($this->fileManifest, $this->root . $filename));
     }
 }

--- a/modules/system/tests/classes/FileManifestTest.php
+++ b/modules/system/tests/classes/FileManifestTest.php
@@ -2,6 +2,8 @@
 
 namespace System\Tests\Classes;
 
+use ReflectionClass;
+
 use System\Tests\Bootstrap\TestCase;
 use Winter\Storm\Exception\ApplicationException;
 use System\Classes\FileManifest;
@@ -60,5 +62,17 @@ class FileManifestTest extends TestCase
         $this->assertEquals([
             'test' => 'c0b794ff210862a4ce16223802efe6e28969f5a4fb42480ec8c2fef2da23d181',
         ], $this->fileManifest->getModuleChecksums());
+    }
+
+    public function testGetFilename()
+    {
+        link(base_path('modules/system/tests/fixtures/manifest/1_0_1'), '/test');
+
+        $fileManifest = new FileManifest('/test', ['test', 'test2']);
+
+        $class = new ReflectionClass('System\Classes\FileManifest');
+        $method = $class->getMethod('getFilename');
+
+        $this->assertEquals('/test', $method->invoke($fileManifest, '/test/test'));
     }
 }

--- a/modules/system/tests/classes/FileManifestTest.php
+++ b/modules/system/tests/classes/FileManifestTest.php
@@ -69,6 +69,7 @@ class FileManifestTest extends TestCase
     {
         $class = new ReflectionClass('System\Classes\FileManifest');
         $method = $class->getMethod('getFilename');
+        $method->setAccessible(true);
 
         $filename = '/modules/test/file1.php';
 


### PR DESCRIPTION
Instead of `str_replace`, which may, instead of truncating lead directory from the path, replace some random inner part of it, use `substr` to remove it.