### PR TITLE
Make stripe loader configurable with data attribute

### DIFF
--- a/modules/system/assets/js/snowboard/ajax/handlers/AttributeRequest.js
+++ b/modules/system/assets/js/snowboard/ajax/handlers/AttributeRequest.js
@@ -202,6 +202,7 @@ export default class AttributeRequest extends Singleton {
             confirm: ('requestConfirm' in data) ? String(data.requestConfirm) : null,
             redirect: ('requestRedirect' in data) ? String(data.requestRedirect) : null,
             loading: ('requestLoading' in data) ? String(data.requestLoading) : null,
+            stripe: ('requestStripe' in data) ? data.requestStripe === 'true' : true,
             flash: ('requestFlash' in data),
             files: ('requestFiles' in data),
             browserValidate: ('requestBrowserValidate' in data),


### PR DESCRIPTION
Add option to define stripe visibility using data attribute (data-request-stripe=['true'|'false']

If the option is omitted stripe option will be true.

Now only using Snowboard with JavaScript API stripe option is available, with this commit will be availabe also using data attribute

Created PR with documentation in docs https://github.com/wintercms/docs/pull/208