### PR TITLE
Prevent cache collision across different themes when combining assets

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -1392,7 +1392,7 @@ class Controller
         $parentTheme = $this->getTheme()->getConfig()['parent'] ?? false;
         $themesPath = themes_path();
 
-        $cacheKey = __METHOD__ . '.' . md5(json_encode($url));
+        $cacheKey = __METHOD__ . '.' . $themeDir . '.' . md5(json_encode($url));
 
         if (!($assets = Cache::get($cacheKey))) {
             $assets = [];

--- a/modules/cms/tests/classes/ControllerTest.php
+++ b/modules/cms/tests/classes/ControllerTest.php
@@ -96,6 +96,22 @@ class ControllerTest extends TestCase
         $this->assertTrue(in_array('style2.css', $files));
     }
 
+    public function testThemeCombineAssetsInDifferentThemes(): void
+    {
+        $themeA = Theme::load('test');
+        $controllerA = new Controller($themeA);
+
+        $themeB = Theme::load('childtest');
+        $controllerB = new Controller($themeB);
+
+        // Generate a url for the same file in both themes.
+        // Because the files are different, the urls should be too.
+        $this->assertNotEquals(
+            $controllerA->themeUrl(['assets/css/style2.css']),
+            $controllerB->themeUrl(['assets/css/style2.css']),
+        );
+    }
+
     public function testPageUrl()
     {
         $theme = Theme::load('test');


### PR DESCRIPTION
## Problem description
When providing an array to the `| theme` twig filter, some processing is done to figure out which actual files should be referenced, i.e. when inheriting from a parent theme.

The result is stored in cache, with the cache key being derived from the input paths only, which doesn't contain the active theme.

I encountered an issue when using 2 different themes (for different hostnames), each one having its own styles, but using a similar structure and thus the same file names.

In this case, when visiting my first theme, paths such as `assets/scss/theme.scss` get resolved to `/.../themes/myfirsttheme/assets/scss/theme.scss`. If I then visit my second theme, the cached result is used and I get the styles from my 1st theme. If I clear the cache, this time `assets/scss/theme.scss` resolves to `/.../themes/mysecondtheme/assets/scss/theme.scss` (but the 1st theme will now have the wrong styles).

I guess adding the theme directory to the cache key would make sense. There is no side effect I could think of.

## Steps to reproduce
1. Starting from a fresh installation
2. In `themes/demo/layouts/default.htm`, put square brackets around `assets/javascript/app.js` to make it use the combiner
3. Duplicate the `demo` theme, I will call the new one `demo2`
4. In `themes/demo/assets/javascript/app.js`, add an `alert('demo1')` somewhere
5. In `themes/demo2/assets/javascript/app.js`, add `alert('demo2')`

Now when you load a page, you should see the alert "demo1". In `config/cms.php` change the `activeTheme` to `demo2` and reload, you will still have "demo1" instead of "demo2".