### PR TITLE
Do not activate .env.example on project creation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,9 +46,6 @@
         "dms/phpunit-arraysubset-asserts": "^0.1.0|^0.2.1"
     },
     "scripts": {
-        "post-root-package-install": [
-            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
-        ],
         "post-create-project-cmd": [
             "@php artisan key:generate"
         ],


### PR DESCRIPTION
Fix #1060