### PR TITLE
Added AssetContainer class that can be shared between AssetMaker objects

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -1494,6 +1494,7 @@ class Controller
         }
 
         $this->setComponentPropertiesFromParams($componentObj);
+        $componentObj->setAssetContainer($this->getAssetContainer());
         $componentObj->init();
 
         return $componentObj;

--- a/modules/system/classes/asset/AssetContainer.php
+++ b/modules/system/classes/asset/AssetContainer.php
@@ -2,27 +2,57 @@
 
 namespace System\Classes\Asset;
 
-class AssetContainer implements \ArrayAccess
+class AssetContainer extends \ArrayIterator
 {
     protected array $assets = ['js' => [], 'css' => [], 'rss' => [], 'vite' => []];
 
-    public function offsetExists(mixed $offset): bool
+    public function offsetExists(mixed $key): bool
     {
-        return isset($this->assets[$offset]);
+        return isset($this->assets[$key]);
     }
 
-    public function &offsetGet(mixed $offset): mixed
+    public function &offsetGet(mixed $key): mixed
     {
-        return $this->assets[$offset];
+        return $this->assets[$key];
     }
 
-    public function offsetSet(mixed $offset, mixed $value): void
+    public function offsetSet(mixed $key, mixed $value): void
     {
-        $this->assets[$offset] = $value;
+        $this->assets[$key] = $value;
     }
 
-    public function offsetUnset(mixed $offset): void
+    public function offsetUnset(mixed $key): void
     {
-        unset($this->assets[$offset]);
+        unset($this->assets[$key]);
+    }
+
+    public function current(): mixed
+    {
+        return current($this->assets);
+    }
+
+    public function next(): void
+    {
+        next($this->assets);
+    }
+
+    public function key(): mixed
+    {
+        return key($this->assets);
+    }
+
+    public function valid(): bool
+    {
+        return isset($this->assets[key($this->assets)]);
+    }
+
+    public function rewind(): void
+    {
+        reset($this->assets);
+    }
+
+    public function count(): int
+    {
+        return count($this->assets);
     }
 }

--- a/modules/system/classes/asset/AssetContainer.php
+++ b/modules/system/classes/asset/AssetContainer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace System\Classes\Asset;
+
+class AssetContainer implements \ArrayAccess
+{
+    protected array $assets = ['js' => [], 'css' => [], 'rss' => [], 'vite' => []];
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->assets[$offset]);
+    }
+
+    public function &offsetGet(mixed $offset): mixed
+    {
+        return $this->assets[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->assets[$offset] = $value;
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->assets[$offset]);
+    }
+}

--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -2,6 +2,7 @@
 
 namespace System\Traits;
 
+use System\Classes\Asset\AssetContainer;
 use System\Classes\CombineAssets;
 use System\Classes\PluginManager;
 use System\Classes\Asset\Vite;
@@ -25,7 +26,7 @@ trait AssetMaker
     /**
      * Collection of assets to display in the layout.
      */
-    protected array $assets = ['js' => [], 'css' => [], 'rss' => [], 'vite' => []];
+    protected AssetContainer $assets;
 
     /**
      * @var string Specifies a path to the asset directory.
@@ -44,7 +45,7 @@ trait AssetMaker
      */
     public function flushAssets(): void
     {
-        $this->assets = ['js' => [], 'css' => [], 'rss' => [], 'vite' => []];
+        $this->assets = new AssetContainer();
     }
 
     /**
@@ -56,6 +57,11 @@ trait AssetMaker
         if ($type != null) {
             $type = strtolower($type);
         }
+
+        if (!isset($this->assets)) {
+            $this->flushAssets();
+        }
+
         $result = null;
         $reserved = ['build', 'order'];
 
@@ -227,6 +233,10 @@ trait AssetMaker
      */
     protected function addAsset(string $type, string $path, array $attributes): void
     {
+        if (!isset($this->assets)) {
+            $this->flushAssets();
+        }
+
         if (!in_array($path, $this->assets[$type])) {
             /**
              * @event system.assets.beforeAddAsset
@@ -289,6 +299,26 @@ trait AssetMaker
         }
         $assetPath = !empty($localPath) ? $localPath : $this->assetPath;
         return Url::to(CombineAssets::combine($assets, $assetPath));
+    }
+
+    /**
+     * Returns this objects asset container
+     */
+    public function getAssetContainer(): AssetContainer
+    {
+        if (!isset($this->assets)) {
+            $this->flushAssets();
+        }
+
+        return $this->assets;
+    }
+
+    /**
+     * Set the asset container
+     */
+    public function setAssetContainer(AssetContainer $assets): void
+    {
+        $this->assets = $assets;
     }
 
     /**

--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -418,7 +418,7 @@ trait AssetMaker
      */
     protected function removeDuplicates(): void
     {
-        foreach ($this->assets as $type => &$collection) {
+        foreach ($this->assets as $type => $collection) {
             $pathCache = [];
             foreach ($collection as $key => $asset) {
                 if (!$path = array_get($asset, 'path')) {
@@ -426,7 +426,7 @@ trait AssetMaker
                 }
 
                 if (isset($pathCache[$path])) {
-                    array_forget($collection, $key);
+                    unset($this->assets[$type][$key]);
                     continue;
                 }
 


### PR DESCRIPTION
This PR allows implementors of the AssetMaker trait to share "assets".

This fixes the issue where a component owning it's own assets aren't added to the parent controller's assets.