### PR TITLE
The popup supports custom url option.

### DIFF
--- a/modules/system/assets/ui/js/popup.js
+++ b/modules/system/assets/ui/js/popup.js
@@ -75,6 +75,7 @@
         if (this.options.handler) {
 
             this.$el.request(this.options.handler, {
+                url: this.options.url || undefined,
                 data: paramToObj('data-extra-data', this.options.extraData),
                 success: function(data, textStatus, jqXHR) {
                     this.success(data, textStatus, jqXHR).done(function(){


### PR DESCRIPTION
The default request URL for $.popup is location.href
```
$.popup({...})
```
Add support for URL parameters
```
$.popup({url: "https://xxxx.com/backend/plugin/author/action",...})
```
