### PR TITLE
Remove redundent vite logic

### DIFF
--- a/modules/system/console/asset/vite/ViteWatch.php
+++ b/modules/system/console/asset/vite/ViteWatch.php
@@ -58,17 +58,6 @@ class ViteWatch extends ViteCompile
     }
 
     /**
-     * Create the public dir if required
-     */
-    protected function beforeExecution(string $configPath): void
-    {
-        $publicDir = dirname($configPath) . '/public';
-        if (!File::exists($publicDir)) {
-            File::makeDirectory($publicDir);
-        }
-    }
-
-    /**
      * Handle the cleanup of this command if a termination signal is received
      */
     public function handleCleanup(): void


### PR DESCRIPTION
This PR removes a function that would create the default dir for vite if running without a customised laravel vite plugin, which is not in use with our default configs.