### PR TITLE
Do not ignore hidden/disabled fields in onRefresh

### DIFF
--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1174,7 +1174,7 @@ class Form extends WidgetBase
      *
      * @return array
      */
-    public function getSaveData($allFields = false)
+    public function getSaveData(bool $includeAllFields = false): array
     {
         $this->defineFormFields();
         $this->applyFiltersFromModel();

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1171,8 +1171,6 @@ class Form extends WidgetBase
 
     /**
      * Returns post data from a submitted form.
-     *
-     * @return array
      */
     public function getSaveData(bool $includeAllFields = false): array
     {

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -354,7 +354,7 @@ class Form extends WidgetBase
     public function onRefresh()
     {
         $result = [];
-        $saveData = $this->getSaveData();
+        $saveData = $this->getSaveData(false);
 
         /**
          * @event backend.form.beforeRefresh
@@ -1174,9 +1174,12 @@ class Form extends WidgetBase
      *
      * @return array
      */
-    public function getSaveData()
+    public function getSaveData($applyFilters=true)
     {
         $this->defineFormFields();
+        if ($applyFilters) {
+            $this->applyFiltersFromModel();
+        }
 
         $result = [];
 

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1174,7 +1174,7 @@ class Form extends WidgetBase
      *
      * @return array
      */
-    public function getSaveData($allFields=false)
+    public function getSaveData($allFields = false)
     {
         $this->defineFormFields();
         $this->applyFiltersFromModel();

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1177,7 +1177,6 @@ class Form extends WidgetBase
     public function getSaveData()
     {
         $this->defineFormFields();
-        $this->applyFiltersFromModel();
 
         $result = [];
 

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -1196,7 +1196,7 @@ class Form extends WidgetBase
             /*
              * Disabled and hidden should be omitted from data set
              */
-            if (!$allFields && ($field->disabled || $field->hidden)) {
+            if (!$includeAllFields && ($field->disabled || $field->hidden)) {
                 continue;
             }
 

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -354,7 +354,7 @@ class Form extends WidgetBase
     public function onRefresh()
     {
         $result = [];
-        $saveData = $this->getSaveData(false);
+        $saveData = $this->getSaveData(true);
 
         /**
          * @event backend.form.beforeRefresh
@@ -1174,12 +1174,10 @@ class Form extends WidgetBase
      *
      * @return array
      */
-    public function getSaveData($applyFilters=true)
+    public function getSaveData($allFields=false)
     {
         $this->defineFormFields();
-        if ($applyFilters) {
-            $this->applyFiltersFromModel();
-        }
+        $this->applyFiltersFromModel();
 
         $result = [];
 
@@ -1198,7 +1196,7 @@ class Form extends WidgetBase
             /*
              * Disabled and hidden should be omitted from data set
              */
-            if ($field->disabled || $field->hidden) {
+            if (!$allFields && ($field->disabled || $field->hidden)) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes #1036

ref.

> I believe I have my issue with filterFields in version 1.2.5 narrowed down to a specific chain of events.
>
> Here's an example scenario:
> I have 3 fields we'll call A, B, and C.  B dependsOn A having a non-null value and is hidden otherwise.  C dependsOn B having a non-null value and is hidden otherwise.  When I set A, I can get B to appear, but when I set B, I can't get C to appear.  When I log out $fields->B->value in filterFields, it's coming in as null even though it's set in the form and is included in the post.
>
> Tracing the code, it's due to the newly added call to Form::applyFiltersFromModel inside of Form::getSaveData.  This fires the filterFields function before the values have been retrieved from the post, so filterFields sees that A, B, and C are unset and hides fields B and C as would be expected.  Then, Form::getSaveData sees that B and C are hidden, so it doesn't retrieve their values from the post.  Later in the process, Form::prepareVars calls Form::applyFiltersFromModel again (this is the original call in version 1.2.3 and before) which calls filterFields again.  Since the data wasn't retrieved for B and C in getSaveData, now this call to filterFields sees that A is set, so it shows B, but leaves C hidden because B isn't set.
>
> What I don't know is how to fix it without just removing the extra call to Form::applyFiltersFromModel inside of Form::getSaveData and potentially breaking other stuff.  Ideas?
