### PR TITLE
Add disabled state styling for switch fields

### DIFF
--- a/modules/backend/widgets/form/partials/_field_switch.php
+++ b/modules/backend/widgets/form/partials/_field_switch.php
@@ -9,28 +9,29 @@ $off = isset($field->config['off']) ? $field->config['off'] : 'backend::lang.for
 ?>
 
 <!-- Switch -->
-<div class="field-switch">
-    <label for="<?= $field->getId() ?>"><?= e(trans($field->label)) ?></label>
-    <?php if ($field->comment): ?>
-        <p class="help-block"><?= $field->commentHtml ? trans($field->comment) : e(trans($field->comment)) ?></p>
-    <?php endif ?>
-</div>
+<div class="<?= $previewMode ? 'disabled' : '' ?>">
+    <div class="field-switch">
+        <label for="<?= $field->getId() ?>"><?= e(trans($field->label)) ?></label>
+        <?php if ($field->comment): ?>
+            <p class="help-block"><?= $field->commentHtml ? trans($field->comment) : e(trans($field->comment)) ?></p>
+        <?php endif ?>
+    </div>
 
-<input
-    type="hidden"
-    name="<?= $field->getName() ?>"
-    value="0"
-    <?= $previewMode ? 'disabled="disabled"' : '' ?>>
-
-<label class="custom-switch" <?= $previewMode ? 'onclick="return false"' : '' ?>>
     <input
-        type="checkbox"
-        id="<?= $field->getId() ?>"
+        type="hidden"
         name="<?= $field->getName() ?>"
-        value="1"
-        <?= $previewMode ? 'readonly="readonly"' : '' ?>
-        <?= $field->value == 1 ? 'checked="checked"' : '' ?>
-        <?= $field->getAttributes() ?>>
-    <span><span><?= e(trans($on)) ?></span><span><?= e(trans($off)) ?></span></span>
-    <a class="slide-button"></a>
-</label>
+        value="0">
+
+    <label class="custom-switch" <?= $previewMode ? 'onclick="return false"' : '' ?>>
+        <input
+            type="checkbox"
+            id="<?= $field->getId() ?>"
+            name="<?= $field->getName() ?>"
+            value="1"
+            <?= $previewMode ? 'readonly="readonly"' : '' ?>
+            <?= $field->value == 1 ? 'checked="checked"' : '' ?>
+            <?= $field->getAttributes() ?>>
+        <span><span><?= e(trans($on)) ?></span><span><?= e(trans($off)) ?></span></span>
+        <a class="slide-button"></a>
+    </label>
+</div>

--- a/modules/backend/widgets/form/partials/_field_switch.php
+++ b/modules/backend/widgets/form/partials/_field_switch.php
@@ -20,7 +20,8 @@ $off = isset($field->config['off']) ? $field->config['off'] : 'backend::lang.for
     <input
         type="hidden"
         name="<?= $field->getName() ?>"
-        value="0">
+        value="0"
+        <?= $previewMode ? 'disabled="disabled"' : '' ?>>
 
     <label class="custom-switch" <?= $previewMode ? 'onclick="return false"' : '' ?>>
         <input

--- a/modules/system/assets/ui/less/checkbox.less
+++ b/modules/system/assets/ui/less/checkbox.less
@@ -211,6 +211,10 @@
 //
 
 .switch-field {
+    .disabled {
+        opacity: .5;
+    }
+    
     .field-switch {
         padding-left: 85px;
         float: left;

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -874,7 +874,7 @@ input[type="button"].btn-block{width:100%}
 .btn-group-justified>.btn-group .btn{width:100%}
 [data-toggle="buttons"]>.btn>input[type="radio"],
 [data-toggle="buttons"]>.btn>input[type="checkbox"]{display:none}
-.btn{font-size:13px;text-align:left;outline:none !important;-webkit-box-shadow:inset 0 -2px 0 rgba(0,0,0,.15);box-shadow:inset 0 -2px 0 rgba(0,0,0,.15)}
+.btn{font-size:13px;outline:none !important;-webkit-box-shadow:inset 0 -2px 0 rgba(0,0,0,.15);box-shadow:inset 0 -2px 0 rgba(0,0,0,.15)}
 .btn[disabled]{color:rgba(255,255,255,0.6)}
 .btn.active,
 .btn:active{-webkit-box-shadow:inset 0 1px 0 rgba(0,0,0,0.3);box-shadow:inset 0 1px 0 rgba(0,0,0,0.3)}

--- a/modules/system/assets/ui/storm.css
+++ b/modules/system/assets/ui/storm.css
@@ -874,7 +874,7 @@ input[type="button"].btn-block{width:100%}
 .btn-group-justified>.btn-group .btn{width:100%}
 [data-toggle="buttons"]>.btn>input[type="radio"],
 [data-toggle="buttons"]>.btn>input[type="checkbox"]{display:none}
-.btn{font-size:13px;outline:none !important;-webkit-box-shadow:inset 0 -2px 0 rgba(0,0,0,.15);box-shadow:inset 0 -2px 0 rgba(0,0,0,.15)}
+.btn{font-size:13px;text-align:left;outline:none !important;-webkit-box-shadow:inset 0 -2px 0 rgba(0,0,0,.15);box-shadow:inset 0 -2px 0 rgba(0,0,0,.15)}
 .btn[disabled]{color:rgba(255,255,255,0.6)}
 .btn.active,
 .btn:active{-webkit-box-shadow:inset 0 1px 0 rgba(0,0,0,0.3);box-shadow:inset 0 1px 0 rgba(0,0,0,0.3)}
@@ -2837,6 +2837,7 @@ html.cssanimations .cursor-loading-indicator.hide{display:none}
 .inline-options .field-checkboxlist-inner .custom-checkbox label:before{top:10px}
 .inline-options.radio-field>label{display:block}
 .inline-options.radio-field .custom-radio{display:inline-block;margin-bottom:0}
+.switch-field .disabled{opacity:.5;}
 .switch-field .field-switch{padding-left:85px;float:left}
 .switch-field .field-switch>label{margin-top:3px}
 .custom-switch{display:block;width:65px;height:26px;position:relative;text-transform:uppercase;border:none;cursor:pointer;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}


### PR DESCRIPTION
Currently has 1 opacity. Needs 0.5 for default WinterCMS disabled state

Before
![image](https://github.com/wintercms/winter/assets/89913092/760e0b16-ada8-48d7-ba20-bce1b400e218)

After
![image](https://github.com/wintercms/winter/assets/89913092/c2ed9eb6-b2fb-4f1c-b0ca-ee92cc6acfa9)