### PR TITLE
Added fix for addVite method to bind assets to parent controller

### DIFF
--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -217,6 +217,10 @@ trait AssetMaker
             $package = $plugin->getPluginIdentifier();
         }
 
+        if (isset($this->controller)) {
+            $this->controller->addVite($entrypoints, $package);
+        }
+
         $this->addAsset('vite', $package, [
             'entrypoints' => $entrypoints
         ]);


### PR DESCRIPTION
This fixes the issue where `addVite` called on a component doesn't add the asset to the controller.