### PR TITLE
Fix minor box shadow issue with recordfinder clear button

### DIFF
--- a/modules/backend/formwidgets/recordfinder/partials/_recordfinder.php
+++ b/modules/backend/formwidgets/recordfinder/partials/_recordfinder.php
@@ -25,7 +25,7 @@ if ($this->previewMode || $field->readOnly) {
         <?php if ($value): ?>
             <button
                 type="button"
-                class="btn clear-record"
+                class="btn btn-default clear-record"
                 data-request="<?= $this->getEventHandler('onClearRecord') ?>"
                 data-request-confirm="<?= e(trans('backend::lang.form.action_confirm')) ?>"
                 data-request-success="var $locker = $('#<?= $field->getId() ?>'); $locker.val(''); $locker.trigger('change')"


### PR DESCRIPTION
### Context
Both `.clear-record` and `.find-record` have `.btn` which bring `box-shadow: inset 0px -2px 0 rgba(0,0,0,.15);` CSS.

### Issue
The `box-shadow` is misaligned as shown here:
![image](https://github.com/user-attachments/assets/ed4c922a-4cd7-4379-be23-9a97309a661b)
It is because `.find-record` has `.btn.btn-default` class, unlike `.clear-record` which only have `.btn`.

### Solution
Add `.btn-default` to `.clear-record` button.

### Result
Box shadow placement is now correct:
![image](https://github.com/user-attachments/assets/cdc1712f-80b7-401f-bcc8-8bd927aa91ea)
