### PR TITLE
UI - Fixed font size of buttons

### DIFF
--- a/modules/system/assets/ui/less/button.less
+++ b/modules/system/assets/ui/less/button.less
@@ -16,7 +16,6 @@
 // --------------------------------------------------
 
 .btn {
-    font-size: @font-size-base - 1;
     outline: none !important;
     .box-shadow(~"inset 0 -2px 0 rgba(0,0,0,.15)");
 


### PR DESCRIPTION
This property (which has been removed) overrides the font size for all buttons. This causes the font to display incorrectly for buttons of different sizes: https://wintercms.com/docs/v1.2/ui/controls/button#sizes

Screenshot before:
![btn-before](https://github.com/user-attachments/assets/7e44c8fc-cee9-4fd6-bfd5-919bebd4b9fc)

Screenshot after:
![btn-after](https://github.com/user-attachments/assets/bce50242-3441-4fdb-b2a4-2500a465d40d)

---

Initially, the `font-size` property is already defined here: https://github.com/wintercms/winter/blob/206e73847cf65f87e3ca12862859223cc1b8a785/modules/system/assets/ui/less/button.base.less#L15

If we want the default font size to be `13px` (as overridden in the property I removed), then perhaps we should change the `@font-size-base` parameter to `@font-size-base - 1` 

Correct to:

```less
.button-size(@padding-base-vertical; @padding-base-horizontal; @font-size-base - 1; @line-height-base; @border-radius-base);
```

**I don't remember if it is possible to pass a calculated expression in parameters for LESS**

Mixin: https://github.com/wintercms/winter/blob/206e73847cf65f87e3ca12862859223cc1b8a785/modules/system/assets/ui/less/button.mixins.less#L97

---

Class sizes are listed here https://github.com/wintercms/winter/blob/206e73847cf65f87e3ca12862859223cc1b8a785/modules/system/assets/ui/less/button.base.less#L147-L160

---

**I don't have the technical ability to recompile styles from LESS.**