### PR TITLE
Added better log viewing

### DIFF
--- a/modules/cms/classes/CodeParser.php
+++ b/modules/cms/classes/CodeParser.php
@@ -153,11 +153,15 @@ class CodeParser
         $fileContents .= trim($body).PHP_EOL;
         $fileContents .= '}'.PHP_EOL;
 
-        $this->validate($fileContents);
-
         $this->makeDirectorySafe(dirname($path));
 
         $this->writeContentSafe($path, $fileContents);
+
+        // Attempt to load the generated code file to ensure any errors are thrown
+        // before the file is cached
+        if (!class_exists($className)) {
+            require_once $path;
+        }
 
         return $className;
     }
@@ -288,15 +292,6 @@ class CodeParser
     //
     // Helpers
     //
-
-    /**
-     * Evaluates PHP content in order to detect syntax errors.
-     * The method handles PHP errors and throws exceptions.
-     */
-    protected function validate($php)
-    {
-        eval('?>'.$php);
-    }
 
     /**
      * Extracts the class name from a cache file

--- a/modules/system/assets/js/eventlogs/exception-beautifier.links.js
+++ b/modules/system/assets/js/eventlogs/exception-beautifier.links.js
@@ -7,10 +7,11 @@
     var ExceptionBeautifier = $.fn.exceptionBeautifier.Constructor
 
     ExceptionBeautifier.EDITORS = {
+        vscode: {scheme: 'vscode://file/%file:%line', name: 'VS Code (vscode://)'},
+        phpstorm: {scheme: 'phpstorm://open?file=%file&line=%line', name: 'PhpStorm (phpstorm://)'},
         subl: {scheme: 'subl://open?url=file://%file&line=%line', name: 'Sublime (subl://)'},
         txmt: {scheme: 'txmt://open/?url=file://%file&line=%line', name: 'TextMate (txmt://)'},
         mvim: {scheme: 'mvim://open/?url=file://%file&line=%line', name: 'MacVim (mvim://)'},
-        phpstorm: {scheme: 'phpstorm://open?file=%file&line=%line', name: 'PhpStorm (phpstorm://)'},
         editor: {scheme: 'editor://open/?file=%file&line=%line', name: 'Custom (editor://)'}
     }
 

--- a/modules/system/controllers/eventlogs/_field_details.php
+++ b/modules/system/controllers/eventlogs/_field_details.php
@@ -169,11 +169,13 @@ function getOrderedExceptionList(array $value): array
                             <span class="item"><?= $exception['file'] ?></span>
                             at line <span class="item"><?= $exception['line'] ?></span>
                         </div>
-                        <div class="snippet-preview-container">
-                            <div class="snippet-preview">
-                                <?= makeSnippet($exception['snippet'], $exception['line']) ?>
+                        <?php if ($exception['snippet']): ?>
+                            <div class="snippet-preview-container">
+                                <div class="snippet-preview">
+                                    <?= makeSnippet($exception['snippet'], $exception['line']) ?>
+                                </div>
                             </div>
-                        </div>
+                        <?php endif; ?>
                     </div>
                 </div>
 
@@ -193,11 +195,13 @@ function getOrderedExceptionList(array $value): array
                                         <span class="app-icon">In App</span>
                                     <?php endif; ?>
                                 </div>
-                                <div class="snippet-preview-container <?= $frame['in_app'] ? 'unfolded' : 'folded' ?>">
-                                    <div class="snippet-preview">
-                                        <?= makeSnippet($frame['snippet'], $frame['line']) ?>
+                                <?php if ($frame['snippet']): ?>
+                                    <div class="snippet-preview-container <?= $frame['in_app'] ? 'unfolded' : 'folded' ?>">
+                                        <div class="snippet-preview">
+                                            <?= makeSnippet($frame['snippet'], $frame['line']) ?>
+                                        </div>
                                     </div>
-                                </div>
+                                <?php endif; ?>
                             </div>
                         <?php endforeach; ?>
                     </div>
@@ -214,7 +218,7 @@ function getOrderedExceptionList(array $value): array
     (() => {
         document.querySelectorAll('.trace-frame').forEach((frame) => {
             frame.querySelector('.label').addEventListener('click', () => {
-                frame.querySelector('div.snippet-preview-container').classList.toggle('folded');
+                frame.querySelector('div.snippet-preview-container')?.classList.toggle('folded');
             });
         });
         window.addEventListener('load', () => {

--- a/modules/system/controllers/eventlogs/_field_details.php
+++ b/modules/system/controllers/eventlogs/_field_details.php
@@ -12,7 +12,7 @@ if (!isset($value['logVersion']) || $value['logVersion'] !== 2) {
 function phpSyntaxHighlight(string $str): string
 {
     $regexes = [
-        'control' => '/\b(for|foreach|while|class |extends|yield from|yield|echo|fn|implements|try|catch|finally|throw|new|instanceof|function|return|unset|static|public|protected|private|count|global|if|else|else if|intval|int|array)\b/',
+        'control' => '/\b(for|foreach|while|class |extends|yield from|yield|echo|fn|implements|try|catch|finally|throw|new|instanceof|parent|function|return|unset|static|public|protected|private|count|global|if|else|else if|intval|int|array)\b/',
         'bool' => '/(\bnull\b|\btrue\b|\bfalse\b)/',
         'string' => [
             'pattern' => '/(\221[^\221]*\221|\222[^\222]*\222)/',

--- a/modules/system/controllers/eventlogs/_field_details.php
+++ b/modules/system/controllers/eventlogs/_field_details.php
@@ -58,16 +58,17 @@ function phpSyntaxHighlight(string $str): string
  * @param int|null $highlight
  * @return string
  */
-function makeSnippet(array $snippet, ?int $highlight = null): string
+function makeSnippet(array $snippet, string $file, ?int $highlight = null): string
 {
     return implode(
         "\n",
         array_reduce(
             array_keys($snippet),
-            function (array $carry, $key) use ($snippet, $highlight) {
+            function (array $carry, $key) use ($snippet, $file, $highlight) {
                 $carry[] = sprintf(
-                    '<div class="preview-line%s"><span class="line-number">%s</span>: %s</div>',
+                    '<div class="preview-line%s"><span class="line-number" data-idelink="idelink://%s&%3$d"">%3$d</span>: %4$s</div>',
                     ($key + 1 === $highlight ? ' highlight' : ''),
+                    urlencode(str_replace('\\', '/', $file)),
                     $key + 1,
                     phpSyntaxHighlight(e($snippet[$key], true))
                 );
@@ -184,6 +185,9 @@ function getOrderedExceptionList(array $value): array
         padding: 5px 10px;
         margin: -5px 0;
     }
+    div.snippet-preview div.preview-line span.line-number {
+        cursor: pointer;
+    }
     div.snippet-preview div.preview-line.highlight span.line-number {
         color: red;
     }
@@ -269,7 +273,11 @@ function getOrderedExceptionList(array $value): array
                         </tr>
                         <tr>
                             <th>Url</th>
-                            <td><?= $value['environment']['url'] ?></td>
+                            <td>
+                                <a href="<?= $value['environment']['url'] ?>" target="_blank" rel="noopener">
+                                    <?= $value['environment']['url'] ?>
+                                </a>
+                            </td>
                         </tr>
                         <tr>
                             <th>User Agent</th>
@@ -333,7 +341,7 @@ function getOrderedExceptionList(array $value): array
                             <?php if ($exception['snippet']): ?>
                                 <div class="snippet-preview-container">
                                     <div class="snippet-preview">
-                                        <?= makeSnippet($exception['snippet'], $exception['line']) ?>
+                                        <?= makeSnippet($exception['snippet'], $exception['file'], $exception['line']) ?>
                                     </div>
                                 </div>
                             <?php endif; ?>
@@ -359,7 +367,7 @@ function getOrderedExceptionList(array $value): array
                                     <?php if ($frame['snippet']): ?>
                                         <div class="snippet-preview-container <?= $frame['in_app'] ? 'unfolded' : 'folded' ?>">
                                             <div class="snippet-preview">
-                                                <?= makeSnippet($frame['snippet'], $frame['line']) ?>
+                                                <?= makeSnippet($frame['snippet'], $frame['file'], $frame['line']) ?>
                                             </div>
                                         </div>
                                     <?php endif; ?>
@@ -377,113 +385,6 @@ function getOrderedExceptionList(array $value): array
 </div>
 
 <script>
-    const EDITORS = {
-        vscode: { scheme: 'vscode://file/%file:%line', name: 'VS Code (vscode://)' },
-        phpstorm: { scheme: 'phpstorm://open?file=%file&line=%line', name: 'PhpStorm (phpstorm://)' },
-        subl: { scheme: 'subl://open?url=file://%file&line=%line', name: 'Sublime (subl://)' },
-        txmt: { scheme: 'txmt://open/?url=file://%file&line=%line', name: 'TextMate (txmt://)' },
-        mvim: { scheme: 'mvim://open/?url=file://%file&line=%line', name: 'MacVim (mvim://)' },
-        editor: { scheme: 'editor://open/?file=%file&line=%line', name: 'Custom (editor://)' }
-    };
-
-    const REGEX = {
-        editor: /idelink:\/\/([^#]+)&([0-9]+)?/
-    };
-
-    let LINKER_POPUP_CONTENT = null;
-
-    function openWithEditor(link) {
-        const matches = link.match(REGEX.editor);
-
-        const open = function(value) {
-            const editorScheme = EDITORS[value].scheme
-                .replace(/%file/, matches[1])
-                .replace(/%line/, matches[2]);
-            window.open(link.replace(REGEX.editor, editorScheme), '_self');
-        };
-
-        console.log(matches);
-
-        if (matches) {
-            if (sessionStorage && sessionStorage.getItem('wn-exception-beautifier-editor')) {
-                open(sessionStorage.getItem('wn-exception-beautifier-editor'));
-            } else {
-                // Create and display the popup if not already created
-                if (!LINKER_POPUP_CONTENT) {
-                    const title = 'Select an Editor';
-                    const description = 'Choose an editor to open the file:';
-                    const openWith = 'Open with:';
-                    const rememberChoice = 'Remember choice for next time';
-                    const open = 'Open';
-                    const cancel = 'Cancel';
-                    const popup = document.createElement('div');
-                    popup.innerHTML = `
-                        <div class="modal-header">
-                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                            <h4 class="modal-title">${title}</h4>
-                        </div>
-                        <div class="modal-body">
-                            <p>${description}</p>
-                            <div class="form-group">
-                                <label class="control-label">${openWith}:</label>
-                                <select class="form-control" name="select-exception-link-editor"></select>
-                            </div>
-                            <div class="checkbox custom-checkbox">
-                                <input name="checkbox" value="1" type="checkbox" id="editor-remember-choice" />
-                                <label for="editor-remember-choice">${rememberChoice}</label>
-                            </div>
-                        </div>
-                        <div class="modal-footer">
-                            <button type="button" class="btn btn-primary" data-action="submit" data-dismiss="modal">${open}</button>
-                            <button type="button" class="btn btn-default" data-dismiss="popup">${cancel}</button>
-                        </div>
-                    `;
-
-                    const select = popup.querySelector('select');
-                    for (let key in EDITORS) {
-                        if (EDITORS.hasOwnProperty(key)) {
-                            const option = document.createElement('option');
-                            option.value = key;
-                            option.textContent = EDITORS[key].name;
-                            select.appendChild(option);
-                        }
-                    }
-
-                    LINKER_POPUP_CONTENT = popup.outerHTML;
-                }
-
-                const modal = document.createElement('div');
-                modal.innerHTML = LINKER_POPUP_CONTENT;
-                document.body.appendChild(modal);
-
-                const popup = modal.querySelector('.modal-body');
-                const select = popup.querySelector('select');
-                const submitBtn = modal.querySelector('[data-action="submit"]');
-                const rememberCheckbox = modal.querySelector('#editor-remember-choice');
-
-                submitBtn.addEventListener('click', function() {
-                    if (rememberCheckbox.checked && sessionStorage) {
-                        sessionStorage.setItem('wn-exception-beautifier-editor', select.value);
-                    }
-                    open(select.value);
-                    document.body.removeChild(modal);
-                });
-
-                modal.querySelector('[data-dismiss="popup"]').addEventListener('click', function() {
-                    document.body.removeChild(modal);
-                });
-            }
-        }
-    }
-
-    function formatFilePath(path, line) {
-        return `<a href="javascript:" data-href="idelink://${encodeURIComponent(rewritePath(path))}&${line}">${path}</a>`;
-    }
-
-    function rewritePath(path) {
-        return path.replace(/\\/g, '/');
-    }
-
     (() => {
         document.querySelectorAll('.trace-frame').forEach((frame) => {
             frame.querySelector('.label').addEventListener('click', () => {
@@ -503,6 +404,102 @@ function getOrderedExceptionList(array $value): array
             $("select#exception-sort-order").on('change', (e) => {
                 document.querySelector('#winter-log-viewer .exception-list').classList[e.target.value === 'old' ? 'remove' : 'add']('reverse');
             });
+
+            // Luke made me do it
+            // Script to load files in editors
+            (() => {
+                const editors = {
+                    vscode: { scheme: 'vscode://file/%file:%line', name: 'VS Code (vscode://)' },
+                    phpstorm: { scheme: 'phpstorm://open?file=%file&line=%line', name: 'PhpStorm (phpstorm://)' },
+                    subl: { scheme: 'subl://open?url=file://%file&line=%line', name: 'Sublime (subl://)' },
+                    txmt: { scheme: 'txmt://open/?url=file://%file&line=%line', name: 'TextMate (txmt://)' },
+                    mvim: { scheme: 'mvim://open/?url=file://%file&line=%line', name: 'MacVim (mvim://)' },
+                    editor: { scheme: 'editor://open/?file=%file&line=%line', name: 'Custom (editor://)' }
+                };
+
+                const ideLinkRegex = /idelink:\/\/([^#]+)&([0-9]+)?/;
+
+                function openWithEditor(link) {
+                    const matches = link.match(ideLinkRegex);
+
+                    const open = function(value) {
+                        const editorScheme = editors[value].scheme
+                            .replace(/%file/, matches[1])
+                            .replace(/%line/, matches[2]);
+                        window.open(link.replace(ideLinkRegex, editorScheme), '_self');
+                    };
+
+                    if (!matches) {
+                        return;
+                    }
+
+                    if (sessionStorage && sessionStorage.getItem('wn-exception-beautifier-editor')) {
+                        open(sessionStorage.getItem('wn-exception-beautifier-editor'));
+                        return;
+                    }
+
+                    const title = 'Select an Editor';
+                    const description = 'Choose an editor to open the file:';
+                    const openWith = 'Open with:';
+                    const rememberChoice = 'Remember choice for next time';
+                    const openString = 'Open';
+                    const cancel = 'Cancel';
+
+                    $.popup({
+                        size: 'large idelink-popup',
+                        content: `
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                                <h4 class="modal-title">${title}</h4>
+                            </div>
+                            <div class="modal-body">
+                                <p>${description}</p>
+                                <div class="form-group">
+                                    <label class="control-label">${openWith}:</label>
+                                    <select class="form-control" name="select-exception-link-editor"></select>
+                                </div>
+                                <div class="checkbox custom-checkbox">
+                                    <input name="checkbox" value="1" type="checkbox" id="editor-remember-choice" />
+                                    <label for="editor-remember-choice">${rememberChoice}</label>
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-primary" data-action="submit" data-dismiss="modal">${openString}</button>
+                                <button type="button" class="btn btn-default" data-dismiss="popup">${cancel}</button>
+                            </div>
+                        `,
+                    });
+
+                    const popup = document.querySelector('.idelink-popup');
+                    const select = popup.querySelector('select');
+
+                    Object.entries(editors).forEach(([name, editor]) => {
+                        const option = document.createElement('option');
+                        option.value = name;
+                        option.textContent = editor.name;
+                        select.appendChild(option);
+                    });
+
+                    const submitBtn = popup.querySelector('[data-action="submit"]');
+                    const closeBtn = popup.querySelector('[data-dismiss="popup"]');
+                    const rememberCheckbox = popup.querySelector('#editor-remember-choice');
+
+                    submitBtn.addEventListener('click', function() {
+                        if (rememberCheckbox.checked && sessionStorage) {
+                            sessionStorage.setItem('wn-exception-beautifier-editor', select.value);
+                        }
+                        open(select.value);
+                        closeBtn.click();
+                        popup.remove();
+                    });
+                }
+
+                document.querySelectorAll('div.snippet-preview div.preview-line span.line-number[data-idelink]').forEach((lineNumber) => {
+                    lineNumber.addEventListener('click', () => {
+                        openWithEditor(lineNumber.dataset.idelink);
+                    })
+                });
+            })();
         });
     })();
 </script>

--- a/modules/system/controllers/eventlogs/_field_details.php
+++ b/modules/system/controllers/eventlogs/_field_details.php
@@ -3,24 +3,57 @@ if (!isset($value['logVersion']) || $value['logVersion'] !== 2) {
     return;
 }
 
-function phpHighlight(string $str): string
+/**
+ * Highlights a line of php code with php syntax highlighting
+ *
+ * @param string $str
+ * @return string
+ */
+function phpSyntaxHighlight(string $str): string
 {
-    $transform = [
-        'control' => '/\b(for|foreach|while|class|extends|implements|try|catch|finally|function|return|unset|static|public|protected|private|count|global|if|else|else if|intval|int|array)\b/',
+    $regexes = [
+        'control' => '/\b(for|foreach|while|class |extends|yield from|yield|echo|fn|implements|try|catch|finally|throw|new|instanceof|function|return|unset|static|public|protected|private|count|global|if|else|else if|intval|int|array)\b/',
         'bool' => '/(\bnull\b|\btrue\b|\bfalse\b)/',
-        'string' => '/(&#039;\w*&#039;)/',
+        'string' => '/(&#039;[\w\\\\\/]*&#039;|&quot;[\w\\\\\/]*&quot;)/',
+        'number' => [
+            'pattern' => '/(=\(\s)?(\d+)(?=(\s|;|,|\)|=))/',
+            'replace' => '$2',
+            'before' => fn ($s) => str_replace('&#039;', '\'', $s),
+            'after' => fn ($s) => str_replace('\'', '&#039;', $s),
+        ],
         'bracket' => '/(\(|\)|\[|\]|\{|\})/',
         'variable' => '/(\$[a-z]\w*)/',
-        'operator' => '/( \! | \!\= | \!== | = | == | === | > | >= | < | <= | and | or )/',
     ];
 
-    foreach ($transform as $label => $regex) {
-        $str = preg_replace($regex, '<span class="' . $label . '">$1</span>', $str);
+    if (preg_match('/(^\s*?\*|^\s*?\*\/|^\s*?\/\*|^\s*?\/\/|^\s*?#)/', $str)) {
+        return sprintf('<span class="comment">%s</span>', $str);
+    }
+
+    foreach ($regexes as $label => $regex) {
+        if (is_string($regex)) {
+            $str = preg_replace($regex, '<span class="' . $label . '">$1</span>', $str);
+            continue;
+        }
+
+        $str = preg_replace(
+            $regex['pattern'],
+            sprintf('<span class="%s">%s</span>', $label, $regex['replace'] ?? '$1'),
+            isset($regex['before']) ? $regex['before']($str) : $str
+        );
+
+        $str = isset($regex['after']) ? $regex['after']($str) : $str;
     }
 
     return $str;
 }
 
+/**
+ * Converts an array of lines into a html snippet of code
+ *
+ * @param array $snippet
+ * @param int|null $highlight
+ * @return string
+ */
 function makeSnippet(array $snippet, ?int $highlight = null): string
 {
     return implode(
@@ -28,12 +61,11 @@ function makeSnippet(array $snippet, ?int $highlight = null): string
         array_reduce(
             array_keys($snippet),
             function (array $carry, $key) use ($snippet, $highlight) {
-                $line = $key + 1;
                 $carry[] = sprintf(
                     '<div class="preview-line%s"><span class="line-number">%s</span>: %s</div>',
-                    ($line === $highlight ? ' highlight' : ''),
-                    $line,
-                    phpHighlight(e($snippet[$key], true))
+                    ($key + 1 === $highlight ? ' highlight' : ''),
+                    $key + 1,
+                    phpSyntaxHighlight(e($snippet[$key], true))
                 );
                 return $carry;
             },
@@ -42,6 +74,12 @@ function makeSnippet(array $snippet, ?int $highlight = null): string
     );
 }
 
+/**
+ * Gets all exceptions in the stack and returns them bottom up
+ *
+ * @param array $value
+ * @return array
+ */
 function getOrderedExceptionList(array $value): array
 {
     $exceptions = [$value];
@@ -107,10 +145,12 @@ function getOrderedExceptionList(array $value): array
     }
     div.snippet-preview span.bracket { color: #343434; }
     div.snippet-preview span.variable { color: #d3542f; }
-    div.snippet-preview span.operator { color: #055c9b; }
-    div.snippet-preview span.control { color: #8e09e1; }
+    div.snippet-preview span.control { color: #7109e1; }
     div.snippet-preview span.string { color: #6a8d00; }
-    div.snippet-preview span.bool { color: #096ee1; }
+    div.snippet-preview span.number { color: #006ac0; }
+    div.snippet-preview span.html { color: #cba604; }
+    div.snippet-preview span.bool { color: #e1095c; }
+    div.snippet-preview span.comment { color: #8c8c8c; }
     .trace-title {
         margin: 15px auto;
         display: block;

--- a/modules/system/controllers/eventlogs/_field_details.php
+++ b/modules/system/controllers/eventlogs/_field_details.php
@@ -14,7 +14,11 @@ function phpSyntaxHighlight(string $str): string
     $regexes = [
         'control' => '/\b(for|foreach|while|class |extends|yield from|yield|echo|fn|implements|try|catch|finally|throw|new|instanceof|function|return|unset|static|public|protected|private|count|global|if|else|else if|intval|int|array)\b/',
         'bool' => '/(\bnull\b|\btrue\b|\bfalse\b)/',
-        'string' => '/(&#039;[\w\\\\\/]*&#039;|&quot;[\w\\\\\/]*&quot;)/',
+        'string' => [
+            'pattern' => '/(\066[^\066]*\066|\065[^\065]*\065)/',
+            'before' => fn ($s) => str_replace('&#039;', "\066", str_replace('&quot;', "\065", $s)),
+            'after' => fn ($s) => str_replace("\066", '&#039;', str_replace("\065", '&quot;', $s)),
+        ],
         'number' => [
             'pattern' => '/(=\(\s)?(\d+)(?=(\s|;|,|\)|=))/',
             'replace' => '$2',
@@ -186,11 +190,14 @@ function getOrderedExceptionList(array $value): array
         font-style: italic;
     }
     .trace-frame .label  .app-icon{
-        background: #a4e9ff;
+        background: #73b2d0;
+        color: #e9f3fa;
         border-radius: 6px;
+        font-size: 0.8em;
         padding: 3px;
+        font-weight: bold;
         float: right;
-        margin-top: -5px;
+        margin-top: -2px;
     }
     .trace-frame .folded {
         display: none;

--- a/modules/system/controllers/eventlogs/_field_details.php
+++ b/modules/system/controllers/eventlogs/_field_details.php
@@ -66,7 +66,7 @@ function makeSnippet(array $snippet, string $file, ?int $highlight = null): stri
             array_keys($snippet),
             function (array $carry, $key) use ($snippet, $file, $highlight) {
                 $carry[] = sprintf(
-                    '<div class="preview-line%s"><span class="line-number" data-idelink="idelink://%s&%3$d"">%3$d</span>: %4$s</div>',
+                    '<div class="preview-line%s"><span class="line-number" data-idelink="idelink://%s&%3$d""><span class="icon wn-icon-file-pen"></span>%3$d</span>: %4$s</div>',
                     ($key + 1 === $highlight ? ' highlight' : ''),
                     urlencode(str_replace('\\', '/', $file)),
                     $key + 1,
@@ -187,6 +187,16 @@ function getOrderedExceptionList(array $value): array
     }
     div.snippet-preview div.preview-line span.line-number {
         cursor: pointer;
+        position: relative;
+    }
+    div.snippet-preview div.preview-line span.line-number .icon {
+        opacity: 0;
+        position: absolute;
+        left: calc(100% + 1em);
+        transition: opacity linear .2s;
+    }
+    div.snippet-preview div.preview-line:hover span.line-number .icon {
+        opacity: 1;
     }
     div.snippet-preview div.preview-line.highlight span.line-number {
         color: red;
@@ -275,7 +285,7 @@ function getOrderedExceptionList(array $value): array
                             <th>Url</th>
                             <td>
                                 <a href="<?= $value['environment']['url'] ?>" target="_blank" rel="noopener">
-                                    <?= $value['environment']['url'] ?>
+                                    <span class="wn-icon-link"></span><?= $value['environment']['url'] ?>
                                 </a>
                             </td>
                         </tr>

--- a/modules/system/controllers/eventlogs/_field_details.php
+++ b/modules/system/controllers/eventlogs/_field_details.php
@@ -248,6 +248,14 @@ function getOrderedExceptionList(array $value): array
     .trace-frame .folded {
         display: none;
     }
+    /* The following are fixes for the TailwindUI plugin */
+    #winter-log-viewer hr {
+        margin-bottom: 20px;
+        margin-top: 20px;
+    }
+    #winter-log-viewer h1 {
+        font-size: 36px;
+    }
 </style>
 <div id="winter-log-viewer">
     <div class="formatted">

--- a/modules/system/controllers/eventlogs/_field_details.php
+++ b/modules/system/controllers/eventlogs/_field_details.php
@@ -377,6 +377,113 @@ function getOrderedExceptionList(array $value): array
 </div>
 
 <script>
+    const EDITORS = {
+        vscode: { scheme: 'vscode://file/%file:%line', name: 'VS Code (vscode://)' },
+        phpstorm: { scheme: 'phpstorm://open?file=%file&line=%line', name: 'PhpStorm (phpstorm://)' },
+        subl: { scheme: 'subl://open?url=file://%file&line=%line', name: 'Sublime (subl://)' },
+        txmt: { scheme: 'txmt://open/?url=file://%file&line=%line', name: 'TextMate (txmt://)' },
+        mvim: { scheme: 'mvim://open/?url=file://%file&line=%line', name: 'MacVim (mvim://)' },
+        editor: { scheme: 'editor://open/?file=%file&line=%line', name: 'Custom (editor://)' }
+    };
+
+    const REGEX = {
+        editor: /idelink:\/\/([^#]+)&([0-9]+)?/
+    };
+
+    let LINKER_POPUP_CONTENT = null;
+
+    function openWithEditor(link) {
+        const matches = link.match(REGEX.editor);
+
+        const open = function(value) {
+            const editorScheme = EDITORS[value].scheme
+                .replace(/%file/, matches[1])
+                .replace(/%line/, matches[2]);
+            window.open(link.replace(REGEX.editor, editorScheme), '_self');
+        };
+
+        console.log(matches);
+
+        if (matches) {
+            if (sessionStorage && sessionStorage.getItem('wn-exception-beautifier-editor')) {
+                open(sessionStorage.getItem('wn-exception-beautifier-editor'));
+            } else {
+                // Create and display the popup if not already created
+                if (!LINKER_POPUP_CONTENT) {
+                    const title = 'Select an Editor';
+                    const description = 'Choose an editor to open the file:';
+                    const openWith = 'Open with:';
+                    const rememberChoice = 'Remember choice for next time';
+                    const open = 'Open';
+                    const cancel = 'Cancel';
+                    const popup = document.createElement('div');
+                    popup.innerHTML = `
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                            <h4 class="modal-title">${title}</h4>
+                        </div>
+                        <div class="modal-body">
+                            <p>${description}</p>
+                            <div class="form-group">
+                                <label class="control-label">${openWith}:</label>
+                                <select class="form-control" name="select-exception-link-editor"></select>
+                            </div>
+                            <div class="checkbox custom-checkbox">
+                                <input name="checkbox" value="1" type="checkbox" id="editor-remember-choice" />
+                                <label for="editor-remember-choice">${rememberChoice}</label>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-primary" data-action="submit" data-dismiss="modal">${open}</button>
+                            <button type="button" class="btn btn-default" data-dismiss="popup">${cancel}</button>
+                        </div>
+                    `;
+
+                    const select = popup.querySelector('select');
+                    for (let key in EDITORS) {
+                        if (EDITORS.hasOwnProperty(key)) {
+                            const option = document.createElement('option');
+                            option.value = key;
+                            option.textContent = EDITORS[key].name;
+                            select.appendChild(option);
+                        }
+                    }
+
+                    LINKER_POPUP_CONTENT = popup.outerHTML;
+                }
+
+                const modal = document.createElement('div');
+                modal.innerHTML = LINKER_POPUP_CONTENT;
+                document.body.appendChild(modal);
+
+                const popup = modal.querySelector('.modal-body');
+                const select = popup.querySelector('select');
+                const submitBtn = modal.querySelector('[data-action="submit"]');
+                const rememberCheckbox = modal.querySelector('#editor-remember-choice');
+
+                submitBtn.addEventListener('click', function() {
+                    if (rememberCheckbox.checked && sessionStorage) {
+                        sessionStorage.setItem('wn-exception-beautifier-editor', select.value);
+                    }
+                    open(select.value);
+                    document.body.removeChild(modal);
+                });
+
+                modal.querySelector('[data-dismiss="popup"]').addEventListener('click', function() {
+                    document.body.removeChild(modal);
+                });
+            }
+        }
+    }
+
+    function formatFilePath(path, line) {
+        return `<a href="javascript:" data-href="idelink://${encodeURIComponent(rewritePath(path))}&${line}">${path}</a>`;
+    }
+
+    function rewritePath(path) {
+        return path.replace(/\\/g, '/');
+    }
+
     (() => {
         document.querySelectorAll('.trace-frame').forEach((frame) => {
             frame.querySelector('.label').addEventListener('click', () => {

--- a/modules/system/controllers/eventlogs/_field_details.php
+++ b/modules/system/controllers/eventlogs/_field_details.php
@@ -252,7 +252,7 @@ function getOrderedExceptionList(array $value): array
 <div id="winter-log-viewer">
     <div class="formatted">
         <div>
-            <?php if ($value['environment']['context'] === 'web'): ?>
+            <?php if (strtolower($value['environment']['context']) === 'web'): ?>
                 <table class="table table-responsive">
                     <tbody>
                         <tr>

--- a/modules/system/controllers/eventlogs/_field_details.php
+++ b/modules/system/controllers/eventlogs/_field_details.php
@@ -1,0 +1,231 @@
+<?php
+if (!isset($value['logVersion']) || $value['logVersion'] !== 2) {
+    return;
+}
+
+function phpHighlight(string $str): string
+{
+    $transform = [
+        'control' => '/\b(for|foreach|while|class|extends|implements|try|catch|finally|function|return|unset|static|public|protected|private|count|global|if|else|else if|intval|int|array)\b/',
+        'bool' => '/(\bnull\b|\btrue\b|\bfalse\b)/',
+        'string' => '/(&#039;\w*&#039;)/',
+        'bracket' => '/(\(|\)|\[|\]|\{|\})/',
+        'variable' => '/(\$[a-z]\w*)/',
+        'operator' => '/( \! | \!\= | \!== | = | == | === | > | >= | < | <= | and | or )/',
+    ];
+
+    foreach ($transform as $label => $regex) {
+        $str = preg_replace($regex, '<span class="' . $label . '">$1</span>', $str);
+    }
+
+    return $str;
+}
+
+function makeSnippet(array $snippet, ?int $highlight = null): string
+{
+    return implode(
+        "\n",
+        array_reduce(
+            array_keys($snippet),
+            function (array $carry, $key) use ($snippet, $highlight) {
+                $line = $key + 1;
+                $carry[] = sprintf(
+                    '<div class="preview-line%s"><span class="line-number">%s</span>: %s</div>',
+                    ($line === $highlight ? ' highlight' : ''),
+                    $line,
+                    phpHighlight(e($snippet[$key], true))
+                );
+                return $carry;
+            },
+            []
+        )
+    );
+}
+
+function getOrderedExceptionList(array $value): array
+{
+    $exceptions = [$value];
+    $current = $value;
+    while (isset($current['previous']) && $current['previous']) {
+        $current = $current['previous'];
+        $exceptions[] = $current;
+    }
+
+    return array_reverse($exceptions);
+}
+?>
+<style>
+    div.plugin-exception-beautifier  span.beautifier-message-container {
+        display: none;
+    }
+    #winter-log-viewer h1 {
+        margin-top: 0;
+    }
+    #winter-log-viewer .exception:not(:first-child) {
+        margin-top: 25px;
+    }
+    p.message-log {
+        font-family: monospace;
+        margin: 15px auto;
+    }
+    div.snippet-preview-container {
+        overflow-x: auto;
+        background: #f5f5f5;
+        margin-top: 15px;
+        border-radius: 4px;
+    }
+    div.snippet-preview {
+        line-height: 0.7em;
+        width: fit-content;
+        min-width: 100%;
+        padding-bottom: 5px;
+        white-space: pre;
+        font-family: monospace, monospace;
+    }
+    div.snippet-preview div.preview-line {
+        display: block;
+        box-sizing: border-box;
+        background: #f5f5f5;
+        width: 100%;
+        padding: 7px 10px;
+        margin: -5px 0;
+    }
+    div.snippet-preview div.preview-line:first-child {
+        margin-top: -18px;
+    }
+    div.snippet-preview div.preview-line:last-child {
+        padding-bottom: 0;
+    }
+    div.snippet-preview div.preview-line.highlight {
+        display: block;
+        background: #fff;
+        padding: 5px 10px;
+        margin: -5px 0;
+    }
+    div.snippet-preview div.preview-line.highlight span.line-number {
+        color: red;
+    }
+    div.snippet-preview span.bracket { color: #343434; }
+    div.snippet-preview span.variable { color: #d3542f; }
+    div.snippet-preview span.operator { color: #055c9b; }
+    div.snippet-preview span.control { color: #8e09e1; }
+    div.snippet-preview span.string { color: #6a8d00; }
+    div.snippet-preview span.bool { color: #096ee1; }
+    .trace-title {
+        margin: 15px auto;
+        display: block;
+        font-weight: bold;
+    }
+    .trace {
+        border: 1px solid #dcdcdc;
+        border-radius: 6px;
+        margin-top: 15px;
+    }
+    .trace-frame {
+        background: #efefef;
+        padding: 10px;
+    }
+    .trace-frame:first-child {
+        border-top-right-radius: 6px;
+        border-top-left-radius: 6px;
+    }
+    .trace-frame:last-child {
+        border-bottom-right-radius: 6px;
+        border-bottom-left-radius: 6px;
+    }
+    .trace-frame:not(:last-child) {
+        border-bottom: 1px solid #dcdcdc;
+    }
+    .trace-frame .label {
+        cursor: pointer;
+        width: 100%;
+        font-size: 0.95em;
+    }
+    .trace-frame .label .item {
+        font-weight: bold;
+        font-style: italic;
+    }
+    .trace-frame .label  .app-icon{
+        background: #a4e9ff;
+        border-radius: 6px;
+        padding: 3px;
+        float: right;
+        margin-top: -5px;
+    }
+    .trace-frame .folded {
+        display: none;
+    }
+</style>
+<div id="winter-log-viewer">
+    <div class="formatted">
+        <?php foreach (getOrderedExceptionList($value) as $index => $exception): ?>
+            <div class="exception">
+                <h1><?= $exception['type'] ?></h1>
+                <p class="message-log"><?= $exception['message'] ?></p>
+
+                <div>
+                    <div class="trace-frame">
+                        <div class="label">
+                            <span class="item"><?= $exception['file'] ?></span>
+                            at line <span class="item"><?= $exception['line'] ?></span>
+                        </div>
+                        <div class="snippet-preview-container">
+                            <div class="snippet-preview">
+                                <?= makeSnippet($exception['snippet'], $exception['line']) ?>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div>
+                    <span class="trace-title">Stack Trace</span>
+                    <div class="trace">
+                        <?php foreach ($exception['trace'] as $traceIndex => $frame): ?>
+                            <div class="trace-frame">
+                                <div class="label">
+                                    <span class="item">#<?= $traceIndex ?> <?= $frame['file'] ?></span>
+                                    in <span class="item"><?= $frame['class'] && !str_contains($frame['function'], '{') ? $frame['class'] . '::' : '' ?><?= $frame['function'] ?></span>
+                                    at line <span class="item"><?= $frame['line'] ?></span>
+                                    <?php if ($frame['arguments']): ?>
+                                        with argument<?= count($frame['arguments']) > 1 ? 's' : '' ?>: (<span class="item"><?= implode('</span>, <span class="item">', $frame['arguments']) ?></span>)
+                                    <?php endif; ?>
+                                    <?php if ($frame['in_app']): ?>
+                                        <span class="app-icon">In App</span>
+                                    <?php endif; ?>
+                                </div>
+                                <div class="snippet-preview-container <?= $frame['in_app'] ? 'unfolded' : 'folded' ?>">
+                                    <div class="snippet-preview">
+                                        <?= makeSnippet($frame['snippet'], $frame['line']) ?>
+                                    </div>
+                                </div>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+    <div class="raw" style="display: none">
+        <pre class="beautifier-raw-content"><?= $value['stringTrace'] ?></pre>
+    </div>
+</div>
+
+<script>
+    (() => {
+        document.querySelectorAll('.trace-frame').forEach((frame) => {
+            frame.querySelector('.label').addEventListener('click', () => {
+                frame.querySelector('div.snippet-preview-container').classList.toggle('folded');
+            });
+        });
+        window.addEventListener('load', () => {
+            document.querySelector('.plugin-exception-beautifier a[href="#beautifier-tab-formatted"]').addEventListener('click', () => {
+                document.querySelector('#winter-log-viewer .formatted').style.display = "block";
+                document.querySelector('#winter-log-viewer .raw').style.display = "none";
+            });
+            document.querySelector('.plugin-exception-beautifier a[href="#beautifier-tab-raw"]').addEventListener('click', () => {
+                document.querySelector('#winter-log-viewer .formatted').style.display = "none";
+                document.querySelector('#winter-log-viewer .raw').style.display = "block";
+            });
+        });
+    })();
+</script>

--- a/modules/system/controllers/eventlogs/_field_details.php
+++ b/modules/system/controllers/eventlogs/_field_details.php
@@ -15,9 +15,9 @@ function phpSyntaxHighlight(string $str): string
         'control' => '/\b(for|foreach|while|class |extends|yield from|yield|echo|fn|implements|try|catch|finally|throw|new|instanceof|function|return|unset|static|public|protected|private|count|global|if|else|else if|intval|int|array)\b/',
         'bool' => '/(\bnull\b|\btrue\b|\bfalse\b)/',
         'string' => [
-            'pattern' => '/(\066[^\066]*\066|\065[^\065]*\065)/',
-            'before' => fn ($s) => str_replace('&#039;', "\066", str_replace('&quot;', "\065", $s)),
-            'after' => fn ($s) => str_replace("\066", '&#039;', str_replace("\065", '&quot;', $s)),
+            'pattern' => '/(\221[^\221]*\221|\222[^\222]*\222)/',
+            'before' => fn ($s) => str_replace('&#039;', "\221", str_replace('&quot;', "\222", $s)),
+            'after' => fn ($s) => str_replace("\221", '&#039;', str_replace("\222", '&quot;', $s)),
         ],
         'number' => [
             'pattern' => '/(=\(\s)?(\d+)(?=(\s|;|,|\)|=))/',
@@ -88,8 +88,7 @@ function getOrderedExceptionList(array $value): array
 {
     $exceptions = [$value];
     $current = $value;
-    while (isset($current['previous']) && $current['previous']) {
-        $current = $current['previous'];
+    while (isset($current['previous']) && ($current = $current['previous'])) {
         $exceptions[] = $current;
     }
 
@@ -100,11 +99,52 @@ function getOrderedExceptionList(array $value): array
     div.plugin-exception-beautifier  span.beautifier-message-container {
         display: none;
     }
-    #winter-log-viewer h1 {
-        margin-top: 0;
+    #winter-log-viewer {
+        background: #fff;
+        margin: -20px;
+        padding: 20px;
     }
-    #winter-log-viewer .exception:not(:first-child) {
-        margin-top: 25px;
+    #winter-log-viewer h1 {
+        margin-top: 20px;
+    }
+    #winter-log-viewer .btn[disabled] {
+        color: #fff;
+        font-weight: bold;
+        user-select: auto;
+    }
+    #winter-log-viewer .btn.btn-secondary[disabled] {
+        color: #000;
+        font-weight: normal;
+    }
+    #winter-log-viewer table.table tr:first-child td, #winter-log-viewer table.table tr:first-child th {
+        border-top: 0;
+    }
+    #winter-log-viewer table.table tr td {
+        font-family: monospace;
+    }
+    #winter-log-viewer .input-group.select-container {
+        position: absolute;
+        right: 0;
+    }
+    #winter-log-viewer .input-group.select-container .select2-container--default {
+        width: auto;
+    }
+    #winter-log-viewer .input-group.select-container .select2-container--default .select2-selection {
+        padding-right: 30px;
+    }
+    #winter-log-viewer .exception-list {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+    }
+    #winter-log-viewer .exception-list.reverse {
+        flex-direction: column-reverse;
+    }
+    #winter-log-viewer .exception-list .exception {
+        width: 100%;
+    }
+    #winter-log-viewer .btn-group:not(:last-of-type) {
+        margin-right: 5px;
     }
     p.message-log {
         font-family: monospace;
@@ -158,7 +198,12 @@ function getOrderedExceptionList(array $value): array
     .trace-title {
         margin: 15px auto;
         display: block;
+        font-size: 1.2em;
         font-weight: bold;
+    }
+    .trace-title small {
+        font-size: 0.85em;
+        font-weight: normal;
     }
     .trace {
         border: 1px solid #dcdcdc;
@@ -184,6 +229,7 @@ function getOrderedExceptionList(array $value): array
         cursor: pointer;
         width: 100%;
         font-size: 0.95em;
+        word-break: break-word;
     }
     .trace-frame .label .item {
         font-weight: bold;
@@ -205,59 +251,120 @@ function getOrderedExceptionList(array $value): array
 </style>
 <div id="winter-log-viewer">
     <div class="formatted">
-        <?php foreach (getOrderedExceptionList($value) as $index => $exception): ?>
-            <div class="exception">
-                <h1><?= $exception['type'] ?></h1>
-                <p class="message-log"><?= $exception['message'] ?></p>
+        <div>
+            <?php if ($value['environment']['context'] === 'web'): ?>
+                <table class="table table-responsive">
+                    <tbody>
+                        <tr>
+                            <th>HTTP Method</th>
+                            <td><?= $value['environment']['method'] ?></td>
+                        </tr>
+                        <tr>
+                            <th>Url</th>
+                            <td><?= $value['environment']['url'] ?></td>
+                        </tr>
+                        <tr>
+                            <th>User Agent</th>
+                            <td><?= $value['environment']['userAgent'] ?></td>
+                        </tr>
+                        <tr>
+                            <th>Client IP</th>
+                            <td><?= $value['environment']['ip'] ?></td>
+                        </tr>
+                    </tbody>
+                </table>
+            <?php endif; ?>
 
-                <div>
-                    <div class="trace-frame">
-                        <div class="label">
-                            <span class="item"><?= $exception['file'] ?></span>
-                            at line <span class="item"><?= $exception['line'] ?></span>
-                        </div>
-                        <?php if ($exception['snippet']): ?>
-                            <div class="snippet-preview-container">
-                                <div class="snippet-preview">
-                                    <?= makeSnippet($exception['snippet'], $exception['line']) ?>
-                                </div>
-                            </div>
-                        <?php endif; ?>
-                    </div>
-                </div>
-
-                <div>
-                    <span class="trace-title">Stack Trace</span>
-                    <div class="trace">
-                        <?php foreach ($exception['trace'] as $traceIndex => $frame): ?>
-                            <div class="trace-frame">
-                                <div class="label">
-                                    <span class="item">#<?= $traceIndex ?> <?= $frame['file'] ?></span>
-                                    in <span class="item"><?= $frame['class'] && !str_contains($frame['function'], '{') ? $frame['class'] . '::' : '' ?><?= $frame['function'] ?></span>
-                                    at line <span class="item"><?= $frame['line'] ?></span>
-                                    <?php if ($frame['arguments']): ?>
-                                        with argument<?= count($frame['arguments']) > 1 ? 's' : '' ?>: (<span class="item"><?= implode('</span>, <span class="item">', $frame['arguments']) ?></span>)
-                                    <?php endif; ?>
-                                    <?php if ($frame['in_app']): ?>
-                                        <span class="app-icon">In App</span>
-                                    <?php endif; ?>
-                                </div>
-                                <?php if ($frame['snippet']): ?>
-                                    <div class="snippet-preview-container <?= $frame['in_app'] ? 'unfolded' : 'folded' ?>">
-                                        <div class="snippet-preview">
-                                            <?= makeSnippet($frame['snippet'], $frame['line']) ?>
-                                        </div>
-                                    </div>
-                                <?php endif; ?>
-                            </div>
-                        <?php endforeach; ?>
-                    </div>
-                </div>
+            <div class="btn-group" role="group" aria-label="Basic example">
+                <button type="button" disabled class="btn btn-sm btn-secondary">Context</button>
+                <button type="button" disabled class="btn btn-sm btn-primary"><?= $value['environment']['context'] ?></button>
             </div>
-        <?php endforeach; ?>
+            <div class="btn-group" role="group" aria-label="Basic example">
+                <button type="button" disabled class="btn btn-sm btn-secondary">Environment</button>
+                <button type="button" disabled class="btn btn-sm btn-primary"><?= $value['environment']['env'] ?></button>
+            </div>
+            <div class="btn-group" role="group" aria-label="Basic example">
+                <button type="button" disabled class="btn btn-sm btn-secondary">Testing</button>
+                <button type="button" disabled class="btn btn-sm btn-primary"><?= $value['environment']['testing'] ? 'true' : 'false' ?></button>
+            </div>
+
+            <hr>
+
+            <?php if ($value['exception']['previous']): ?>
+                <div class="select-container input-group mb-3">
+                    <select class="custom-select" id="exception-sort-order">
+                        <option selected value="old">Oldest first</option>
+                        <option value="new">Newest first</option>
+                    </select>
+                </div>
+            <?php endif; ?>
+        </div>
+        <div class="exception-list">
+            <?php foreach (getOrderedExceptionList($value['exception']) as $index => $exception): ?>
+                <div class="exception">
+                    <h1><?= $exception['type'] ?></h1>
+                    <p class="message-log"><?= $exception['message'] ?></p>
+
+                    <div>
+                        <div class="btn-group" role="group" aria-label="Basic example">
+                            <button type="button" disabled class="btn btn-sm btn-secondary">Exception</button>
+                            <button type="button" disabled class="btn btn-sm btn-primary">#<?= $index ?></button>
+                        </div>
+                        <div class="btn-group" role="group" aria-label="Basic example">
+                            <button type="button" disabled class="btn btn-sm btn-secondary">Code</button>
+                            <button type="button" disabled class="btn btn-sm btn-primary"><?= $exception['code'] ?></button>
+                        </div>
+                    </div>
+
+                    <div class="trace">
+                        <div class="trace-frame">
+                            <div class="label">
+                                <span class="item"><?= $exception['file'] ?></span>
+                                at line <span class="item"><?= $exception['line'] ?></span>
+                            </div>
+                            <?php if ($exception['snippet']): ?>
+                                <div class="snippet-preview-container">
+                                    <div class="snippet-preview">
+                                        <?= makeSnippet($exception['snippet'], $exception['line']) ?>
+                                    </div>
+                                </div>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+
+                    <div>
+                        <span class="trace-title">Stack Trace <small>(<?= count($exception['trace']) ?> frames)</small></span>
+                        <div class="trace">
+                            <?php foreach ($exception['trace'] as $traceIndex => $frame): ?>
+                                <div class="trace-frame">
+                                    <div class="label">
+                                        <span class="item">#<?= $traceIndex ?> <?= $frame['file'] ?></span>
+                                        in <span class="item"><?= $frame['class'] && !str_contains($frame['function'], '{') ? $frame['class'] . '::' : '' ?><?= $frame['function'] ?></span>
+                                        at line <span class="item"><?= $frame['line'] ?></span>
+                                        <?php if ($frame['arguments']): ?>
+                                            with argument<?= count($frame['arguments']) > 1 ? 's' : '' ?>: (<span class="item"><?= implode('</span>, <span class="item">', $frame['arguments']) ?></span>)
+                                        <?php endif; ?>
+                                        <?php if ($frame['in_app']): ?>
+                                            <span class="app-icon">In App</span>
+                                        <?php endif; ?>
+                                    </div>
+                                    <?php if ($frame['snippet']): ?>
+                                        <div class="snippet-preview-container <?= $frame['in_app'] ? 'unfolded' : 'folded' ?>">
+                                            <div class="snippet-preview">
+                                                <?= makeSnippet($frame['snippet'], $frame['line']) ?>
+                                            </div>
+                                        </div>
+                                    <?php endif; ?>
+                                </div>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
+                </div>
+            <?php endforeach; ?>
+        </div>
     </div>
     <div class="raw" style="display: none">
-        <pre class="beautifier-raw-content"><?= $value['stringTrace'] ?></pre>
+        <pre class="beautifier-raw-content"><?= $value['exception']['stringTrace'] ?></pre>
     </div>
 </div>
 
@@ -276,6 +383,10 @@ function getOrderedExceptionList(array $value): array
             document.querySelector('.plugin-exception-beautifier a[href="#beautifier-tab-raw"]').addEventListener('click', () => {
                 document.querySelector('#winter-log-viewer .formatted').style.display = "none";
                 document.querySelector('#winter-log-viewer .raw').style.display = "block";
+            });
+            // jQuery to tie in with select2
+            $("select#exception-sort-order").on('change', (e) => {
+                document.querySelector('#winter-log-viewer .exception-list').classList[e.target.value === 'old' ? 'remove' : 'add']('reverse');
             });
         });
     })();

--- a/modules/system/controllers/eventlogs/preview.php
+++ b/modules/system/controllers/eventlogs/preview.php
@@ -26,6 +26,12 @@
 
     <div class="layout-item stretch layout-column">
         <?= $this->formRenderPreview() ?>
+
+        <p>
+            <a href="<?= Backend::url('system/eventlogs') ?>" class="btn btn-default wn-icon-chevron-left">
+                <?= e(trans('system::lang.event_log.return_link')) ?>
+            </a>
+        </p>
     </div>
 
 <?php else: ?>
@@ -33,9 +39,3 @@
     <p class="flash-message static error"><?= e(trans($this->fatalError)) ?></p>
 
 <?php endif ?>
-
-<p>
-    <a href="<?= Backend::url('system/eventlogs') ?>" class="btn btn-default wn-icon-chevron-left">
-        <?= e(trans('system::lang.event_log.return_link')) ?>
-    </a>
-</p>

--- a/modules/system/controllers/eventlogs/preview.php
+++ b/modules/system/controllers/eventlogs/preview.php
@@ -24,7 +24,7 @@
         </div>
     </div>
 
-    <div class="layout-item stretch layout-column">
+    <div class="layout-item stretch layout-column" style="padding-bottom: 1em;">
         <?= $this->formRenderPreview() ?>
 
         <p>

--- a/modules/system/models/eventlog/fields.yaml
+++ b/modules/system/models/eventlog/fields.yaml
@@ -9,3 +9,7 @@ fields:
         path: field_message
         containerAttributes:
             data-plugin: exception-beautifier
+
+    details:
+        type: partial
+        path: field_details


### PR DESCRIPTION
Relies on https://github.com/wintercms/storm/pull/204

This change adds a fully backwards compatible "v2" log viewer that allows of unrolling of all previous exceptions.

<img width="1728" alt="Screenshot 2025-02-12 at 11 07 32 PM" src="https://github.com/user-attachments/assets/e6b85291-3064-45b8-8b1b-7ee54055936d" />

It also adds snippets for each frame in the call stack :)