### PR TITLE
Add fix for error not being correctly reported

### DIFF
--- a/modules/backend/behaviors/formcontroller/views/update/_sidebar.php
+++ b/modules/backend/behaviors/formcontroller/views/update/_sidebar.php
@@ -35,6 +35,6 @@
     </div>
     <div class="padded-container">
         <p class="flash-message static error"><?= e(trans($this->fatalError)) ?></p>
-        <p><a href="<?= Backend::url($formConfig->defaultRedirect) ?>" class="btn btn-default"><?= e(trans('backend::lang.form.return_to_list')); ?></a></p>
+        <p><a href="<?= isset($formConfig) ? Backend::url($formConfig->defaultRedirect) : 'javascript:history.back()' ?>" class="btn btn-default"><?= e(trans('backend::lang.form.return_to_list')); ?></a></p>
     </div>
 <?php endif ?>


### PR DESCRIPTION
A misconfiguration can cause an issue that is currently being incorrectly reported.
![image](https://github.com/user-attachments/assets/3c6956c9-9be2-4849-857e-b22a63d69e67)
With this patch, we only use `$formConfig` if defined, if not we default to a js back. This results in the correct information being presented to the user:
![image](https://github.com/user-attachments/assets/a47fc9c6-f549-4952-b068-0db62cd659a9)
