### PR TITLE
Expand repeater items by clicking on their title

### DIFF
--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -53,6 +53,11 @@
         this.$el.on('click', '> ul > li > .repeater-item-collapse .repeater-item-collapse-one', this.proxy(this.toggleCollapse))
         this.$el.on('click', '> .field-repeater-items > .field-repeater-add-item > [data-repeater-add-group]', this.proxy(this.clickAddGroupButton))
 
+        this.$el
+            .find('> ul > li > .repeater-item-collapsed-title')
+            .css({'cursor': 'pointer', 'width': '100%'})
+            .on('click', this.proxy(this.toggleCollapse))
+
         this.$el.one('dispose-control', this.proxy(this.dispose))
 
         this.togglePrompt()
@@ -67,6 +72,7 @@
         this.$el.off('ajaxDone', '> .field-repeater-items > .field-repeater-item > .repeater-item-remove > [data-repeater-remove]', this.proxy(this.onRemoveItemSuccess))
         this.$el.off('ajaxDone', '> .field-repeater-items > .field-repeater-add-item > [data-repeater-add]', this.proxy(this.onAddItemSuccess))
         this.$el.off('click', '> ul > li > .repeater-item-collapse .repeater-item-collapse-one', this.proxy(this.toggleCollapse))
+        this.$el.off('click', '> ul > li > .repeater-item-collapsed-title', this.proxy(this.toggleCollapse))
         this.$el.off('click', '> .field-repeater-items > .field-repeater-add-item > [data-repeater-add-group]', this.proxy(this.clickAddGroupButton))
 
         this.$el.off('dispose-control', this.proxy(this.dispose))

--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -53,8 +53,11 @@
         this.$el.on('click', '> ul > li > .repeater-item-collapse .repeater-item-collapse-one', this.proxy(this.toggleCollapse))
         this.$el.on('click', '> .field-repeater-items > .field-repeater-add-item > [data-repeater-add-group]', this.proxy(this.clickAddGroupButton))
 
-        this.$el
-            .find('> ul > li > .repeater-item-collapsed-title')
+        this.$el.find('> ul > li > .repeater-item-collapsed-title')
+            .css({'cursor': 'pointer', 'width': '100%'})
+            .on('click', this.proxy(this.toggleCollapse))
+
+        this.$el.find('> ul > li > .field-repeater-form > .form-group > label')
             .css({'cursor': 'pointer', 'width': '100%'})
             .on('click', this.proxy(this.toggleCollapse))
 
@@ -73,6 +76,7 @@
         this.$el.off('ajaxDone', '> .field-repeater-items > .field-repeater-add-item > [data-repeater-add]', this.proxy(this.onAddItemSuccess))
         this.$el.off('click', '> ul > li > .repeater-item-collapse .repeater-item-collapse-one', this.proxy(this.toggleCollapse))
         this.$el.off('click', '> ul > li > .repeater-item-collapsed-title', this.proxy(this.toggleCollapse))
+        this.$el.off('click', '> ul > li > .field-repeater-form > .form-group > label', this.proxy(this.toggleCollapse))
         this.$el.off('click', '> .field-repeater-items > .field-repeater-add-item > [data-repeater-add-group]', this.proxy(this.clickAddGroupButton))
 
         this.$el.off('dispose-control', this.proxy(this.dispose))


### PR DESCRIPTION
Take 2, avoid previous problems.

Only caveat is there is no element to easily allow collapse when the repeater item is expanded (other than the collapse/expand arrow)

Added click event on the form labels to be able to easily collapse the expanded form.