### PR TITLE
Added fix to refresh only on src change

### DIFF
--- a/modules/system/console/asset/fixtures/config/vite/vite.config.mjs.fixture
+++ b/modules/system/console/asset/fixtures/config/vite/vite.config.mjs.fixture
@@ -16,8 +16,8 @@ export default defineConfig({
                 paths: [
                     './**/*.htm',
                     './**/*.block',
-                    'assets/**/*.css',
-                    'assets/**/*.js',
+                    'assets/src/**/*.css',
+                    'assets/src/**/*.js',
                 ]
             },
         }),


### PR DESCRIPTION
Simple config change to ensure updates created by vite don't mix with updates triggered by the user