### PR TITLE
Added fix to maintenance settings to correctly show status

### DIFF
--- a/modules/cms/models/MaintenanceSetting.php
+++ b/modules/cms/models/MaintenanceSetting.php
@@ -82,7 +82,7 @@ class MaintenanceSetting extends Model
     {
         if (
             ($theme = Theme::getEditTheme())
-            && ($themeMap = array_get($this->attributes, 'theme_map'))
+            && ($themeMap = array_get($this->value, 'theme_map'))
             && ($cmsPage = array_get($themeMap, $theme->getDirName()))
         ) {
             $this->cms_page = $cmsPage;


### PR DESCRIPTION
The check fails as `$this->attributes` contains the uncast json, switching to `$this->value` returns the array of settings values.