### PR TITLE
Add --batchable option to create:job command

### DIFF
--- a/modules/system/console/CreateJob.php
+++ b/modules/system/console/CreateJob.php
@@ -15,6 +15,7 @@ class CreateJob extends BaseScaffoldCommand
     protected $signature = 'create:job
         {plugin : The name of the plugin. <info>(eg: Winter.Blog)</info>}
         {name : The name of the job class to generate. <info>(eg: ImportPosts)</info>}
+        {--b|batchable : Generates a batchable queue job.}
         {--s|sync : Generates a non-queueable job.}
         {--f|force : Overwrite existing files with generated files.}
         {--uninspiring : Disable inspirational quotes}
@@ -44,6 +45,9 @@ class CreateJob extends BaseScaffoldCommand
         'sync' => [
             'scaffold/job/job.stub' => 'jobs/{{studly_name}}.php',
         ],
+        'batched' => [
+            'scaffold/job/job.batched.stub' => 'jobs/{{studly_name}}.php',
+        ],
         'queued' => [
             'scaffold/job/job.queued.stub' => 'jobs/{{studly_name}}.php',
         ],
@@ -56,6 +60,8 @@ class CreateJob extends BaseScaffoldCommand
     {
         if ($this->option('sync')) {
             $this->stubs = $this->jobStubs['sync'];
+        } elseif ($this->option('batchable')) {
+            $this->stubs = $this->jobStubs['batched'];
         } else {
             $this->stubs = $this->jobStubs['queued'];
         }

--- a/modules/system/console/scaffold/job/job.batched.stub
+++ b/modules/system/console/scaffold/job/job.batched.stub
@@ -1,0 +1,46 @@
+<?php
+
+namespace {{ plugin_namespace }}\Jobs;
+
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\SkipIfBatchCancelled;
+use Illuminate\Queue\SerializesModels;
+
+class {{studly_name}} implements ShouldQueue
+{
+    use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        //
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     */
+    public function middleware()
+    {
+        return []; // Remove this line to activate
+
+        return [
+            // Instruct Laravel to not process the job if
+            // its corresponding batch has been cancelled
+            new SkipIfBatchCancelled()
+        ];
+    }
+}


### PR DESCRIPTION
Allow `create:job` command to accept an option to generate batchable job.