### PR TITLE
WIP: Add extension events for the main relation widgets

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -394,6 +394,19 @@ class RelationController extends ControllerBehavior
 
         /*
          * View widget
+         *
+         * @event relation.extendViewWidget
+         * Called when the relation viewWidget is created
+         *
+         * Example usage:
+         *
+         *     $controller->bindEvent('relation.extendViewWidget', function ($widget, $field, $model) {
+         *         if ($field === 'myRelationField') {
+         *             $widget->addColumns([
+         *                 'myNewColumn' => ['label' => 'My New Column'],
+         *             ]);
+         *         }
+         *     });
          */
         if ($this->viewWidget = $this->makeViewWidget()) {
             $this->controller->bindEvent('relation.extendViewWidget', [$this->controller, 'relationExtendViewWidget']);
@@ -403,6 +416,21 @@ class RelationController extends ControllerBehavior
 
         /*
          * Manage widget
+         *
+         * @event relation.extendManageWidget
+         * Called when the relation manageWidget is created
+         *
+         * Example usage:
+         *
+         *     $controller->bindEvent('relation.extendManageWidget', function ($widget, $field, $model) {
+         *         if ($field === 'myRelationField') {
+         *             $widget->model->bindEvent('model.form.filterFields', function ($widget, $fields, $context) {
+         *                 if (isset($fields->myFormField)) {
+         *                     $fields->myFormField->hidden = true;
+         *                 }
+         *             });
+         *         }
+         *     });
          */
         if ($this->manageWidget = $this->makeManageWidget()) {
             $this->controller->bindEvent('relation.extendManageWidget', [$this->controller, 'relationExtendManageWidget']);
@@ -412,6 +440,19 @@ class RelationController extends ControllerBehavior
 
         /*
          * Pivot widget
+         *
+         * @event relation.extendPivotWidget
+         * Called when the relation pivotWidget is created
+         *
+         * Example usage:
+         *
+         *     $controller->bindEvent('relation.extendPivotWidget', function ($widget, $field, $model) {
+         *         if ($field === 'myRelationField') {
+         *             $widget->addFields([
+         *                 'myNewPivotField' => ['label' => 'My New Pivot Field'],
+         *             });
+         *         }
+         *     });
          */
         if ($this->manageMode === 'pivot' && $this->pivotWidget = $this->makePivotWidget()) {
             $this->controller->bindEvent('relation.extendPivotWidget', [$this->controller, 'relationExtendPivotWidget']);

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -397,6 +397,7 @@ class RelationController extends ControllerBehavior
          */
         if ($this->viewWidget = $this->makeViewWidget()) {
             $this->controller->relationExtendViewWidget($this->viewWidget, $this->field, $this->model);
+            $this->controller->fireEvent('relation.extendViewWidget', [$this->viewWidget, $this->field, $this->model]);
             $this->viewWidget->bindToController();
         }
 
@@ -405,6 +406,7 @@ class RelationController extends ControllerBehavior
          */
         if ($this->manageWidget = $this->makeManageWidget()) {
             $this->controller->relationExtendManageWidget($this->manageWidget, $this->field, $this->model);
+            $this->controller->fireEvent('relation.extendManageWidget', [$this->manageWidget, $this->field, $this->model]);
             $this->manageWidget->bindToController();
         }
 
@@ -413,6 +415,7 @@ class RelationController extends ControllerBehavior
          */
         if ($this->manageMode === 'pivot' && $this->pivotWidget = $this->makePivotWidget()) {
             $this->controller->relationExtendPivotWidget($this->pivotWidget, $this->field, $this->model);
+            $this->controller->fireEvent('relation.extendPivotWidget', [$this->pivotWidget, $this->field, $this->model]);
             $this->pivotWidget->bindToController();
         }
     }

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -400,11 +400,13 @@ class RelationController extends ControllerBehavior
          *
          * Example usage:
          *
-         *     $controller->bindEvent('relation.extendViewWidget', function ($widget, $field, $model) {
+         *     $controller->bindEvent('relation.extendViewWidget', function (\Backend\Widgets\Lists|\Backend\Widgets\Form $widget, string $field, \Winter\Storm\Database\Model $model) {
          *         if ($field === 'myRelationField') {
-         *             $widget->addColumns([
-         *                 'myNewColumn' => ['label' => 'My New Column'],
-         *             ]);
+         *             $widget->model->bindEvent('list.extendColumns', function ($widget) {
+         *                 $widget->addColumns([
+         *                      'myNewColumn' => ['label' => 'My New Column'],
+         *                 ]);
+         *             });
          *         }
          *     });
          */
@@ -422,7 +424,7 @@ class RelationController extends ControllerBehavior
          *
          * Example usage:
          *
-         *     $controller->bindEvent('relation.extendManageWidget', function ($widget, $field, $model) {
+         *     $controller->bindEvent('relation.extendManageWidget', function (\Backend\Widgets\Lists|\Backend\Widgets\Form $widget, string $field, \Winter\Storm\Database\Model $model) {
          *         if ($field === 'myRelationField') {
          *             $widget->model->bindEvent('model.form.filterFields', function ($widget, $fields, $context) {
          *                 if (isset($fields->myFormField)) {
@@ -446,10 +448,12 @@ class RelationController extends ControllerBehavior
          *
          * Example usage:
          *
-         *     $controller->bindEvent('relation.extendPivotWidget', function ($widget, $field, $model) {
+         *     $controller->bindEvent('relation.extendPivotWidget', function (\Backend\Widgets\Form $widget, string $field, \Winter\Storm\Database\Model $model) {
          *         if ($field === 'myRelationField') {
-         *             $widget->addFields([
-         *                 'myNewPivotField' => ['label' => 'My New Pivot Field'],
+         *             $widget->model->bindEvent('form.extendFields', function ($widget) {
+         *                 $widget->addFields([
+         *                     'myNewPivotField' => ['label' => 'My New Pivot Field'],
+         *                 ]);
          *             });
          *         }
          *     });

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -396,8 +396,8 @@ class RelationController extends ControllerBehavior
          * View widget
          */
         if ($this->viewWidget = $this->makeViewWidget()) {
-            $this->controller->relationExtendViewWidget($this->viewWidget, $this->field, $this->model);
-            $this->controller->fireEvent('relation.extendViewWidget', [$this->viewWidget, $this->field, $this->model]);
+            $this->controller->bindEvent('relation.extendViewWidget', [$this, 'relationExtendViewWidget']);
+            $this->controller->fireEvent('relation.extendViewWidget', [$this->viewWidget, $this->field, $this->model], halt:true);
             $this->viewWidget->bindToController();
         }
 
@@ -405,8 +405,8 @@ class RelationController extends ControllerBehavior
          * Manage widget
          */
         if ($this->manageWidget = $this->makeManageWidget()) {
-            $this->controller->relationExtendManageWidget($this->manageWidget, $this->field, $this->model);
-            $this->controller->fireEvent('relation.extendManageWidget', [$this->manageWidget, $this->field, $this->model]);
+            $this->controller->bindEvent('relation.extendManageWidget', [$this, 'relationExtendManageWidget']);
+            $this->controller->fireEvent('relation.extendManageWidget', [$this->manageWidget, $this->field, $this->model], halt:true);
             $this->manageWidget->bindToController();
         }
 
@@ -414,8 +414,8 @@ class RelationController extends ControllerBehavior
          * Pivot widget
          */
         if ($this->manageMode === 'pivot' && $this->pivotWidget = $this->makePivotWidget()) {
-            $this->controller->relationExtendPivotWidget($this->pivotWidget, $this->field, $this->model);
-            $this->controller->fireEvent('relation.extendPivotWidget', [$this->pivotWidget, $this->field, $this->model]);
+            $this->controller->bindEvent('relation.extendPivotWidget', [$this, 'relationExtendPivotWidget']);
+            $this->controller->fireEvent('relation.extendPivotWidget', [$this->pivotWidget, $this->field, $this->model], halt:true);
             $this->pivotWidget->bindToController();
         }
     }

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -396,7 +396,7 @@ class RelationController extends ControllerBehavior
          * View widget
          */
         if ($this->viewWidget = $this->makeViewWidget()) {
-            $this->controller->bindEvent('relation.extendViewWidget', [$this, 'relationExtendViewWidget']);
+            $this->controller->bindEvent('relation.extendViewWidget', [$this->controller, 'relationExtendViewWidget']);
             $this->controller->fireEvent('relation.extendViewWidget', [$this->viewWidget, $this->field, $this->model], halt:true);
             $this->viewWidget->bindToController();
         }
@@ -405,7 +405,7 @@ class RelationController extends ControllerBehavior
          * Manage widget
          */
         if ($this->manageWidget = $this->makeManageWidget()) {
-            $this->controller->bindEvent('relation.extendManageWidget', [$this, 'relationExtendManageWidget']);
+            $this->controller->bindEvent('relation.extendManageWidget', [$this->controller, 'relationExtendManageWidget']);
             $this->controller->fireEvent('relation.extendManageWidget', [$this->manageWidget, $this->field, $this->model], halt:true);
             $this->manageWidget->bindToController();
         }
@@ -414,7 +414,7 @@ class RelationController extends ControllerBehavior
          * Pivot widget
          */
         if ($this->manageMode === 'pivot' && $this->pivotWidget = $this->makePivotWidget()) {
-            $this->controller->bindEvent('relation.extendPivotWidget', [$this, 'relationExtendPivotWidget']);
+            $this->controller->bindEvent('relation.extendPivotWidget', [$this->controller, 'relationExtendPivotWidget']);
             $this->controller->fireEvent('relation.extendPivotWidget', [$this->pivotWidget, $this->field, $this->model], halt:true);
             $this->pivotWidget->bindToController();
         }


### PR DESCRIPTION
Add the following events for the primary RelationController widgets:
```
- relation.extendViewWidget
- relation.extendManageWidget
- relation.extendPivotWidget
```

Questions: 
   - do we need the global events?
   - do we need the following events:
```
   - relation.extendViewFilterWidget
   - relation.extendManageFilterWidget
   - relation.extendRefreshResults
   - relation.extendConfig
```

_Note:_

I didn't add parenthesis around the arguments in the handler method signatures because I find this is a pain when copy/pasting an example to get you started as they need to be removed.

I think we should do the same for the other events examples elsewhere in the codebase.