### PR TITLE
Media Manager upload size and file name validation

### DIFF
--- a/modules/backend/traits/UploadableWidget.php
+++ b/modules/backend/traits/UploadableWidget.php
@@ -27,6 +27,11 @@ trait UploadableWidget
     // public $uploadPath;
 
     /**
+     * @var bool $validateFileName Determines whether the file name should be validated.
+     */
+    public bool $validateMediaFileName = true;
+
+    /**
      * Returns the disk that will be used to store the uploaded file
      */
     public function uploadableGetDisk(): FilesystemAdapter
@@ -171,7 +176,7 @@ trait UploadableWidget
         /*
          * File name contains non-latin characters, attempt to slug the value
          */
-        if (!$this->validateFileName($fileName)) {
+        if (!$this->validateFileName($fileName) && $this->validateMediaFileName) {
             $fileName = $this->cleanFileName(File::name($fileName)) . '.' . $extension;
         }
 

--- a/modules/backend/widgets/mediamanager/assets/js/mediamanager.js
+++ b/modules/backend/widgets/mediamanager/assets/js/mediamanager.js
@@ -838,7 +838,7 @@
     MediaManager.prototype.uploadError = function(file, message) {
         this.updateUploadBar('error', 'progress-bar progress-bar-danger');
 
-        if (file.xhr.status === 413) {
+        if (file?.xhr?.status === 413) {
             message = 'Server rejected the file because it was too large, try increasing post_max_size';
         }
         if (!message) {

--- a/modules/backend/widgets/mediamanager/assets/js/mediamanager.js
+++ b/modules/backend/widgets/mediamanager/assets/js/mediamanager.js
@@ -732,7 +732,8 @@
             paramName: 'file_data',
             timeout: 0,
             headers: {},
-            createImageThumbnails: false
+            createImageThumbnails: false,
+            maxFilesize: this.options.maxFilesize,
             // fallback: implement method that would set a flag that the uploader is not supported by the browser
         }
 
@@ -1309,7 +1310,8 @@
         selectSingleImage: 'Please select a single image.',
         selectionNotImage: 'The selected item is not an image.',
         bottomToolbar: false,
-        cropAndInsertButton: false
+        cropAndInsertButton: false,
+        maxFileSize: 0,
     }
 
     var old = $.fn.mediaManager


### PR DESCRIPTION
This is more of a getting started guideline as I'm not sure how to proceed with the changes or if they're good enough quality.
The first issue I encountered is the fact that by default `mediamanager.js` will have a max filesize of 256MB (dropzone default) and cant be increased any further.

2nd issue was actually trying to find why an error was popping up which lead to the first issue. When the file size is too big it just gives a console error. As it turns out the xhr property doesn't exist within the context so i had to make it conditional so it'd go to the actual popup.

3rd issue (or rather more of a preference) is that in some cases I'd prefer to keep the file names intact without any cleanup. So I made it so that you can optionally disable file name validation cleanup.

I'm not that familiar with dropzone, so im unsure how to integrate filesizes with winter so it works like how the fileupload widget does for now it's set to `0`. There also came an issue where because it's using `post_max_size` to upload a file to media manager, a memory exhaustion error popped up, and rather than having to globally set the memory limit higher, it would be better to use `ini_set` temporarily.