### PR TITLE
fix added support for --force option when migrating the database

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -100,6 +100,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Console Configuration Table
+    |--------------------------------------------------------------------------
+    |
+    | This table controls the configurable behavior of the console as
+    | as it relates to the database and migrations.
+    |
+    */
+
+    'console' => [
+        'confirm_in_prod' => env('MIGRATION_CONFIRM_IN_PROD', false),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Redis Databases
     |--------------------------------------------------------------------------
     |

--- a/modules/system/console/WinterUp.php
+++ b/modules/system/console/WinterUp.php
@@ -25,7 +25,7 @@ class WinterUp extends Command implements Isolatable
      */
     protected $signature = 'winter:up
         {--seed : Included for compatibility with Laravel default signature, no effect at this time}
-        {--force : Included for compatibility with Laravel default signature, force the operation to run when in production}
+        {--force : Force the operation to run when in production}
     ';
 
     /**

--- a/modules/system/console/WinterUp.php
+++ b/modules/system/console/WinterUp.php
@@ -1,6 +1,9 @@
-<?php namespace System\Console;
+<?php
+
+namespace System\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Console\Isolatable;
 use System\Classes\UpdateManager;
 
@@ -14,13 +17,16 @@ use System\Classes\UpdateManager;
  */
 class WinterUp extends Command implements Isolatable
 {
+    use ConfirmableTrait;
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
     protected $signature = 'winter:up
-                            {--seed : Included for compatibility with Laravel default signature, no effect at this time}';
+        {--seed : Included for compatibility with Laravel default signature, no effect at this time}
+        {--force : Included for compatibility with Laravel default signature, force the operation to run when in production}
+    ';
 
     /**
      * The console command description.
@@ -43,6 +49,10 @@ class WinterUp extends Command implements Isolatable
      */
     public function handle()
     {
+        if (! $this->confirmToProceed()) {
+            return 1;
+        }
+
         $this->output->writeln('<info>Migrating application and plugins...</info>');
 
         UpdateManager::instance()

--- a/modules/system/console/WinterUp.php
+++ b/modules/system/console/WinterUp.php
@@ -50,7 +50,7 @@ class WinterUp extends Command implements Isolatable
      */
     public function handle()
     {
-        if (!$this->confirmToProceed()) {
+        if (config('database.console.confirm_in_prod', false) && !$this->confirmToProceed()) {
             return 1;
         }
 

--- a/modules/system/console/WinterUp.php
+++ b/modules/system/console/WinterUp.php
@@ -18,6 +18,7 @@ use System\Classes\UpdateManager;
 class WinterUp extends Command implements Isolatable
 {
     use ConfirmableTrait;
+
     /**
      * The name and signature of the console command.
      *

--- a/modules/system/console/WinterUp.php
+++ b/modules/system/console/WinterUp.php
@@ -50,7 +50,7 @@ class WinterUp extends Command implements Isolatable
      */
     public function handle()
     {
-        if (! $this->confirmToProceed()) {
+        if (!$this->confirmToProceed()) {
             return 1;
         }
 


### PR DESCRIPTION
Fixes: https://github.com/wintercms/winter/issues/1332

Added the --force option to the winter:up command, in order to align with how Laravel handles this in their migrate command. I also added the ConfirmableTrait and uses a method from it to print a confirmation message to console if APP_ENV=production.

This will be a minor breaking change for any users who are using winter:up or any of its aliases without the --force option when `APP_ENV` is set to `production`.

@LukeTowers To be 100% honest, I forgot to estimate this one, but it took about 1 story point, if we are going by 1 story point being about 4 hours, when you include discovery, writing, and testing.