### PR TITLE
Fix Mix webpack config not being cleaned

### DIFF
--- a/modules/system/console/asset/mix/MixCompile.php
+++ b/modules/system/console/asset/mix/MixCompile.php
@@ -95,9 +95,9 @@ class MixCompile extends AssetCompile
      */
     protected function afterExecution(string $configPath): void
     {
-        $webpackJsPath = $this->getPackagePath($configPath);
-        if (File::exists($webpackJsPath)) {
-            File::delete($webpackJsPath);
+        $webpackConfigPath = $this->getJsConfigPath($configPath);
+        if (File::exists($webpackConfigPath) && File::isFile($webpackConfigPath)) {
+            File::delete($webpackConfigPath);
         }
     }
 }

--- a/modules/system/console/asset/mix/MixWatch.php
+++ b/modules/system/console/asset/mix/MixWatch.php
@@ -60,7 +60,7 @@ class MixWatch extends MixCompile
     public function handleCleanup(): void
     {
         $this->newLine();
-        $this->info('Cleaning up: ' . $this->getPackagePath(base_path($this->watchingFilePath)));
+        $this->info('Cleaning up: ' . $this->getPackagePath($this->watchingFilePath));
         $this->afterExecution(base_path($this->watchingFilePath));
     }
 }


### PR DESCRIPTION
Adds a fix for issue raised by @damsfx where the `mix.webpack.js` file was not being automatically cleaned up after running `mix:watch` / `mix:compile`.

