### PR TITLE
Remove --base option from vite:build command

### DIFF
--- a/modules/system/console/asset/vite/ViteCompile.php
+++ b/modules/system/console/asset/vite/ViteCompile.php
@@ -62,7 +62,6 @@ class ViteCompile extends AssetCompile
             $basePath . sprintf('%1$snode_modules%1$s.bin%1$svite', DIRECTORY_SEPARATOR),
             'build',
             $this->option('silent') ? '--logLevel=silent' : '',
-            '--base=' . Str::after($this->getPackagePath($configPath), base_path())
         );
 
         return $command;


### PR DESCRIPTION
The `--base` option should be removed from the command to ensure that the base path is managed exclusively through vite.config.mjs, since the command line argument overrides the config file setting.

Since the `base` option determines the public base path that Vite uses during assets compilation, it needs to be managed on a per-package basis to ensure full customization of the process (e.g., custom path, CDN, etc.).

@jaxwilko do you agree?
