### PR TITLE
Allow command names to contain number

### DIFF
--- a/modules/system/console/CreateCommand.php
+++ b/modules/system/console/CreateCommand.php
@@ -58,7 +58,7 @@ class CreateCommand extends BaseScaffoldCommand
 
         // More strict than the base Symfony validateName()
         // method, make a PR if it's a problem for you
-        if (preg_match('/^[a-z]++(:[a-z]++)*$/', $command) !== 1) {
+        if (preg_match('/^[\w]++(:[\w]++)*$/', $command) !== 1) {
             throw new InvalidArgumentException(sprintf('Command name "%s" is invalid.', $command));
         }
 

--- a/modules/system/console/CreateCommand.php
+++ b/modules/system/console/CreateCommand.php
@@ -58,7 +58,8 @@ class CreateCommand extends BaseScaffoldCommand
 
         // More strict than the base Symfony validateName()
         // method, make a PR if it's a problem for you
-        if (preg_match('/^[\w]++(:[\w]++)*$/', $command) !== 1) {
+        // Plugin and command names can contain a number, but they can't start with it.
+        if (preg_match('/^[a-z][\w]++(:[a-z][\w]++)*$/', $command) !== 1) {
             throw new InvalidArgumentException(sprintf('Command name "%s" is invalid.', $command));
         }
 

--- a/modules/system/tests/console/CreateCommandTest.php
+++ b/modules/system/tests/console/CreateCommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace System\Tests\Console;
+
+use File;
+use InvalidArgumentException;
+use System\Tests\Bootstrap\TestCase;
+
+class CreateCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->setPluginsPath(base_path() . '/modules/system/tests/fixtures/plugins/');
+
+    }
+
+    public function testCreatingCommand()
+    {
+        $this->artisan('create:command Winter.Tester TestCommand')
+            ->assertExitCode(0);
+        $this->artisan('create:command Winter.Tester Test1Command')
+            ->assertExitCode(0);
+
+        $this->artisan('create:command Winter.Tester4You TestCommand')
+            ->assertExitCode(0);
+        $this->artisan('create:command Winter.Tester4You Test1Command')
+            ->assertExitCode(0);
+    }
+
+    public function testNotCreatingCommandBeginingWithNumber()
+    {
+        $this->artisan('create:command Winter.Tester 1Command')->assertFailed();
+        $this->artisan('create:command Winter.Tester4You 1Command')->assertFailed();
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory(plugins_path('winter/tester/console'));
+        File::deleteDirectory(plugins_path('winter/tester4you'));
+
+        parent::tearDown();
+    }
+}

--- a/modules/system/tests/console/CreateCommandTest.php
+++ b/modules/system/tests/console/CreateCommandTest.php
@@ -13,7 +13,6 @@ class CreateCommandTest extends TestCase
         parent::setUp();
 
         $this->app->setPluginsPath(base_path() . '/modules/system/tests/fixtures/plugins/');
-
     }
 
     public function testCreatingCommand()


### PR DESCRIPTION
Allow command name to contains numbers, eg:
```bash
php artisan create:command Acme.MyPlugin4You MyCommand
```
