### PR TITLE
Fix: prevent null/undefined in Snowboard.request createFormData

### DIFF
--- a/modules/system/assets/js/snowboard/ajax/Request.js
+++ b/modules/system/assets/js/snowboard/ajax/Request.js
@@ -815,6 +815,10 @@ export default class Request extends PluginBase {
      * @returns {void}
      */
     createFormData(formData, data, prefix = '') {
+        if (data === null || data === undefined) {
+            return;
+        }
+
         if (typeof data !== 'object') {
             formData.append(prefix, data);
             return;


### PR DESCRIPTION
### Problem

When using `Snowboard.request()` with `data` that includes `null` or `undefined` values, a `TypeError` is thrown due to `Object.entries()` not accepting such values.

### Fix

A simple check for `null` or `undefined` was added at the beginning of the `createFormData()` function to prevent the error and silently skip those fields.

### Reproduction Example

```js
Snowboard.request('onSomething', {
    data: {
        name: 'phpiando',
        optionalField: null // This causes an error in current version
    }
});
```

This PR prevents that error.

