### PR TITLE
Removes <p> tag inside of email button partial

### DIFF
--- a/modules/system/views/mail/partial-button.php
+++ b/modules/system/views/mail/partial-button.php
@@ -11,9 +11,7 @@ name = "Button"
                         <table border="0" cellpadding="0" cellspacing="0">
                             <tr>
                                 <td>
-                                    <a href="{{ url }}" class="button button-{{ type ?: 'primary' }}" target="_blank">
-                                        {{ body }}
-                                    </a>
+                                    <a href="{{ url }}" class="button button-{{ type ?: 'primary' }}" target="_blank">{{ body }}</a>
                                 </td>
                             </tr>
                         </table>


### PR DESCRIPTION
A minor update to remove an extra `<p>` tag that is rendered inside of email button partials.  This is due to the fact that the markdown parser considers the line-break the start of a paragraph and so inserts one into the html when rendering the mail template.

![image](https://github.com/wintercms/winter/assets/4382816/2bdfd035-cd98-43be-93d2-f3be4ecd4125)

![Screenshot 2024-02-21 at 3 28 50 PM](https://github.com/wintercms/winter/assets/4382816/5c548de1-ef60-485e-a7ba-e2c69a55278c)

