### PR TITLE
Added fix for multiple vite assets being deleted as duplicate

### DIFF
--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -399,12 +399,31 @@ trait AssetMaker
                     continue;
                 }
 
-                if (isset($pathCache[$path])) {
-                    array_forget($collection, $key);
+                if ($type !== 'vite') {
+                    if (isset($pathCache[$path])) {
+                        array_forget($collection, $key);
+                        continue;
+                    }
+
+                    $pathCache[$path] = true;
                     continue;
                 }
 
-                $pathCache[$path] = true;
+                // If handling vite, ensure that each entrypoint is considered it's own path within a package
+                foreach ($asset['attributes']['entrypoints'] ?? [] as $index => $entrypoint) {
+                    $vitePath = $path . '|' . $entrypoint;
+                    // If we detect a duplicate, remove it
+                    if (isset($pathCache[$vitePath])) {
+                        array_forget($collection[$key]['attributes']['entrypoints'], $index);
+                        // If all entry points have been removed from an asset, then remove it
+                        if (empty($collection[$key]['attributes']['entrypoints'])) {
+                            unset($collection[$key]);
+                        }
+                        continue;
+                    }
+
+                    $pathCache[$vitePath] = true;
+                }
             }
         }
     }

--- a/modules/system/traits/AssetMaker.php
+++ b/modules/system/traits/AssetMaker.php
@@ -399,31 +399,33 @@ trait AssetMaker
                     continue;
                 }
 
-                if ($type !== 'vite') {
-                    if (isset($pathCache[$path])) {
-                        array_forget($collection, $key);
-                        continue;
+                if ($type === 'vite') {
+                    // If handling vite, ensure that each entrypoint is considered it's own path within a package
+                    foreach ($asset['attributes']['entrypoints'] ?? [] as $index => $entrypoint) {
+                        $vitePath = $path . '|' . $entrypoint;
+                        // If we detect a duplicate, remove it
+                        if (isset($pathCache[$vitePath])) {
+                            array_forget($collection[$key]['attributes']['entrypoints'], $index);
+                            // If all entry points have been removed from an asset, then remove it
+                            if (empty($collection[$key]['attributes']['entrypoints'])) {
+                                unset($collection[$key]);
+                            }
+
+                            continue;
+                        }
+
+                        $pathCache[$vitePath] = true;
                     }
 
-                    $pathCache[$path] = true;
                     continue;
                 }
 
-                // If handling vite, ensure that each entrypoint is considered it's own path within a package
-                foreach ($asset['attributes']['entrypoints'] ?? [] as $index => $entrypoint) {
-                    $vitePath = $path . '|' . $entrypoint;
-                    // If we detect a duplicate, remove it
-                    if (isset($pathCache[$vitePath])) {
-                        array_forget($collection[$key]['attributes']['entrypoints'], $index);
-                        // If all entry points have been removed from an asset, then remove it
-                        if (empty($collection[$key]['attributes']['entrypoints'])) {
-                            unset($collection[$key]);
-                        }
-                        continue;
-                    }
-
-                    $pathCache[$vitePath] = true;
+                if (isset($pathCache[$path])) {
+                    array_forget($collection, $key);
+                    continue;
                 }
+
+                $pathCache[$path] = true;
             }
         }
     }


### PR DESCRIPTION
This PR adds a fix for vite packages being deleted as duplicate.

If you have 2 components:
- `ComponentA`
- `ComponentB`

And they each add a the same vite package but with different entrypoints:
```php
// ComponentA
$this->addVite('src/js/example.js', 'author.plugin');

// ComponentB
$this->addVite('src/js/another-example.js', 'author.plugin');
```

Then the `removeDuplicates()` method would trim the second as we use "path" for the package name rather in vite.

This PR adds special handling for vite packages that will convert the "path" into `${package-name}-${entrypoint}` and check for duplicate entrypoints across all assets.

If all entry points are removed from an asset then it will remove it.