### PR TITLE
Add --no-progress and --json options to mix:compile and mix:list

### DIFF
--- a/modules/system/console/MixCompile.php
+++ b/modules/system/console/MixCompile.php
@@ -227,8 +227,8 @@ class MixCompile extends Command
         $fixture = File::get(__DIR__ . '/fixtures/mix.webpack.js.fixture');
 
         $config = str_replace(
-            ['%base%', '%notificationInject%', '%mixConfigPath%', '%pluginsPath%', '%appPath%', '%silent%'],
-            [addslashes($basePath), 'mix._api.disableNotifications();', addslashes($mixJsPath), addslashes(plugins_path()), addslashes(base_path()), (int) ($this->option('silent') || $this->option('no-progress'))],
+            ['%base%', '%notificationInject%', '%mixConfigPath%', '%pluginsPath%', '%appPath%', '%silent%', '%noProgress%'],
+            [addslashes($basePath), 'mix._api.disableNotifications();', addslashes($mixJsPath), addslashes(plugins_path()), addslashes(base_path()), (int) $this->option('silent'), (int) $this->option('no-progress')],
             $fixture
         );
 

--- a/modules/system/console/MixCompile.php
+++ b/modules/system/console/MixCompile.php
@@ -102,7 +102,7 @@ class MixCompile extends Command
                 continue;
             }
 
-            if (!$this->option('no-progress')) {
+            if (!$this->option('silent')) {
                 $this->info(sprintf('Mixing package "%s"', $name));
             }
 

--- a/modules/system/console/MixCompile.php
+++ b/modules/system/console/MixCompile.php
@@ -22,7 +22,8 @@ class MixCompile extends Command
         {--s|silent : Silent mode}
         {--e|stop-on-error : Exit once an error is encountered}
         {--m|manifest= : Defines package.json to use for compile}
-        {--p|package=* : Defines one or more packages to compile}';
+        {--p|package=* : Defines one or more packages to compile}
+        {--no-progress : Do not show mix progress}';
 
     /**
      * @var string The console command description.
@@ -101,7 +102,9 @@ class MixCompile extends Command
                 continue;
             }
 
-            $this->info(sprintf('Mixing package "%s"', $name));
+            if (!$this->option('no-progress')) {
+                $this->info(sprintf('Mixing package "%s"', $name));
+            }
 
             $exitCode = $this->mixPackage(base_path($relativeMixJsPath));
 
@@ -225,7 +228,7 @@ class MixCompile extends Command
 
         $config = str_replace(
             ['%base%', '%notificationInject%', '%mixConfigPath%', '%pluginsPath%', '%appPath%', '%silent%'],
-            [addslashes($basePath), 'mix._api.disableNotifications();', addslashes($mixJsPath), addslashes(plugins_path()), addslashes(base_path()), (int) $this->option('silent')],
+            [addslashes($basePath), 'mix._api.disableNotifications();', addslashes($mixJsPath), addslashes(plugins_path()), addslashes(base_path()), (int) ($this->option('silent') || $this->option('no-progress'))],
             $fixture
         );
 

--- a/modules/system/console/MixList.php
+++ b/modules/system/console/MixList.php
@@ -40,7 +40,7 @@ class MixList extends Command
         foreach ($packages as $name => $package) {
             $rows[] = [
                 'name' => $name,
-                'active' => $this->option('json') ? !$package['ignored'] : ($package['ignored'] ? '<fg=red>No</>' : '<info>Yes</info>'),
+                'active' => !$package['ignored'],
                 'path' => $package['path'],
                 'configuration' => $package['mix'],
             ];
@@ -50,13 +50,16 @@ class MixList extends Command
             }
         }
 
-        if($this->option('json')) {
-            echo json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($this->option('json')) {
+            $this->line(json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
         } else {
             $this->line('');
             $this->info('Packages registered:');
             $this->line('');
-            $this->table(['Name', 'Active', 'Path', 'Configuration'], $rows);
+            $this->table(['Name', 'Active', 'Path', 'Configuration'], array_map(function ($row) {
+                $row['active'] = ($row['active']) ? '<info>Yes</info>' : '<fg=red>No</>';
+                return $row;
+            }, $rows));
             $this->line('');
         }
 

--- a/modules/system/console/MixList.php
+++ b/modules/system/console/MixList.php
@@ -14,7 +14,8 @@ class MixList extends Command
     /**
      * @var string The name and signature of this command.
      */
-    protected $signature = 'mix:list';
+    protected $signature = 'mix:list
+        {--json : Output as JSON}';
 
     /**
      * @var string The console command description.
@@ -23,8 +24,6 @@ class MixList extends Command
 
     public function handle(): int
     {
-        $this->line('');
-
         $mixedAssets = MixAssets::instance();
         $mixedAssets->fireCallbacks();
 
@@ -35,16 +34,13 @@ class MixList extends Command
             return 0;
         }
 
-        $this->info('Packages registered:');
-        $this->line('');
-
         $errors = [];
 
         $rows = [];
         foreach ($packages as $name => $package) {
             $rows[] = [
                 'name' => $name,
-                'active' => $package['ignored'] ?? false ? '<fg=red>No</>' : '<info>Yes</info>',
+                'active' => $this->option('json') ? !$package['ignored'] : ($package['ignored'] ? '<fg=red>No</>' : '<info>Yes</info>'),
                 'path' => $package['path'],
                 'configuration' => $package['mix'],
             ];
@@ -54,9 +50,15 @@ class MixList extends Command
             }
         }
 
-        $this->table(['Name', 'Active', 'Path', 'Configuration'], $rows);
-
-        $this->line('');
+        if($this->option('json')) {
+            echo json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        } else {
+            $this->line('');
+            $this->info('Packages registered:');
+            $this->line('');
+            $this->table(['Name', 'Active', 'Path', 'Configuration'], $rows);
+            $this->line('');
+        }
 
         if (!empty($errors)) {
             foreach ($errors as $error) {

--- a/modules/system/console/fixtures/mix.webpack.js.fixture
+++ b/modules/system/console/fixtures/mix.webpack.js.fixture
@@ -64,7 +64,7 @@ module.exports = async () => {
                     };
                     break;
                 case "WebpackBarPlugin":
-                    if (%silent%) {
+                    if (%silent% || %noProgress%) {
                         plugins[index].apply = _ => void 0;
                     }
                     break;


### PR DESCRIPTION
- Add --no-progress option to mix:compile

This will suppress the mix progress output while allowing the webpack progress to be output. 

- Add --json to mix:list

This outputs the mix package information in a json format. Also instead of "yes" and "no" for the "active" property, with the --json option the values are true and false.

These additions will be useful for scripts or automation tools that need to parse information about mix packages and information for when they're compiled. 