### PR TITLE
Change 'save' to 'confirm'

### DIFF
--- a/modules/backend/formwidgets/fileupload/partials/_config_form.php
+++ b/modules/backend/formwidgets/fileupload/partials/_config_form.php
@@ -32,7 +32,7 @@
                 class="btn btn-primary"
                 data-request="<?= $this->getEventHandler('onSaveAttachmentConfig') ?>"
                 data-popup-load-indicator>
-                <?= e(trans('backend::lang.form.save')) ?>
+                <?= e(trans('backend::lang.form.confirm')) ?>
             </button>
             <button
                 type="button"


### PR DESCRIPTION
The uploaded image isn't being saved, but the title and description are added.
This is confusing because it doesn't save/upload the image even though the button says 'save'.

My collegues tought it 'saves' the image as well but their work is gone because they didn't press the actual form submit button. What do you think?

Once the image is actually saved/uploaded, it does edit the title and you don't have to submit the form anymore.
But if the image isn't saved/uploaded, adding the title/description does NOT save/upload the image, which is why I think the button shouldn't be labeled 'save' (or it should save/upload the image)

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->