### PR TITLE
Automatically set BackendMenu context from controller path

### DIFF
--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -8,6 +8,7 @@ use Flash;
 use Config;
 use Request;
 use Backend;
+use BackendMenu;
 use Redirect;
 use Response;
 use Exception;
@@ -116,6 +117,21 @@ class Controller extends ControllerBase
     protected $guarded = [];
 
     /**
+     * @var string Plugin author's name specified by the extending controller class in order to properly set the backend context
+     */
+    protected $author;
+
+    /**
+     * @var string Plugin's name specified by the extending controller class in order to properly set the backend context
+     */
+    protected $plugin;
+
+    /**
+     * @var ?string Side menu item code specified by the extending controller class in order to properly set the backend context
+     */
+    protected $sideMenuItemCode = null;
+
+    /**
      * Constructor.
      */
     public function __construct()
@@ -159,6 +175,8 @@ class Controller extends ControllerBase
         }
 
         $this->extendableConstruct();
+
+        BackendMenu::setContext("$this->author.$this->plugin", strtolower($this->plugin), $this->sideMenuItemCode);
     }
 
     public function __get($name)

--- a/modules/backend/console/scaffold/controller/controller.stub
+++ b/modules/backend/console/scaffold/controller/controller.stub
@@ -1,6 +1,5 @@
 <?php namespace {{ plugin_namespace }}\Controllers;
 
-use BackendMenu;
 use Backend\Classes\Controller;
 
 /**
@@ -23,14 +22,26 @@ class {{ studly_name }} extends Controller
         '{{ lower_author }}.{{ lower_plugin }}.{{ lower_name }}.manage_all',
     ];
 
-    public function __construct()
-    {
-        parent::__construct();
+    /**
+     * @var string Plugin author's name specified by the extending controller class in order to properly set the backend context
+     */
+    protected $author = '{{ studly_author }}';
 
-        BackendMenu::setContext('{{ plugin_code }}', '{{ lower_plugin }}', '{{ lower_name }}');
-    {% if sidebar %}
+    /**
+     * @var string Plugin's name specified by the extending controller class in order to properly set the backend context
+     */
+    protected $plugin = '{{ studly_plugin }}';
 
-        $this->bodyClass = 'compact-container';
-    {% endif -%}
-    }
+    /**
+     * @var ?string Side menu item code specified by the extending controller class in order to properly set the backend context
+     */
+    protected $sideMenuItemCode = '{{ lower_name }}';
+
+{% if sidebar %}
+    /**
+     * @var string Body class property used for customising the layout on a controller basis.
+     */
+    public $bodyClass = 'compact-container';
+{% endif -%}
+
 }


### PR DESCRIPTION
Closes #1269 

I've added the three protected attributes `$author`, `$plugin` and `$sideMenuItemCode` in order to set the backend menu context in the base controller class. As per linked issue's description, I'm setting the values for these attributes during class generation.

The only reason left for the constructor to be overridden by the created controller was the chance of using the `--sidebar` option when using the `create:controller` artisan command. Passing this option resulted in setting the boolean `sidebar` property for it to be used in the template scaffold file. If this property is `true` the controller assigns the value `compact-container` to the `$bodyClass` attribute.

In order to get rid of it I thought it would be better to set the same value for the `$bodyClass` outside the constructor