### PR TITLE
Add boot/initialize traits methods to backend controller

### DIFF
--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -775,10 +775,8 @@ class Controller extends ControllerBase
      */
     protected static function bootTraits(): void
     {
-        $class = static::class;
-
         $booted = [];
-
+        $class = static::class;
         static::$traitInitializers[$class] = [];
 
         foreach (class_uses_recursive($class) as $trait) {
@@ -786,13 +784,11 @@ class Controller extends ControllerBase
 
             if (method_exists($class, $method) && ! in_array($method, $booted)) {
                 forward_static_call([$class, $method]);
-
                 $booted[] = $method;
             }
 
             if (method_exists($class, $method = 'initialize'.class_basename($trait))) {
                 static::$traitInitializers[$class][] = $method;
-
                 static::$traitInitializers[$class] = array_unique(
                     static::$traitInitializers[$class]
                 );

--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -112,10 +112,8 @@ class Controller extends ControllerBase
 
     /**
      * The array of trait initializers that will be called on each new instance.
-     *
-     * @var array
      */
-    protected static $traitInitializers = [];
+    protected static array $traitInitializers = [];
 
     /**
      * @var array Controller specified methods which cannot be called as actions.
@@ -774,7 +772,6 @@ class Controller extends ControllerBase
 
     /**
      * Boot all of the bootable traits on the controller.
-     *
      */
     protected static function bootTraits(): void
     {
@@ -805,7 +802,6 @@ class Controller extends ControllerBase
 
     /**
      * Initialize any initializable traits on the controller.
-     *
      */
     protected function initializeTraits(): void
     {


### PR DESCRIPTION
Allow traits's initialize/boot methods to be called on Traits used by the Backend controller (similar to Eloquent Model).