### PR TITLE
Remove unnecessary text-align override on btn class

### DIFF
--- a/modules/system/assets/ui/less/button.less
+++ b/modules/system/assets/ui/less/button.less
@@ -17,7 +17,6 @@
 
 .btn {
     font-size: @font-size-base - 1;
-    text-align: left;
     outline: none !important;
     .box-shadow(~"inset 0 -2px 0 rgba(0,0,0,.15)");
 

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -874,7 +874,7 @@ input[type="button"].btn-block{width:100%}
 .btn-group-justified>.btn-group .btn{width:100%}
 [data-toggle="buttons"]>.btn>input[type="radio"],
 [data-toggle="buttons"]>.btn>input[type="checkbox"]{display:none}
-.btn{font-size:13px;text-align:left;outline:none !important;-webkit-box-shadow:inset 0 -2px 0 rgba(0,0,0,.15);box-shadow:inset 0 -2px 0 rgba(0,0,0,.15)}
+.btn{font-size:13px;outline:none !important;-webkit-box-shadow:inset 0 -2px 0 rgba(0,0,0,.15);box-shadow:inset 0 -2px 0 rgba(0,0,0,.15)}
 .btn[disabled]{color:rgba(255,255,255,0.6)}
 .btn.active,
 .btn:active{-webkit-box-shadow:inset 0 1px 0 rgba(0,0,0,0.3);box-shadow:inset 0 1px 0 rgba(0,0,0,0.3)}


### PR DESCRIPTION
I insert
```html
<button type="button" class="btn btn-primary btn-lg btn-block">Block level button</button>
<button type="button" class="btn btn-default btn-lg btn-block">Block level button</button>
```

Result:
![2023-12-08_032127](https://github.com/wintercms/winter/assets/61043464/7e722b1e-b0bc-420d-a2c9-0e9ffed87d58)

Removed property overrides
```css
text-align: center;
```

The correct value of the property is written here: https://github.com/wintercms/winter/blob/78af271c2e34372f81bd481f3e21406b1fed8350/modules/system/assets/ui/storm.css#L475C16-L475C16

Less file: https://github.com/wintercms/winter/blob/78af271c2e34372f81bd481f3e21406b1fed8350/modules/system/assets/ui/less/button.base.less#L9