### PR TITLE
Proper handling of Ajax exceptions

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -13,7 +13,7 @@ use Config;
 use Session;
 use Request;
 use Response;
-use Exception;
+use Throwable;
 use SystemException;
 use BackendAuth;
 use Twig\Environment as TwigEnvironment;
@@ -778,8 +778,8 @@ class Controller
                 $responseContents['X_WINTER_ERROR_MESSAGE'] = $ex->getMessage();
                 throw new AjaxException($responseContents);
             }
-            catch (Exception $ex) {
-                throw $ex;
+            catch (Throwable $ex) {
+                throw new SystemException(Lang::get('cms::lang.ajax_handler.error_occurred'), previous: $ex);
             }
         }
 

--- a/modules/cms/lang/en/lang.php
+++ b/modules/cms/lang/en/lang.php
@@ -169,6 +169,7 @@ return [
     'ajax_handler' => [
         'invalid_name' => 'Invalid AJAX handler name: :name.',
         'not_found' => "AJAX handler ':name' was not found.",
+        'error_occurred' => 'An error occurred while executing the AJAX handler.',
     ],
     'cms' => [
         'menu_label' => 'CMS',


### PR DESCRIPTION
Unhandled exceptions in Ajax handlers are currently relayed back to the user. Since they can potentially contain sensitive details about the system, such as absolute file paths, these exceptions should be properly masked.

Depends on https://github.com/wintercms/storm/pull/160.