### PR TITLE
Hide checkboxAll when there are no records

### DIFF
--- a/modules/backend/widgets/lists/partials/_list_head_row.php
+++ b/modules/backend/widgets/lists/partials/_list_head_row.php
@@ -1,5 +1,5 @@
 <tr>
-    <?php if ($showCheckboxes): ?>
+    <?php if ($showCheckboxes && count($records)): ?>
         <th class="list-checkbox">
             <div class="checkbox custom-checkbox nolabel">
                 <input type="checkbox" id="<?= $this->getId('checkboxAll') ?>" />


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->
## Related Issue 
Fixes #1365 

## Updates
Add `count($records)` to the checkBoxALL condition to prevent displaying it when there are no records
