### PR TITLE
Fix anchor tag styling on Firefox

### DIFF
--- a/modules/backend/assets/css/winter.css
+++ b/modules/backend/assets/css/winter.css
@@ -647,6 +647,7 @@ body.compact-container .layout .layout-container{padding:0 !important}
 body.slim-container .layout.layout-container,
 body.slim-container .layout .layout-container{padding-left:0 !important;padding-right:0 !important}
 @media (max-width:768px){.layout .hide-on-small{display:none}.layout.responsive-sidebar>.layout-cell:first-child{display:table-footer-group;height:auto}.layout.responsive-sidebar>.layout-cell:first-child .control-breadcrumb{display:none}.layout.responsive-sidebar>.layout-cell:last-child{display:table-header-group;width:auto;height:auto}.layout.responsive-sidebar>.layout-cell:last-child .layout-absolute{position:static}}
+@supports (-moz-appearance:none){a:focus:not(:focus-visible){outline:none}}
 .flex-layout-column{display:-webkit-box;display:-webkit-flex;display:-moz-flex;display:-ms-flexbox;display:-ms-flex;display:flex;-webkit-flex-direction:column;-moz-flex-direction:column;-webkit-box-orient:vertical;-ms-flex-direction:column;flex-direction:column}
 .flex-layout-column.full-height-strict{height:100%}
 .flex-layout-column.absolute{position:absolute !important}

--- a/modules/backend/assets/less/layout/layout.less
+++ b/modules/backend/assets/less/layout/layout.less
@@ -22,6 +22,12 @@ body.no-select {
     cursor: default !important;
 }
 
+// Remove focus outline for mouse clicks, keep for keyboard navigation (Only needs to happen on Firefox)
+@supports (-moz-appearance: none) {
+    a:focus:not(:focus-visible) {
+        outline: none;
+    }
+}
 //
 // Layout canvas
 //

--- a/modules/backend/assets/less/layout/layout.less
+++ b/modules/backend/assets/less/layout/layout.less
@@ -22,12 +22,6 @@ body.no-select {
     cursor: default !important;
 }
 
-// Remove focus outline for mouse clicks, keep for keyboard navigation (Only needs to happen on Firefox)
-@supports (-moz-appearance: none) {
-    a:focus:not(:focus-visible) {
-        outline: none;
-    }
-}
 //
 // Layout canvas
 //
@@ -226,3 +220,15 @@ body.slim-container {
         }
     }
 }
+
+//
+// Browser specific
+//
+
+// Remove focus outline for mouse clicks, keep for keyboard navigation
+@supports (-moz-appearance: none) {
+    a:focus:not(:focus-visible) {
+        outline: none;
+    }
+}
+


### PR DESCRIPTION
I have added some CSS to fix this bug: https://github.com/wintercms/winter/issues/1247.

The issue was that, in Firefox only, clicking on an anchor tag would show an accessibility outline. This should only happen when navigating with the keyboard. To better align the behavior with Chrome, I added CSS that targets all anchor tags that are :focus but not :focus-visible, and sets their outline to none. But only if the browser is Firefox.

This means the outline will not appear unless the user is navigating with a keyboard. This improves the visual experience, without breaking any existing features, it only affects anchor tags and is purely a visual adjustment.

I figured I'd put this in the layout.less file because this seems like the most global file, I am not sure if this is the best place, happy to make changes as seen fit.

I initially thought this change would be simple and quick, but it took me a second to trace where all the CSS was coming from. Factoring in the time spent learning this small part of the codebase, I figured it would take me the better part of an afternoon, and that's about how long it took me.