### PR TITLE
Revert "Make the whole repeater-item clickable for expansion (#1218)"

### DIFF
--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -50,12 +50,8 @@
 
         this.$el.on('ajaxDone', '> .field-repeater-items > .field-repeater-item > .repeater-item-remove > [data-repeater-remove]', this.proxy(this.onRemoveItemSuccess))
         this.$el.on('ajaxDone', '> .field-repeater-items > .field-repeater-add-item > [data-repeater-add]', this.proxy(this.onAddItemSuccess))
+        this.$el.on('click', '> ul > li > .repeater-item-collapse .repeater-item-collapse-one', this.proxy(this.toggleCollapse))
         this.$el.on('click', '> .field-repeater-items > .field-repeater-add-item > [data-repeater-add-group]', this.proxy(this.clickAddGroupButton))
-
-        var $item = this.$el.find('> ul > li.field-repeater-item')
-        $item.css('cursor', 'pointer')
-        $item.on('click', this.proxy(this.toggleCollapse))
-        $item.on('click', '> .repeater-item-collapse-one', this.proxy(this.toggleCollapse))
 
         this.$el.one('dispose-control', this.proxy(this.dispose))
 


### PR DESCRIPTION
I'll need to revisit in another PR, this breaks anything part of the repeater item as the click event also fires whenever the item's content (when expanded) is clicked.