### PR TITLE
Remove empty item for all taglist modes

### DIFF
--- a/modules/backend/formwidgets/TagList.php
+++ b/modules/backend/formwidgets/TagList.php
@@ -110,15 +110,17 @@ class TagList extends FormWidgetBase
      */
     public function getSaveValue($value)
     {
-        if (is_array($value)) {
-            $value = array_filter($value);
+        if (!is_array($value)) {
+            $value = [$value];
         }
+
+        $value = array_filter($value);
 
         if ($this->mode === static::MODE_RELATION) {
             return $this->hydrateRelationSaveValue($value);
         }
 
-        if (is_array($value) && $this->mode === static::MODE_STRING) {
+        if ($this->mode === static::MODE_STRING) {
             return implode($this->getSeparatorCharacter(), $value);
         }
 
@@ -129,12 +131,8 @@ class TagList extends FormWidgetBase
      * Returns an array suitable for saving against a relation (array of keys).
      * This method also creates non-existent tags.
      */
-    protected function hydrateRelationSaveValue($names): ?array
+    protected function hydrateRelationSaveValue(array $names): ?array
     {
-        if (!is_array($names)) {
-            $names = [$names];
-        }
-
         $relation = $this->getRelationObject();
         $relationModel = $this->getRelationModel();
 

--- a/modules/backend/formwidgets/TagList.php
+++ b/modules/backend/formwidgets/TagList.php
@@ -110,6 +110,10 @@ class TagList extends FormWidgetBase
      */
     public function getSaveValue($value)
     {
+        if (is_array($value)) {
+            $value = array_filter($value);
+        }
+
         if ($this->mode === static::MODE_RELATION) {
             return $this->hydrateRelationSaveValue($value);
         }
@@ -130,8 +134,6 @@ class TagList extends FormWidgetBase
         if (!is_array($names)) {
             $names = [$names];
         }
-
-        $names = array_filter($names);
 
         $relation = $this->getRelationObject();
         $relationModel = $this->getRelationModel();

--- a/modules/backend/formwidgets/taglist/partials/_taglist.php
+++ b/modules/backend/formwidgets/taglist/partials/_taglist.php
@@ -29,7 +29,7 @@ foreach ($availableOptions as $key => $option) {
     <?php else: ?>
         <input
             type="hidden"
-            name="<?= $field->getName() ?>"
+            name="<?= $field->getName() ?>[]"
             value="<?= $field->value ?>">
     <?php endif ?>
 <?php else: ?>


### PR DESCRIPTION
The empty item that was added in previous PR was not removed in array and string modes.
Make sure we always deal with arrays from the POST data.

Fixes #1275 