### PR TITLE
Make entire mediafinder field clickable when mode=file

### DIFF
--- a/modules/backend/formwidgets/mediafinder/assets/js/mediafinder.js
+++ b/modules/backend/formwidgets/mediafinder/assets/js/mediafinder.js
@@ -61,6 +61,7 @@
         }
 
         this.$el.on('click', '.find-button', this.proxy(this.onClickFindButton))
+        this.$el.on('click', '.find-empty-message', this.proxy(this.onClickFindButton)).css({'cursor':'pointer'})
         this.$el.on('click', '.find-remove-button', this.proxy(this.onClickRemoveButton))
 
         this.$findValue = $('[data-find-value]', this.$el)


### PR DESCRIPTION
Make the whole widget clickable to open the mediafinder (as it was done on the fileupload widget)