### PR TITLE
Migrate logging code to winter from storm to prevent excess file logs being written

### DIFF
--- a/modules/system/models/EventLog.php
+++ b/modules/system/models/EventLog.php
@@ -107,12 +107,8 @@ class EventLog extends Model
         return Str::limit($matches[1] ?? '', 500);
     }
 
-
     /**
      * Constructs the details array for logging
-     *
-     * @param Throwable $throwable
-     * @return array
      */
     public function getDetails(Throwable $throwable): array
     {
@@ -125,11 +121,8 @@ class EventLog extends Model
 
     /**
      * Convert a throwable into an array of data for logging
-     *
-     * @param Throwable $throwable
-     * @return array
      */
-    protected function exceptionToArray(\Throwable $throwable): array
+    protected function exceptionToArray(Throwable $throwable): array
     {
         return [
             'type' => $throwable::class,
@@ -149,8 +142,6 @@ class EventLog extends Model
     /**
      * Generate an array trace with extra data not provided by the default trace
      *
-     * @param array $trace
-     * @return array
      * @throws \ReflectionException
      */
     protected function exceptionTraceToArray(array $trace): array
@@ -211,10 +202,6 @@ class EventLog extends Model
 
     /**
      * Get the code snippet referenced in a trace
-     *
-     * @param string $file
-     * @param int $line
-     * @return array
      */
     protected function getSnippet(string $file, int $line): array
     {
@@ -238,8 +225,6 @@ class EventLog extends Model
 
     /**
      * Get environment details to record with the exception
-     *
-     * @return array
      */
     protected function getEnviromentInfo(): array
     {
@@ -265,9 +250,6 @@ class EventLog extends Model
 
     /**
      * Helper to work out if a file should be considered "In App" or not
-     *
-     * @param string $file
-     * @return bool
      */
     protected function isInAppError(string $file): bool
     {
@@ -275,6 +257,6 @@ class EventLog extends Model
             return false;
         }
 
-        return !\Winter\Storm\Support\Str::startsWith($file, base_path('vendor')) && !Str::startsWith($file, base_path('modules'));
+        return !Str::startsWith($file, base_path('vendor')) && !Str::startsWith($file, base_path('modules'));
     }
 }

--- a/modules/system/models/EventLog.php
+++ b/modules/system/models/EventLog.php
@@ -1,9 +1,11 @@
 <?php namespace System\Models;
 
-use App;
 use Exception;
-use Model;
-use Str;
+use Illuminate\Support\Facades\App;
+use Throwable;
+use ReflectionClass;
+use Winter\Storm\Database\Model;
+use Winter\Storm\Support\Str;
 
 /**
  * Model for logging system errors and debug trace messages
@@ -13,6 +15,9 @@ use Str;
  */
 class EventLog extends Model
 {
+    protected const EXCEPTION_LOG_VERSION = 2;
+    protected const EXCEPTION_SNIPPET_LINES = 12;
+
     /**
      * @var string The database table used by the model.
      */
@@ -40,7 +45,7 @@ class EventLog extends Model
     /**
      * Creates a log record
      */
-    public static function add(string $message, string $level = 'info', ?array $details = null): self
+    public static function add(string $message, string $level = 'info', ?array $details = null): static
     {
         $record = new static;
         $record->message = $message;
@@ -49,6 +54,25 @@ class EventLog extends Model
         if ($details !== null) {
             $record->details = (array) $details;
         }
+
+        try {
+            $record->save();
+        }
+        catch (Exception $ex) {
+        }
+
+        return $record;
+    }
+
+    /**
+     * Creates an exception log record
+     */
+    public static function addException(Throwable $throwable, string $level = 'error'): static
+    {
+        $record = new static;
+        $record->message = $throwable->getMessage();
+        $record->level = $level;
+        $record->details = $record->getDetails($throwable);
 
         try {
             $record->save();
@@ -81,5 +105,176 @@ class EventLog extends Model
         preg_match('/^([^\n\r]+)/m', $this->message, $matches);
 
         return Str::limit($matches[1] ?? '', 500);
+    }
+
+
+    /**
+     * Constructs the details array for logging
+     *
+     * @param Throwable $throwable
+     * @return array
+     */
+    public function getDetails(Throwable $throwable): array
+    {
+        return [
+            'logVersion' => static::EXCEPTION_LOG_VERSION,
+            'exception' => $this->exceptionToArray($throwable),
+            'environment' => $this->getEnviromentInfo(),
+        ];
+    }
+
+    /**
+     * Convert a throwable into an array of data for logging
+     *
+     * @param Throwable $throwable
+     * @return array
+     */
+    protected function exceptionToArray(\Throwable $throwable): array
+    {
+        return [
+            'type' => $throwable::class,
+            'message' => $throwable->getMessage(),
+            'file' => $throwable->getFile(),
+            'line' => $throwable->getLine(),
+            'snippet' => $this->getSnippet($throwable->getFile(), $throwable->getLine()),
+            'trace' => $this->exceptionTraceToArray($throwable->getTrace()),
+            'stringTrace' => $throwable->getTraceAsString(),
+            'code' => $throwable->getCode(),
+            'previous' => $throwable->getPrevious()
+                ? $this->exceptionToArray($throwable->getPrevious())
+                : null,
+        ];
+    }
+
+    /**
+     * Generate an array trace with extra data not provided by the default trace
+     *
+     * @param array $trace
+     * @return array
+     * @throws \ReflectionException
+     */
+    protected function exceptionTraceToArray(array $trace): array
+    {
+        foreach ($trace as $index => $frame) {
+            if (!isset($frame['file']) && isset($frame['class'])) {
+                $ref = new ReflectionClass($frame['class']);
+                $frame['file'] = $ref->getFileName();
+
+                if (!isset($frame['line']) && isset($frame['function']) && !str_contains($frame['function'], '{')) {
+                    foreach (file($frame['file']) as $line => $text) {
+                        if (preg_match(sprintf('/function\s.*%s/', $frame['function']), $text)) {
+                            $frame['line'] = $line + 1;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            $trace[$index] = [
+                'file' => $frame['file'] ?? null,
+                'line' => $frame['line'] ?? null,
+                'function' => $frame['function'] ?? null,
+                'class' => $frame['class'] ?? null,
+                'type' => $frame['type'] ?? null,
+                'snippet' => !empty($frame['file']) && !empty($frame['line'])
+                    ? $this->getSnippet($frame['file'], $frame['line'])
+                    : '',
+                'in_app' => ($frame['file'] ?? null) ? $this->isInAppError($frame['file']) : false,
+                'arguments' => array_map(function ($arg) {
+                    if (is_numeric($arg)) {
+                        return $arg;
+                    }
+                    if (is_string($arg)) {
+                        return "'$arg'";
+                    }
+                    if (is_null($arg)) {
+                        return 'null';
+                    }
+                    if (is_bool($arg)) {
+                        return $arg ? 'true' : 'false';
+                    }
+                    if (is_array($arg)) {
+                        return 'Array';
+                    }
+                    if (is_object($arg)) {
+                        return get_class($arg);
+                    }
+                    if (is_resource($arg)) {
+                        return 'Resource';
+                    }
+                }, $frame['args'] ?? []),
+            ];
+        }
+
+        return $trace;
+    }
+
+    /**
+     * Get the code snippet referenced in a trace
+     *
+     * @param string $file
+     * @param int $line
+     * @return array
+     */
+    protected function getSnippet(string $file, int $line): array
+    {
+        if (str_contains($file, ': eval()\'d code')) {
+            return [];
+        }
+
+        $lines = file($file);
+
+        if (count($lines) < static::EXCEPTION_SNIPPET_LINES) {
+            return $lines;
+        }
+
+        return array_slice(
+            $lines,
+            $line - (static::EXCEPTION_SNIPPET_LINES / 2),
+            static::EXCEPTION_SNIPPET_LINES,
+            true
+        );
+    }
+
+    /**
+     * Get environment details to record with the exception
+     *
+     * @return array
+     */
+    protected function getEnviromentInfo(): array
+    {
+        if (app()->runningInConsole()) {
+            return [
+                'context' => 'CLI',
+                'testing' => app()->runningUnitTests(),
+                'env' => app()->environment(),
+            ];
+        }
+
+        return [
+            'context' => 'Web',
+            'backend' => method_exists(app(), 'runningInBackend') ? app()->runningInBackend() : false,
+            'testing' => app()->runningUnitTests(),
+            'url' => app('url')->current(),
+            'method' => app('request')->method(),
+            'env' => app()->environment(),
+            'ip' => app('request')->ip(),
+            'userAgent' => app('request')->header('User-Agent'),
+        ];
+    }
+
+    /**
+     * Helper to work out if a file should be considered "In App" or not
+     *
+     * @param string $file
+     * @return bool
+     */
+    protected function isInAppError(string $file): bool
+    {
+        if (basename($file) === 'index.php' || basename($file) === 'artisan') {
+            return false;
+        }
+
+        return !\Winter\Storm\Support\Str::startsWith($file, base_path('vendor')) && !Str::startsWith($file, base_path('modules'));
     }
 }


### PR DESCRIPTION
Relies on: https://github.com/wintercms/storm/pull/208

This PR migrates the sexy logger code into winter. This hooks into the exisiting `exception.report` event.

This has been done to prevent the detailed logs being written to file, restoring the old style string stack traces when writing to file and the detailed logs are now only written to the db.