### PR TITLE
Add button field

### DIFF
--- a/modules/backend/widgets/form/partials/_field-button.php
+++ b/modules/backend/widgets/form/partials/_field-button.php
@@ -36,7 +36,7 @@ $loadingText = $field->config['loading'] ?? '';
 $icon = $field->config['icon'] ?? '';
 ?>
 <div class="loading-indicator-container">
-    <?php if ($field->path) : ?>
+    <?php if ($field->path): ?>
         <?= $this->controller->makePartial($field->path, [
             'formWidget' => $this,
             'formModel'  => $formModel,
@@ -57,7 +57,7 @@ $icon = $field->config['icon'] ?? '';
             'loading'    => $loadingText,
             'icon'       => $icon,
         ]) ?>
-    <?php else : ?>
+    <?php else: ?>
         <<?= e($element); ?>
             class="<?= e($classes); ?>"
             data-load-indicator<?= !empty($loadingText) ? '="' . e(trans($loadingText)) . '"' : ''; ?>

--- a/modules/backend/widgets/form/partials/_field-button.php
+++ b/modules/backend/widgets/form/partials/_field-button.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @var \Winter\Storm\Database\Model $formModel
+ * @var \Backend\Classes\FormField $field
+ */
+$action = 'button';
+$handler = null;
+$href = null;
+$target = null;
+
+if (!empty($field->config['href']) || filter_var($field->value, FILTER_VALIDATE_URL)) {
+    $action = 'link';
+    $href = $field->config['href'] ?? '';
+    $target = $field->config['target'] ?? null;
+    if ($formModel->hasAttribute($href)) {
+        $href = $formModel->getAttribute($href);
+    }
+    if (filter_var($field->value, FILTER_VALIDATE_URL)) {
+        $href = $field->value;
+    }
+} elseif (!empty($field->config['handler'])) {
+    $action = 'popup';
+    $handler = $field->config['handler'];
+}
+
+$element = $action === 'link' ? 'a' : 'button';
+$label = $field->config['buttonLabel'] ?? '';
+$buttonType = $field->config['buttonType'] ?? 'default';
+$classes = implode(' ', array_filter([
+    "btn btn-$buttonType",
+    $field->config['buttonCssClass'] ?? ''
+]));
+$request = $field->config['request'] ?? '';
+
+$loadingText = $field->config['loading'] ?? '';
+$icon = $field->config['icon'] ?? '';
+?>
+<div class="loading-indicator-container">
+    <?php if ($field->path) : ?>
+        <?= $this->controller->makePartial($field->path, [
+            'formWidget' => $this,
+            'formModel'  => $formModel,
+            'formField'  => $field,
+            'formValue'  => $field->value,
+            'model'      => $formModel,
+            'field'      => $field,
+            'value'      => $field->value,
+            'action'     => $action,
+            'element'    => $element,
+            'label'      => $label,
+            'buttonType' => $buttonType,
+            'classes'    => $classes,
+            'handler'    => $handler,
+            'request'    => $request,
+            'href'       => $href,
+            'target'     => $target,
+            'loading'    => $loadingText,
+            'icon'       => $icon,
+        ]) ?>
+    <?php else : ?>
+        <<?= e($element); ?>
+            class="<?= e($classes); ?>"
+            data-load-indicator<?= !empty($loadingText) ? '="' . e(trans($loadingText)) . '"' : ''; ?>
+            <?= $action === 'popup' ? 'data-control="popup"' : ''; ?>
+            <?= !empty($handler) ? 'data-handler="' . e($handler) . '"' : ''; ?>
+            <?= !empty($request) ? 'data-request="' . e($request) . '"' : ''; ?>
+            <?= !empty($href) ? 'href="' . e($href) . '"' : ''; ?>
+            <?= !empty($target) ? 'target="' . e($target) . '"' : ''; ?>
+        >
+            <?= !empty($icon) ? '<i class="' . e($icon) . '"></i>' : '' ?>
+            <?= e(trans($label)); ?>
+        </<?= e($element); ?>>
+    <?php endif; ?>
+</div>


### PR DESCRIPTION
Adds support for the `type: button` field with the following options:

## Definition
```yaml
button:
    type: button
    action: # button | link | popup (automatically determined by the values provider, if the value of the field is a URL or the href config is set (or the value of the field is a valid URL), then it'll be type link. If a handler is set, it'll be type popup. All other cases will be type: button)
    buttonLabel: # The label of the button itself.
    buttonType: # default | primary | success | info | warning | danger | link
    path: # Use a custom partial to render the button
    handler: # popup action only
    href: # link action only
    target: # link action only
    request: # button action only
    loading: # message to display while waiting for the request
    icon: 'icon-pencil'
```

## Examples:

Simple button with AJAX request:
```yaml
_sync_ics:
    label: Actions
    buttonLabel: Sync
    type: button
    request: onSyncICS
    icon: 'icon-rotate'
    loading: Syncing...
```

Simple Link button:
```yaml
places_url:
    type: button
    buttonType: primary
    buttonLabel: View on Google Maps
    icon: icon-map-location-dot
    target: _blank
```

Button triggering popup:
```yaml
_btn_autofill:
    label: Autofill
    buttonLabel: Autofill Club Information
    type: button
    handler: onRenderAutofillPopup
    buttonType: primary
    icon: icon-map-location-dot
```

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->