### PR TITLE
Restore original md filter behavior for null content

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -218,9 +218,15 @@ class ServiceProvider extends ModuleServiceProvider
                 'studly'         => ['Str', 'studly'],
                 'trans'          => ['Lang', 'get'],
                 'transchoice'    => ['Lang', 'choice'],
-                'md'             => ['Markdown', 'parse'],
-                'md_safe'        => ['Markdown', 'parseSafe'],
-                'md_line'        => ['Markdown', 'parseLine'],
+                'md'             => function($value) {
+                    return $value ? Markdown::parse($value) : null;
+                },
+                'md_safe'        => function($value) {
+                    return $value ? Markdown::parseSafe($value) : null;
+                },
+                'md_line'        => function($value) {
+                    return $value ? Markdown::parseLine($value) : null;
+                },
                 'time_since'     => ['System\Helpers\DateTime', 'timeSince'],
                 'time_tense'     => ['System\Helpers\DateTime', 'timeTense'],
             ]);

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -219,13 +219,13 @@ class ServiceProvider extends ModuleServiceProvider
                 'trans'          => ['Lang', 'get'],
                 'transchoice'    => ['Lang', 'choice'],
                 'md'             => function($value) {
-                    return $value ? Markdown::parse($value) : null;
+                    return (is_string($value) && $value !== '') ? Markdown::parse($value) : '';
                 },
                 'md_safe'        => function($value) {
-                    return $value ? Markdown::parseSafe($value) : null;
+                    return (is_string($value) && $value !== '') ? Markdown::parseSafe($value) : '';
                 },
                 'md_line'        => function($value) {
-                    return $value ? Markdown::parseLine($value) : null;
+                    return (is_string($value) && $value !== '') ? Markdown::parseLine($value) : '';
                 },
                 'time_since'     => ['System\Helpers\DateTime', 'timeSince'],
                 'time_tense'     => ['System\Helpers\DateTime', 'timeTense'],

--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -218,13 +218,13 @@ class ServiceProvider extends ModuleServiceProvider
                 'studly'         => ['Str', 'studly'],
                 'trans'          => ['Lang', 'get'],
                 'transchoice'    => ['Lang', 'choice'],
-                'md'             => function($value) {
+                'md'             => function ($value) {
                     return (is_string($value) && $value !== '') ? Markdown::parse($value) : '';
                 },
-                'md_safe'        => function($value) {
+                'md_safe'        => function ($value) {
                     return (is_string($value) && $value !== '') ? Markdown::parseSafe($value) : '';
                 },
-                'md_line'        => function($value) {
+                'md_line'        => function ($value) {
                     return (is_string($value) && $value !== '') ? Markdown::parseLine($value) : '';
                 },
                 'time_since'     => ['System\Helpers\DateTime', 'timeSince'],


### PR DESCRIPTION
This used to work:
```twig
{% set content = null %}

{{ content | md }}
```

Since Markdown::parse() method signature was changed we need to sanitize the content passed to `md`:
```twig
{% set content = null %}
{{ content | default('') | md }}
```
This potentially broke a lot of legacy templates.

This PR restore the previous behavior.