### PR TITLE
Use temporary rewriting of curly brackets when rendering Markdown content blocks

### DIFF
--- a/modules/cms/classes/Content.php
+++ b/modules/cms/classes/Content.php
@@ -78,9 +78,6 @@ class Content extends CmsCompoundObject
      *
      * This method replaces curly variables in the content temporarily while Markdown rendering takes place, to
      * circumvent the escaping that Commonmark does on curly brackets in links.
-     *
-     * @param string $markup
-     * @return string
      */
     protected function parseMarkdownMarkup(string $markup): string
     {

--- a/modules/cms/classes/Content.php
+++ b/modules/cms/classes/Content.php
@@ -1,7 +1,9 @@
-<?php namespace Cms\Classes;
+<?php
 
-use File;
-use Markdown;
+namespace Cms\Classes;
+
+use Winter\Storm\Support\Facades\File;
+use Winter\Storm\Support\Facades\Markdown;
 
 /**
  * The CMS content file class.
@@ -62,12 +64,46 @@ class Content extends CmsCompoundObject
                 $result = htmlspecialchars($this->markup);
                 break;
             case 'md':
-                $result = Markdown::parse($this->markup);
+                $result = $this->parseMarkdownMarkup($this->markup);
                 break;
             default:
                 $result = $this->markup;
         }
 
         return $result;
+    }
+
+    /**
+     * Parse Markdown content files.
+     *
+     * This method replaces curly variables in the content temporarily while Markdown rendering takes place, to
+     * circumvent the escaping that Commonmark does on curly brackets in links.
+     *
+     * @param string $markup
+     * @return string
+     */
+    protected function parseMarkdownMarkup(string $markup): string
+    {
+        /**
+         * Replace variables temporarily for Markdown parsing, as the Commonmark library escapes curly brackets in
+         * links.
+         * @see https://github.com/wintercms/winter/issues/992
+         */
+        $variables = [];
+        $markup = preg_replace_callback('/\{([^\n \}]+)\}/', function (array $matches) use (&$variables) {
+            $signature = hash('sha256', $matches[1]);
+            if (!array_key_exists($signature, $variables)) {
+                $variables[$signature] = $matches[1];
+            }
+            return ".=VAR={$signature}=.";
+        }, $markup);
+
+        $markup = Markdown::parse($markup);
+
+        foreach ($variables as $signature => $variable) {
+            $markup = str_replace(".=VAR={$signature}=.", "{{$variable}}", $markup);
+        }
+
+        return $markup;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/wintercms/winter/issues/992

The new Markdown parser (CommonMark) applies some escaping logic for links and some HTML attributes. This prevents the curly bracket variables working in these, as they are escaped upon parsing. Since the Commonmark library is very much locked down with `final` classes and the like, we can't directly override this behaviour, so this is the next best thing (although feels kinda dirty).

This replaces the curly brackets with another placeholder while the Markdown parsing takes place and then switches it back to curly brackets afterwards. The characters chosen should be safe from being parsed, I believe. It should also ensure that the curly brackets are still cached as it was with the previous behaviour.