### PR TITLE
Make `twig.environment.cms` singleton

### DIFF
--- a/modules/cms/ServiceProvider.php
+++ b/modules/cms/ServiceProvider.php
@@ -90,7 +90,7 @@ class ServiceProvider extends ModuleServiceProvider
     protected function registerTwigParser()
     {
         // Register CMS Twig environment
-        $this->app->bind('twig.environment.cms', function ($app) {
+        $this->app->singleton('twig.environment.cms', function ($app) {
             // Load Twig options
             $useCache = !Config::get('cms.twigNoCache');
             $isDebugMode = Config::get('app.debug', false);


### PR DESCRIPTION
https://github.com/wintercms/winter/blob/d9ff4e0fca3a92b0bae995637130c33abd200370/modules/system/ServiceProvider.php#L322

https://github.com/wintercms/winter/blob/d9ff4e0fca3a92b0bae995637130c33abd200370/modules/system/ServiceProvider.php#L327

Is there any reason why it is not a singleton like the other environments?