### PR TITLE
Fix displaying repeater item titles in preview contexts

### DIFF
--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -259,7 +259,7 @@
                     return $textInput.val()
             }
         } else {
-            var $disabledTextInput = $('.form-control', $target)
+            var $disabledTextInput = $('.form-control:first', $target)
             if ($disabledTextInput.length) {
                 return $disabledTextInput.text()
             }

--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -259,7 +259,7 @@
                     return $textInput.val()
             }
         } else {
-            var $disabledTextInput = $('.text-field:first > .form-control', $target)
+            var $disabledTextInput = $('.form-control', $target)
             if ($disabledTextInput.length) {
                 return $disabledTextInput.text()
             }


### PR DESCRIPTION
Cleaned up version of the preview HTML:
```
<div class="text-field" data-field-name="name">
    <label>Name</label>
    <span class="form-control">Test</span>
</div>
```
As you can see, there is no element to select with class `text-field` **if titleFrom is set**, because the target itself has the class:
```
var $disabledTextInput = $('.text-field:first > .form-control', $target)
```
so I removed the `.text-field` part of the query selector

Now it succesfuly shows the text value from `name` in both preview and update context.
If titleFrom is not set, it will take the first `.form-control` value, which is the same field as in update context
![image](https://github.com/user-attachments/assets/41bc3818-17f8-4b2d-be1c-a5675f6ed13f)
Before this change, it showed nothing, because the selector was invalid
![image](https://github.com/user-attachments/assets/2de9c67e-e389-482e-a31c-9f1a1424141a)

fields.yaml:
```
items:
    context: ['preview', 'update', 'relation']
    tab: Content
    label: aic.aftersales::lang.form.items.title
    titleFrom: name
    type: repeater
    style: collapsed
    dependsOn: order
    form:
        fields:
            name:
                label: aic.aftersales::lang.form.items.name
            requires_payment:
                label: aic.aftersales::lang.form.items.requires_payment
                type: balloon-selector
                options:
                    0: Nee
                    1: Ja
                default: 0
```