### PR TITLE
Move after login logic to event listener instead of controller

### DIFF
--- a/modules/backend/ServiceProvider.php
+++ b/modules/backend/ServiceProvider.php
@@ -33,6 +33,7 @@ class ServiceProvider extends ModuleServiceProvider
         $this->registerMailer();
         $this->registerAssetBundles();
         $this->registerBackendPermissions();
+        $this->registerBackendUserEvents();
 
         /*
          * Backend specific
@@ -53,20 +54,6 @@ class ServiceProvider extends ModuleServiceProvider
     public function boot()
     {
         parent::boot('backend');
-
-        Event::listen('backend.user.login', function (\Backend\Models\User $user) {
-            $runMigrationsOnLogin = (bool) Config::get('cms.runMigrationsOnLogin', Config::get('app.debug', false));
-            if ($runMigrationsOnLogin) {
-                try {
-                    // Load version updates
-                    UpdateManager::instance()->update();
-                } catch (Exception $e) {
-                    Flash::error($e->getMessage());
-                }
-            }
-            // Log the sign in event
-            AccessLog::add($user);
-        });
     }
 
     /**
@@ -226,6 +213,28 @@ class ServiceProvider extends ModuleServiceProvider
                 ],
             ]);
             $manager->registerPermissionOwnerAlias('Winter.Backend', 'October.Backend');
+        });
+    }
+
+    /**
+     * Register the backend user events
+     */
+    protected function registerBackendUserEvents()
+    {
+        Event::listen('backend.user.login', function (\Backend\Models\User $user) {
+            // @TODO: Deprecate this, and only run migrations when it makes sense
+            $runMigrationsOnLogin = (bool) Config::get('cms.runMigrationsOnLogin', Config::get('app.debug', false));
+            if ($runMigrationsOnLogin) {
+                try {
+                    // Load version updates
+                    UpdateManager::instance()->update();
+                } catch (Exception $e) {
+                    Flash::error($e->getMessage());
+                }
+            }
+
+            // Log the sign in event
+            AccessLog::add($user);
         });
     }
 

--- a/modules/backend/ServiceProvider.php
+++ b/modules/backend/ServiceProvider.php
@@ -1,13 +1,21 @@
 <?php namespace Backend;
 
-use Backend;
-use BackendMenu;
-use BackendAuth;
-use Backend\Models\UserRole;
 use Backend\Classes\WidgetManager;
-use System\Classes\MailManager;
+use Backend\Facades\Backend;
+use Backend\Facades\BackendAuth;
+use Backend\Facades\BackendMenu;
+use Backend\Models\AccessLog;
+use Backend\Models\UserRole;
+use Exception;
+use Illuminate\Support\Facades\Event;
 use System\Classes\CombineAssets;
+use System\Classes\MailManager;
 use System\Classes\SettingsManager;
+use System\Classes\UpdateManager;
+use Winter\Storm\Auth\Models\User as UserBase;
+use Winter\Storm\Support\Facades\Config;
+use Winter\Storm\Support\Facades\Flash;
+use Winter\Storm\Support\Facades\Mail;
 use Winter\Storm\Support\ModuleServiceProvider;
 
 class ServiceProvider extends ModuleServiceProvider
@@ -45,6 +53,20 @@ class ServiceProvider extends ModuleServiceProvider
     public function boot()
     {
         parent::boot('backend');
+
+        Event::listen('backend.user.login', function (\Backend\Models\User $user) {
+            $runMigrationsOnLogin = (bool) Config::get('cms.runMigrationsOnLogin', Config::get('app.debug', false));
+            if ($runMigrationsOnLogin) {
+                try {
+                    // Load version updates
+                    UpdateManager::instance()->update();
+                } catch (Exception $e) {
+                    Flash::error($e->getMessage());
+                }
+            }
+            // Log the sign in event
+            AccessLog::add($user);
+        });
     }
 
     /**

--- a/modules/backend/ServiceProvider.php
+++ b/modules/backend/ServiceProvider.php
@@ -12,10 +12,8 @@ use System\Classes\CombineAssets;
 use System\Classes\MailManager;
 use System\Classes\SettingsManager;
 use System\Classes\UpdateManager;
-use Winter\Storm\Auth\Models\User as UserBase;
 use Winter\Storm\Support\Facades\Config;
 use Winter\Storm\Support\Facades\Flash;
-use Winter\Storm\Support\Facades\Mail;
 use Winter\Storm\Support\ModuleServiceProvider;
 
 class ServiceProvider extends ModuleServiceProvider

--- a/modules/backend/controllers/Auth.php
+++ b/modules/backend/controllers/Auth.php
@@ -4,13 +4,11 @@ use ApplicationException;
 use Backend;
 use BackendAuth;
 use Backend\Classes\Controller;
-use Backend\Models\AccessLog;
 use Config;
 use Exception;
 use Flash;
 use Mail;
 use Request;
-use System\Classes\UpdateManager;
 use ValidationException;
 use Validator;
 use Winter\Storm\Foundation\Http\Middleware\CheckForTrustedHost;
@@ -93,20 +91,6 @@ class Auth extends Controller
             'login' => post('login'),
             'password' => post('password')
         ], $remember);
-
-        $runMigrationsOnLogin = (bool) Config::get('cms.runMigrationsOnLogin', Config::get('app.debug', false));
-
-        if ($runMigrationsOnLogin) {
-            try {
-                // Load version updates
-                UpdateManager::instance()->update();
-            } catch (Exception $ex) {
-                Flash::error($ex->getMessage());
-            }
-        }
-
-        // Log the sign in event
-        AccessLog::add($user);
 
         // Redirect to the intended page after successful sign in
         return Backend::redirectIntended('backend');

--- a/modules/backend/models/User.php
+++ b/modules/backend/models/User.php
@@ -1,10 +1,15 @@
 <?php namespace Backend\Models;
 
-use Mail;
-use Event;
-use Backend;
-use BackendAuth;
+use Backend\Facades\Backend;
+use Backend\Facades\BackendAuth;
+use Backend\Models\AccessLog;
+use Exception;
+use Illuminate\Support\Facades\Event;
+use System\Classes\UpdateManager;
 use Winter\Storm\Auth\Models\User as UserBase;
+use Winter\Storm\Support\Facades\Config;
+use Winter\Storm\Support\Facades\Flash;
+use Winter\Storm\Support\Facades\Mail;
 
 /**
  * Administrator user model
@@ -155,6 +160,18 @@ class User extends UserBase
          *
          */
         Event::fire('backend.user.login', [$this]);
+
+        $runMigrationsOnLogin = (bool) Config::get('cms.runMigrationsOnLogin', Config::get('app.debug', false));
+        if ($runMigrationsOnLogin) {
+            try {
+                // Load version updates
+                UpdateManager::instance()->update();
+            } catch (Exception $e) {
+                Flash::error($e->getMessage());
+            }
+        }
+        // Log the sign in event
+        AccessLog::add($user);
     }
 
     /**

--- a/modules/backend/models/User.php
+++ b/modules/backend/models/User.php
@@ -2,13 +2,8 @@
 
 use Backend\Facades\Backend;
 use Backend\Facades\BackendAuth;
-use Backend\Models\AccessLog;
-use Exception;
 use Illuminate\Support\Facades\Event;
-use System\Classes\UpdateManager;
 use Winter\Storm\Auth\Models\User as UserBase;
-use Winter\Storm\Support\Facades\Config;
-use Winter\Storm\Support\Facades\Flash;
 use Winter\Storm\Support\Facades\Mail;
 
 /**
@@ -160,18 +155,6 @@ class User extends UserBase
          *
          */
         Event::fire('backend.user.login', [$this]);
-
-        $runMigrationsOnLogin = (bool) Config::get('cms.runMigrationsOnLogin', Config::get('app.debug', false));
-        if ($runMigrationsOnLogin) {
-            try {
-                // Load version updates
-                UpdateManager::instance()->update();
-            } catch (Exception $e) {
-                Flash::error($e->getMessage());
-            }
-        }
-        // Log the sign in event
-        AccessLog::add($this);
     }
 
     /**

--- a/modules/backend/models/User.php
+++ b/modules/backend/models/User.php
@@ -171,7 +171,7 @@ class User extends UserBase
             }
         }
         // Log the sign in event
-        AccessLog::add($user);
+        AccessLog::add($this);
     }
 
     /**


### PR DESCRIPTION
User model now handles running the migrations in its afterLogin() method.