### PR TITLE
Allow for File model IDs to be UUIDs

### DIFF
--- a/modules/backend/formwidgets/fileupload/partials/_file_multi.php
+++ b/modules/backend/formwidgets/fileupload/partials/_file_multi.php
@@ -36,7 +36,7 @@
                             class="upload-remove-button"
                             data-request="<?= $this->getEventHandler('onRemoveAttachment') ?>"
                             data-request-confirm="<?= e(trans('backend::lang.fileupload.remove_confirm')) ?>"
-                            data-request-data="file_id: <?= $file->id ?>"
+                            data-request-data="file_id: '<?= $file->id ?>'"
                             ><i class="icon-times"></i></a>
                     </h4>
                     <p class="size"><?= e($file->sizeToString()) ?></p>

--- a/modules/backend/formwidgets/fileupload/partials/_file_single.php
+++ b/modules/backend/formwidgets/fileupload/partials/_file_single.php
@@ -39,7 +39,7 @@
                         class="upload-remove-button"
                         data-request="<?= $this->getEventHandler('onRemoveAttachment') ?>"
                         data-request-confirm="<?= e(trans('backend::lang.fileupload.remove_confirm')) ?>"
-                        data-request-data="file_id: <?= $singleFile->id ?>"
+                        data-request-data="file_id: '<?= $singleFile->id ?>'"
                         ><i class="icon-times"></i></a>
                 </div>
             </div>

--- a/modules/backend/formwidgets/fileupload/partials/_image_multi.php
+++ b/modules/backend/formwidgets/fileupload/partials/_image_multi.php
@@ -36,7 +36,7 @@
                             class="upload-remove-button"
                             data-request="<?= $this->getEventHandler('onRemoveAttachment') ?>"
                             data-request-confirm="<?= e(trans('backend::lang.fileupload.remove_confirm')) ?>"
-                            data-request-data="file_id: <?= $file->id ?>"
+                            data-request-data="file_id: '<?= $file->id ?>'"
                             ><i class="icon-times"></i></a>
                     </h4>
                     <p class="size"><?= e($file->sizeToString()) ?></p>

--- a/modules/backend/formwidgets/fileupload/partials/_image_single.php
+++ b/modules/backend/formwidgets/fileupload/partials/_image_single.php
@@ -40,7 +40,7 @@
                             class="upload-remove-button"
                             data-request="<?= $this->getEventHandler('onRemoveAttachment') ?>"
                             data-request-confirm="<?= e(trans('backend::lang.fileupload.remove_confirm')) ?>"
-                            data-request-data="file_id: <?= $singleFile->id ?>"
+                            data-request-data="file_id: '<?= $singleFile->id ?>'"
                             ><i class="icon-times"></i></a>
                     </h4>
                     <p class="size"><?= e($singleFile->sizeToString()) ?></p>


### PR DESCRIPTION
I've come to notice that when i'm making projects for people they want to utilize uuids for file uploads (everything really) regardless of performance impact, so I end up having to manually edit this every time... So can I just put this here so i don't have to keep doing this?