### PR TITLE
Add fix for colorpicker hex with alpha saving

### DIFF
--- a/modules/backend/formwidgets/ColorPicker.php
+++ b/modules/backend/formwidgets/ColorPicker.php
@@ -64,7 +64,7 @@ class ColorPicker extends FormWidgetBase
      */
     protected array $validationPatterns = [
         'cmyk' => '/^cmyk\((\d{1,2}\.?\d{0,2}%,? ?){4}\)$/',
-        'hex' => '/^#[\w\d]{6}$/',
+        'hex' => '/^#[\w\d]{6,8}$/',
         'hsl' => '/^hsla\((\d{1,3}\.?\d{0,2}%?, ?){3}\d\.?\d{0,2}?\)$/',
         'rgb' => '/^rgba\((\d{1,3}\.?\d{0,2}, ?){3}\d\.?\d{0,2}?\)$/',
     ];


### PR DESCRIPTION
Should fix https://github.com/wintercms/winter/issues/1316#issuecomment-2685144593.

 I tested all supported formats (`cmyk, hex, hsl, rgb`) with and without `showAlpha: true` and they all save correctly.