### PR TITLE
Force mirror absolute paths on Windows

### DIFF
--- a/modules/system/console/WinterMirror.php
+++ b/modules/system/console/WinterMirror.php
@@ -197,7 +197,7 @@ class WinterMirror extends Command
 
     protected function mirror($src, $dest)
     {
-        if ($this->option('relative')) {
+        if ($this->option('relative') && PHP_OS_FAMILY !== 'Windows') {
             $src = $this->getRelativePath($dest, $src);
 
             if (strpos($src, '../') === 0) {


### PR DESCRIPTION
This change makes the `--relative` flag inactive on Windows as Windows symlinks must be absolute. 