### PR TITLE
Add fix to unify asset:compile & asset:watch arguments

### DIFF
--- a/modules/system/console/asset/AssetCompile.php
+++ b/modules/system/console/asset/AssetCompile.php
@@ -126,15 +126,16 @@ abstract class AssetCompile extends Command
 
         $packages = $compilableAssets->getPackages($type);
         $name = $this->argument('package');
+        $nameLower = strtolower($name);
 
-        if (!in_array($name, array_keys($packages))) {
+        if (!in_array($nameLower, array_keys($packages))) {
             $this->error(
                 sprintf('Package "%s" is not a registered package.', $name)
             );
             return 1;
         }
 
-        $package = $packages[$name];
+        $package = $packages[$nameLower];
 
         $relativeConfigPath = $package['config'];
         if (!$this->isPackageWithinWorkspace($relativeConfigPath)) {


### PR DESCRIPTION
Currently when calling:
```bash
./artisan vite:compile -p JaxWilko.Test # Works!
./artisan vite:watch JaxWilko.Test # Fails :(
```
This is because in `compileHandle()` we are calling:
```php
// Normalize the requestedPackages option
if (count($requestedPackages)) {
    foreach ($requestedPackages as &$name) {
        $name = strtolower($name);
    }
    unset($name);
}
```
However no such transformation happens in `watchHandle()`, this PR addresses that by reporting the user input value but internally using `$nameLower` as the key for the `PackageManager` package.

With this patch:
```bash
./artisan vite:compile -p JaxWilko.Test # Works!
./artisan vite:compile -p jaxwilko.test # Works!
./artisan vite:watch JaxWilko.Test # Works!
./artisan vite:watch jaxwilko.test # Works!
```