### PR TITLE
Recalculate the sort order values when sorting from the backend.

### DIFF
--- a/modules/backend/behaviors/reordercontroller/assets/js/winter.reorder.js
+++ b/modules/backend/behaviors/reordercontroller/assets/js/winter.reorder.js
@@ -69,8 +69,8 @@
         this.initSortingSimple = function () {
             var sortOrders = []
 
-            $('#reorderTreeList li').each(function(){
-                sortOrders.push($(this).data('recordSortOrder'))
+            $('#reorderTreeList li').each(function(i) {
+                sortOrders.push(i);
             })
 
             this.simpleSortOrders = sortOrders


### PR DESCRIPTION
Supersedes #882 - This PR is so the changes can be merged into dev / 1.2 rather than the 1.1 branch.

Re-calculate new sort order values to resolve an issue with duplicate sort order values causing records not to be sorted correctly.