### PR TITLE
Code tidying

### DIFF
--- a/modules/system/behaviors/SettingsModel.php
+++ b/modules/system/behaviors/SettingsModel.php
@@ -127,12 +127,12 @@ class SettingsModel extends ModelBehavior
             $query = $query->remember($this->cacheTtl, $this->getCacheKey());
         }
 
+        $record = null;
         try {
             $record = $query->first();
         } catch (QueryException $ex) {
             // SQLSTATE[42S02]: Base table or view not found - migrations haven't run yet
             if ($ex->getCode() === '42S02') {
-                $record = null;
                 traceLog($ex);
             }
         }


### PR DESCRIPTION
…(wintercms#1132)

### Package targeted

Winter CMS

### Description

If the query fails not because of a base table or view not found, the getSettingsRecord() function tries to access a $record variable that is not defined.

Here is an excerpt commenting on the changes:
```
    public function getSettingsRecord()
    {
        $query = $this->model->where('item', $this->recordCode);

        if ($this->cacheTtl > 0) {
            $query = $query->remember($this->cacheTtl, $this->getCacheKey());
        }

        $record = null; // PR: "$record = null;" defined outside of Try/Catch block.

        try {
            $record = $query->first();
        } catch (QueryException $ex) {
            // SQLSTATE[42S02]: Base table or view not found - migrations haven't run yet
            if ($ex->getCode() === '42S02') {
                // PR: "$record = null;" removed from this "if" case ("$record" already set to "null" if exception caught)
                traceLog($ex);
            }
        }

        return $record ?: null; // PR: We still need a condition to return "null" in case of empty collection.
    }
```

`// PR:` comments are here to explain my modifications.

Maybe I'm wrong, but I think it will be better code writing

### Will this change be backwards-compatible?

This seems fully backwards compatible since the return will have the same values, the only difference being that it will become impossible to encounter the "Undefined variable $record" error.