### PR TITLE
Remove redundant backend route

### DIFF
--- a/modules/backend/routes.php
+++ b/modules/backend/routes.php
@@ -20,7 +20,7 @@ Event::listen('system.route', function () {
     Event::fire('backend.beforeRoute');
 
     /*
-     * Other pages
+     * Entry point
      */
     Route::group([
         'middleware' => ['web'],
@@ -28,11 +28,6 @@ Event::listen('system.route', function () {
     ], function () {
         Route::any('{slug?}', 'Backend\Classes\BackendController@run')->where('slug', '(.*)?');
     });
-
-    /*
-     * Entry point
-     */
-    Route::any(Config::get('cms.backendUri', 'backend'), 'Backend\Classes\BackendController@run')->middleware('web');
 
     /**
      * @event backend.route

--- a/modules/backend/routes.php
+++ b/modules/backend/routes.php
@@ -20,7 +20,7 @@ Event::listen('system.route', function () {
     Event::fire('backend.beforeRoute');
 
     /*
-     * Entry point
+     * Route everything to `Backend\Classes\BackendController`, which itself acts as a router for the Backend.
      */
     Route::group([
         'middleware' => ['web'],


### PR DESCRIPTION
I tested this on nginx and apache on both Laravel 9 and Laravel 11 by making sure the route cache was cleared.

No issues so far.