### PR TITLE
Fix TagList returning an object in array mode

### DIFF
--- a/modules/backend/formwidgets/TagList.php
+++ b/modules/backend/formwidgets/TagList.php
@@ -114,7 +114,7 @@ class TagList extends FormWidgetBase
             $value = [$value];
         }
 
-        $value = array_filter($value);
+        $value = array_values(array_filter($value));
 
         if ($this->mode === static::MODE_RELATION) {
             return $this->hydrateRelationSaveValue($value);


### PR DESCRIPTION
After applying the `array_filter` method, the `$value` array lost its 0-based indexing, causing it to be treated as an object instead of an array. To resolve this, I’ve wrapped the result with `array_values` to reindex it and restore it as an array.