### PR TITLE
Add create:factory command

### DIFF
--- a/modules/system/ServiceProvider.php
+++ b/modules/system/ServiceProvider.php
@@ -296,6 +296,7 @@ class ServiceProvider extends ModuleServiceProvider
         $this->registerConsoleCommand('create.job', \System\Console\CreateJob::class);
         $this->registerConsoleCommand('create.migration', \System\Console\CreateMigration::class);
         $this->registerConsoleCommand('create.model', \System\Console\CreateModel::class);
+        $this->registerConsoleCommand('create.factory', \System\Console\CreateFactory::class);
         $this->registerConsoleCommand('create.plugin', \System\Console\CreatePlugin::class);
         $this->registerConsoleCommand('create.settings', \System\Console\CreateSettings::class);
         $this->registerConsoleCommand('create.test', \System\Console\CreateTest::class);

--- a/modules/system/console/CreateFactory.php
+++ b/modules/system/console/CreateFactory.php
@@ -1,0 +1,62 @@
+<?php namespace System\Console;
+
+use System\Console\BaseScaffoldCommand;
+
+class CreateFactory extends BaseScaffoldCommand
+{
+    /**
+     * @var string|null The default command name for lazy loading.
+     */
+    protected static $defaultName = 'create:factory';
+
+    /**
+     * @var string The name and signature of this command.
+     */
+    protected $signature = 'create:factory
+        {plugin : The name of the plugin. <info>(eg: Winter.Blog)</info>}
+        {factory : The name of the factory to generate. <info>(eg: PostFactory)</info>}
+        {--m|model= : The name of the model. <info>(eg: Post)</info>}
+        {--f|force : Overwrite existing files with generated files.}
+
+        {--uninspiring : Disable inspirational quotes}
+    ';
+
+    /**
+     * @var string The console command description.
+     */
+    protected $description = 'Creates a new factory.';
+
+    /**
+     * @var array List of commands that this command replaces (aliases)
+     */
+    protected $replaces = [
+        'make:factory',
+    ];
+
+    /**
+     * @var string The type of class being generated.
+     */
+    protected $type = 'Factory';
+
+    /**
+     * @var string The argument that the generated class name comes from
+     */
+    protected $nameFrom = 'factory';
+
+    /**
+     * @var array A mapping of stubs to generated files.
+     */
+    protected $stubs = [
+        'scaffold/factory/factory.stub' => 'database/factories/{{studly_name}}.php',
+    ];
+
+
+    protected function processVars($vars): array
+    {
+        $vars = parent::processVars($vars);
+
+        $vars['model'] = $this->option('model');
+
+        return $vars;
+    }
+}

--- a/modules/system/console/CreateFactory.php
+++ b/modules/system/console/CreateFactory.php
@@ -50,7 +50,6 @@ class CreateFactory extends BaseScaffoldCommand
         'scaffold/factory/factory.stub' => 'database/factories/{{studly_name}}.php',
     ];
 
-
     protected function processVars($vars): array
     {
         $vars = parent::processVars($vars);

--- a/modules/system/console/CreateModel.php
+++ b/modules/system/console/CreateModel.php
@@ -21,6 +21,7 @@ class CreateModel extends BaseScaffoldCommand
         {--a|all : Generate a controller, migration, & seeder for the model}
         {--c|controller : Create a new controller for the model}
         {--s|seed : Create a new seeder for the model}
+        {--F|factory : Create a new factory for the model}
         {--p|pivot : Indicates if the generated model should be a custom intermediate table model}
         {--no-migration : Don\'t create a migration file for the model}
         {--uninspiring : Disable inspirational quotes}
@@ -71,6 +72,7 @@ class CreateModel extends BaseScaffoldCommand
         if ($this->option('all')) {
             $this->input->setOption('controller', true);
             $this->input->setOption('seed', true);
+            $this->input->setOption('factory', true);
         }
 
         if ($this->option('controller')) {
@@ -83,6 +85,10 @@ class CreateModel extends BaseScaffoldCommand
 
         if (!$this->option('no-migration')) {
             $this->createMigration();
+        }
+
+        if ($this->option('factory')) {
+            $this->createFactory();
         }
     }
 
@@ -149,6 +155,20 @@ class CreateModel extends BaseScaffoldCommand
         $this->call('create:controller', [
             'plugin'  => $this->getPluginIdentifier(),
             'controller' => Str::plural($this->argument('model')),
+            '--model' => $this->getNameInput(),
+            '--force' => $this->option('force'),
+            '--uninspiring' => $this->option('uninspiring'),
+        ]);
+    }
+
+    /**
+     * Create a factory class for the model.
+     */
+    public function createFactory(): void
+    {
+        $this->call('create:factory', [
+            'plugin'  => $this->getPluginIdentifier(),
+            'factory' => "{$this->getNameInput()}Factory",
             '--model' => $this->getNameInput(),
             '--force' => $this->option('force'),
             '--uninspiring' => $this->option('uninspiring'),

--- a/modules/system/console/scaffold/factory/factory.stub
+++ b/modules/system/console/scaffold/factory/factory.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ plugin_namespace }}\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * {{ name }} Factory
+ {% if model %}
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\{{ plugin_namespace }}\Models\{{ model }}>
+ {% endif %}
+ */
+class {{ studly_name }} extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/modules/system/console/scaffold/factory/factory.stub
+++ b/modules/system/console/scaffold/factory/factory.stub
@@ -6,9 +6,9 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
  * {{ name }} Factory
- {% if model %}
+{% if model %}
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\{{ plugin_namespace }}\Models\{{ model }}>
- {% endif %}
+{% endif %}
  */
 class {{ studly_name }} extends Factory
 {


### PR DESCRIPTION
also added `--F|factory` option to make:model for factory creation

---

Implements feature request https://github.com/wintercms/winter/issues/1007

---

Hello everyone, I'd love a review of this PR. My main concern is that I'm not using a Winter-specific Factory class to inherit from in the factory.stub, but the created Factory inherits directly from the Laravel base factory class.

```php
// Created Factory Class PostFactory.php
//[...]
use Illuminate\Database\Eloquent\Factories\Factory;

class PostFactory extends Factory
//[...]
```

Unlike the related model, which inherits from the Winter Model class

```php
// Created Model Class Post.php
//[...]
use Winter\Storm\Database\Model;

/**
 * Post Model
 */
class Post extends Model
{
```

I don't think this is inherently an issue, but in the case it is, I think I'll have to add a Factory base class in the Storm library
