### PR TITLE
Fix issue when page has no components

### DIFF
--- a/modules/cms/classes/CmsCompoundObject.php
+++ b/modules/cms/classes/CmsCompoundObject.php
@@ -294,6 +294,8 @@ class CmsCompoundObject extends CmsObject
             }
 
             return [];
+        } else {
+            $objectComponentMap[$objectCode] = [];
         }
 
         if (!isset($this->settings['components'])) {


### PR DESCRIPTION
This bug triggered for a page that used the `blogPost` component and its `categoryPage` referenced a page that had no components assigned.

An error got triggered on line 329, trying to access a non-existent index in the `$objectComponentMap` array;

```php
if (array_key_exists($componentName, $objectComponentMap[$objectCode])) {
```

This PR makes sure the array is initialized.