### PR TITLE
Avoid Vite generating an extra `assets` folder in `assets/dist`

### DIFF
--- a/modules/system/console/asset/fixtures/config/vite/vite.config.mjs.fixture
+++ b/modules/system/console/asset/fixtures/config/vite/vite.config.mjs.fixture
@@ -4,6 +4,7 @@ import laravel from 'laravel-vite-plugin';
 export default defineConfig({
     build: {
         outDir: 'assets/dist',
+        assetsDir: '',
     },
     plugins: [
         laravel({


### PR DESCRIPTION
Before : 
```
themes/mytheme
├─ assets/
│  ├─ dist/
│  │  ├─ assets/
│  │  │  ├─ mytheme-xxxxx.js
│  │  │  ├─ mytheme-xxxxx.css
│  │  ├─ manifest.json
│  ├─ src/
│  │  ├─ css/
│  │  │  ├─ mytheme.css
│  │  ├─ js/
│  │  │  ├─mytheme.js
│  ├─ manifest.json
```

After : 
```
themes/mytheme
├─ assets/
│  ├─ dist/
│  │  ├─ mytheme-xxxxx.js
│  │  ├─ mytheme-xxxxx.css
│  │  ├─ manifest.json
│  ├─ src/
│  │  ├─ css/
│  │  │  ├─ mytheme.css
│  │  ├─ js/
│  │  │  ├─ mytheme.js
│  ├─ manifest.json
```