### PR TITLE
Initialize the Filter widget even when no scopes are initially defined

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -233,7 +233,7 @@ class ListController extends ControllerBehavior
          * Prepare the filter widget (optional)
          */
         if (isset($listConfig->filter)) {
-            $filterConfig = $this->makeConfig($listConfig->filter ?? []);
+            $filterConfig = $this->makeConfig($listConfig->filter);
 
             $widget->cssClasses[] = 'list-flush';
 

--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -230,45 +230,41 @@ class ListController extends ControllerBehavior
         }
 
         /*
-         * Prepare the filter widget (optional)
+         * Prepare the filter widget
          */
-        if (isset($listConfig->filter)) {
-            $filterConfig = $this->makeConfig($listConfig->filter);
+        $filterConfig = $this->makeConfig($listConfig->filter ?? []);
 
-            if (!empty($filterConfig->scopes)) {
-                $widget->cssClasses[] = 'list-flush';
+        $widget->cssClasses[] = 'list-flush';
 
-                $filterConfig->alias = $widget->alias . 'Filter';
-                $filterWidget = $this->makeWidget(\Backend\Widgets\Filter::class, $filterConfig);
-                $filterWidget->bindToController();
+        $filterConfig->alias = $widget->alias . 'Filter';
+        $filterWidget = $this->makeWidget(\Backend\Widgets\Filter::class, $filterConfig);
+        $filterWidget->bindToController();
 
-                /*
-                * Filter the list when the scopes are changed
-                */
-                $filterWidget->bindEvent('filter.update', function () use ($widget, $filterWidget) {
-                    return $widget->onFilter();
-                });
+        /*
+        * Filter the list when the scopes are changed
+        */
+        $filterWidget->bindEvent('filter.update', function () use ($widget, $filterWidget) {
+            return $widget->onFilter();
+        });
 
-                /*
-                * Filter Widget with extensibility
-                */
-                $filterWidget->bindEvent('filter.extendScopes', function () use ($filterWidget) {
-                    $this->controller->listFilterExtendScopes($filterWidget);
-                });
+        /*
+        * Filter Widget with extensibility
+        */
+        $filterWidget->bindEvent('filter.extendScopes', function () use ($filterWidget) {
+            $this->controller->listFilterExtendScopes($filterWidget);
+        });
 
-                /*
-                * Extend the query of the list of options
-                */
-                $filterWidget->bindEvent('filter.extendQuery', function ($query, $scope) {
-                    $this->controller->listFilterExtendQuery($query, $scope);
-                });
+        /*
+        * Extend the query of the list of options
+        */
+        $filterWidget->bindEvent('filter.extendQuery', function ($query, $scope) {
+            $this->controller->listFilterExtendQuery($query, $scope);
+        });
 
-                // Apply predefined filter values
-                $widget->addFilter([$filterWidget, 'applyAllScopesToQuery']);
+        // Apply predefined filter values
+        $widget->addFilter([$filterWidget, 'applyAllScopesToQuery']);
 
-                $this->filterWidgets[$definition] = $filterWidget;
-            }
-        }
+        $this->filterWidgets[$definition] = $filterWidget;
 
         return $widget;
     }

--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -230,41 +230,43 @@ class ListController extends ControllerBehavior
         }
 
         /*
-         * Prepare the filter widget
+         * Prepare the filter widget (optional)
          */
-        $filterConfig = $this->makeConfig($listConfig->filter ?? []);
+        if (isset($listConfig->filter)) {
+            $filterConfig = $this->makeConfig($listConfig->filter ?? []);
 
-        $widget->cssClasses[] = 'list-flush';
+            $widget->cssClasses[] = 'list-flush';
 
-        $filterConfig->alias = $widget->alias . 'Filter';
-        $filterWidget = $this->makeWidget(\Backend\Widgets\Filter::class, $filterConfig);
-        $filterWidget->bindToController();
+            $filterConfig->alias = $widget->alias . 'Filter';
+            $filterWidget = $this->makeWidget(\Backend\Widgets\Filter::class, $filterConfig);
+            $filterWidget->bindToController();
 
-        /*
-        * Filter the list when the scopes are changed
-        */
-        $filterWidget->bindEvent('filter.update', function () use ($widget, $filterWidget) {
-            return $widget->onFilter();
-        });
+            /*
+            * Filter the list when the scopes are changed
+            */
+            $filterWidget->bindEvent('filter.update', function () use ($widget, $filterWidget) {
+                return $widget->onFilter();
+            });
 
-        /*
-        * Filter Widget with extensibility
-        */
-        $filterWidget->bindEvent('filter.extendScopes', function () use ($filterWidget) {
-            $this->controller->listFilterExtendScopes($filterWidget);
-        });
+            /*
+            * Filter Widget with extensibility
+            */
+            $filterWidget->bindEvent('filter.extendScopes', function () use ($filterWidget) {
+                $this->controller->listFilterExtendScopes($filterWidget);
+            });
 
-        /*
-        * Extend the query of the list of options
-        */
-        $filterWidget->bindEvent('filter.extendQuery', function ($query, $scope) {
-            $this->controller->listFilterExtendQuery($query, $scope);
-        });
+            /*
+            * Extend the query of the list of options
+            */
+            $filterWidget->bindEvent('filter.extendQuery', function ($query, $scope) {
+                $this->controller->listFilterExtendQuery($query, $scope);
+            });
 
-        // Apply predefined filter values
-        $widget->addFilter([$filterWidget, 'applyAllScopesToQuery']);
+            // Apply predefined filter values
+            $widget->addFilter([$filterWidget, 'applyAllScopesToQuery']);
 
-        $this->filterWidgets[$definition] = $filterWidget;
+            $this->filterWidgets[$definition] = $filterWidget;
+        }
 
         return $widget;
     }


### PR DESCRIPTION
This makes it possible to dynamically extend filter scopes even if no scopes exist.