### PR TITLE
Add fix for maintenance setting containing value but null ip list

### DIFF
--- a/modules/cms/models/MaintenanceSetting.php
+++ b/modules/cms/models/MaintenanceSetting.php
@@ -100,6 +100,6 @@ class MaintenanceSetting extends Model
      */
     public static function isAllowedIp(string $ip): bool
     {
-        return IpUtils::checkIp($ip, Arr::pluck(static::get('allowed_ips', []), 'ip'));
+        return IpUtils::checkIp($ip, Arr::pluck(static::get('allowed_ips', []) ?? [], 'ip'));
     }
 }


### PR DESCRIPTION
This PR fixes an issue where the user enables maintenance mode but doesn't add any IPs to whitelist by ensuring an iteratable is passed to `Arr::pluck()`.

![image](https://github.com/user-attachments/assets/0a607696-1e26-4eb2-b366-ed069a1779b9)
