### PR TITLE
Note for debug MixList.php package not active

### DIFF
--- a/modules/system/console/MixList.php
+++ b/modules/system/console/MixList.php
@@ -28,6 +28,7 @@ class MixList extends Command
         $mixedAssets = MixAssets::instance();
         $mixedAssets->fireCallbacks();
 
+        // If after registration package is not active, check in package.json for workspaces.packages; can be set automatically as ignored.
         $packages = $mixedAssets->getPackages(true);
 
         if (count($packages) === 0) {


### PR DESCRIPTION
After registering my theme i couldn't compile because not active. It was automatically added to the ignored package in package.json

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->