### PR TITLE
Allow dynamic methods to be used for custom list column types

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -1147,8 +1147,9 @@ class Lists extends WidgetBase
     {
         $value = $this->getColumnValueRaw($record, $column);
 
-        if (method_exists($this, 'eval'. studly_case($column->type) .'TypeValue')) {
-            $value = $this->{'eval'. studly_case($column->type) .'TypeValue'}($record, $column, $value);
+        $customMethod = 'eval'. studly_case($column->type) .'TypeValue';
+        if ($this->methodExists($customMethod)) {
+            $value = $this->{$customMethod}($record, $column, $value);
         }
         else {
             $value = $this->evalCustomListType($column->type, $record, $column, $value);


### PR DESCRIPTION
This will allow using the following code to add custom column types:
```php
\Backend\Widgets\Lists::extend(function () {
    $this->addDynamicMethod('evalMyCustomColumnTypeValue', function ($record, $column, $value) {
        return strtoupper($value);
    });
}, true);