### PR TITLE
Add `useEscapeFormula` option to ImportExportController

### DIFF
--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -611,6 +611,7 @@ class ImportExportController extends ControllerBehavior
             'delimiter' => $this->getConfig('defaultFormatOptions[delimiter]', ','),
             'enclosure' => $this->getConfig('defaultFormatOptions[enclosure]', '"'),
             'escape' => $this->getConfig('defaultFormatOptions[escape]', '\\'),
+            'useEscapeFormula' => $this->getConfig('defaultFormatOptions[useEscapeFormula]', True),
         ];
 
         $options = array_merge($defaultOptions, $options);
@@ -625,7 +626,10 @@ class ImportExportController extends ControllerBehavior
         $csv->setDelimiter($options['delimiter']);
         $csv->setEnclosure($options['enclosure']);
         $csv->setEscape($options['escape']);
-        $csv->addFormatter(new CsvEscapeFormula());
+
+        if ($options['useEscapeFormula']) {
+            $csv->addFormatter(new CsvEscapeFormula());
+        }
 
         /*
          * Add headers

--- a/modules/backend/behaviors/ImportExportController.php
+++ b/modules/backend/behaviors/ImportExportController.php
@@ -611,7 +611,7 @@ class ImportExportController extends ControllerBehavior
             'delimiter' => $this->getConfig('defaultFormatOptions[delimiter]', ','),
             'enclosure' => $this->getConfig('defaultFormatOptions[enclosure]', '"'),
             'escape' => $this->getConfig('defaultFormatOptions[escape]', '\\'),
-            'useEscapeFormula' => $this->getConfig('defaultFormatOptions[useEscapeFormula]', True),
+            'useEscapeFormula' => $this->getConfig('defaultFormatOptions[useEscapeFormula]', true),
         ];
 
         $options = array_merge($defaultOptions, $options);

--- a/modules/backend/models/ExportModel.php
+++ b/modules/backend/models/ExportModel.php
@@ -84,10 +84,11 @@ abstract class ExportModel extends Model
         $defaultOptions = [
             'firstRowTitles' => true,
             'useOutput' => false,
+            'useEscapeFormula' => true,
             'fileName' => 'export.csv',
             'delimiter' => null,
             'enclosure' => null,
-            'escape' => null
+            'escape' => null,
         ];
 
         $options = array_merge($defaultOptions, $options);
@@ -112,7 +113,9 @@ abstract class ExportModel extends Model
             $csv->setEscape($options['escape']);
         }
 
-        $csv->addFormatter(new CsvEscapeFormula());
+        if ($options['useEscapeFormula']) {
+            $csv->addFormatter(new CsvEscapeFormula());
+        }
 
         /*
          * Add headers


### PR DESCRIPTION
This option allow to skip adding the CsvEscapeFormula to the CsvWriter formatters.
The default is true, preserving existing behavior.

One can change this option in the config_import_export as below:
```yaml
export:
  fileName: export.csv
defaultFormatOptions:
  useEscapeFormula: false
```