### PR TITLE
Improved French translation

### DIFF
--- a/modules/backend/lang/fr/lang.php
+++ b/modules/backend/lang/fr/lang.php
@@ -3,7 +3,7 @@
 return [
     'auth' => [
         'title' => 'Zone d\'administration',
-        'invalid_login' => 'L\'utilisateur saisi ne correspond à aucun utilisateur enregistré. Merci de vérifier votre saisie et de réessayer.'
+        'invalid_login' => 'Les détails saisis ne correspondent à aucun de nos enregistrements. Merci de vérifier et de réessayer.'
     ],
     'field' => [
         'invalid_type' => 'Type de champ invalide :type.',


### PR DESCRIPTION
### Issue:
When current language is French, front-end users may think they are using the wrong username when they are simply using the wrong password to log in. The reason is that `'L\'utilisateur saisi ne correspond à aucun utilisateur enregistré. Merci de vérifier votre saisie et de réessayer.'` means `'The user entered does not match any registered user. Please check your entry and try again.'`, which is not the true meaning of this error.

### How to reproduce:
You have to set French as the front-end language, have `Winter.User` configured well with a login page, and debug mode set to false. Then, try to log in with a correct front-end username, but a wrong password. I know this happens with a plugin and not with core `Winter`, but this plugin is using **`Winter\Storm\Auth\AuthenticationException` which uses the translation reference `backend::lang.auth.invalid_login`, both part of core.**

### Solution:
The French translation `'invalid_login' => 'Les détails saisis ne correspondent à aucun de nos enregistrements. Merci de vérifier et de réessayer.'` is more accurate to the original English sentence `'invalid_login' => 'The details you entered did not match our records. Please double-check and try again.'`.

### Result:
After this fix, French users are encouraged to verify all their entries, like English ones do.