### PR TITLE
Added fix to ensure escaped backslash paths are preserved in DB_DATABASE env values

### DIFF
--- a/modules/system/console/WinterEnv.php
+++ b/modules/system/console/WinterEnv.php
@@ -122,7 +122,11 @@ class WinterEnv extends Command
                     $dbConfig = $this->dbConfig()[$default] ?? [];
 
                     foreach ($dbConfig as $dbEnvKey => $dbConfigKey) {
-                        $env->set($dbEnvKey, config(join('.', [$config, 'connections', $default, $dbConfigKey])));
+                        $value = config(join('.', [$config, 'connections', $default, $dbConfigKey]));
+                        if ($dbEnvKey === 'DB_DATABASE' && PHP_OS_FAMILY === 'Windows' && str_contains($value, '\\')) {
+                            $value = str_replace('\\', '\\\\', $value);
+                        }
+                        $env->set($dbEnvKey, $value);
                     }
                 }
 

--- a/modules/system/console/WinterEnv.php
+++ b/modules/system/console/WinterEnv.php
@@ -123,6 +123,7 @@ class WinterEnv extends Command
 
                     foreach ($dbConfig as $dbEnvKey => $dbConfigKey) {
                         $value = config(join('.', [$config, 'connections', $default, $dbConfigKey]));
+                        // Fix for https://github.com/wintercms/winter/issues/1242#issuecomment-2515344385
                         if ($dbEnvKey === 'DB_DATABASE' && PHP_OS_FAMILY === 'Windows' && str_contains($value, '\\')) {
                             $value = str_replace('\\', '\\\\', $value);
                         }


### PR DESCRIPTION
This fix  adds support for preserving double escapped backslashes when running `winter:env` on Windows when copying the `DB_DATABASE` env value, this fixes an issue caused by `winter:install` creating the sqlite db database path with a Windows directory seperator.