### PR TITLE
remove columns limit query

### DIFF
--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -575,10 +575,6 @@ class Lists extends WidgetBase
                     $joinQuery->whereRaw(DbDongle::parse($column->config['conditions']));
                 }
 
-                if ($limit) {
-                    $joinQuery->limit($column->config['limit']);
-                }
-
                 $joinSql = $joinQuery->toSql();
 
                 $selects[] = DB::raw("(" . $joinSql . ") as " . $alias);


### PR DESCRIPTION
For example, if a user has two payment orders, only one payment order will be counted when there is a `limit`. Now, the `limit` is removed, but we can still restrict it by setting `limit: 1` in the `conditions`.

```yaml
user_orders_real_amount:
      label: real_amount
      relations: user_orders
      limit: 1
      select: 'sum(real_amount)'
```

```yaml
user_orders_max_id:
      label: user_orders_max_id
      relations: user_orders
      limit: 1
      select: 'user_orders.id'
      conditions:  order by  user_orders.id desc limit 1
```
