### PR TITLE
Fixes winter:util purge uploads deleting files that are in-use

### DIFF
--- a/modules/system/console/WinterUtil.php
+++ b/modules/system/console/WinterUtil.php
@@ -347,7 +347,7 @@ class WinterUtil extends Command
                 $currentDir = dirname($filePath);
                 while ($currentDir !== $uploadsFolder) {
                     // Get parent directory children
-                    $children = Storage::disk($uploadsDisk)->directories($currentDir);
+                    $children = Storage::disk($uploadsDisk)->allFiles($currentDir);
                     // Parent directory is empty
                     if (count($children) === 0) {
                         Storage::disk($uploadsDisk)->deleteDirectory($currentDir);


### PR DESCRIPTION
Changes `directories` to `allFiles` so as to not delete directories that contain files that are in-use.  

Per the Laravel docs, the [directories command](https://laravel.com/docs/9.x/filesystem#directories) only retrieves the directories/folders for a given path, and does not include files.  This means when running `php artisan winter:util purge uploads`, if there's an upload that is set to be deleted and is purged, sibling files may be unnecessarily deleted as it does not check if they are also in use during cleanup.

### Example:

Create your controller and model:
```php artisan create:controller Winter.Demo test
php artisan create:model Winter.Demo Test
php artisan make:migration Winter.Demo  
```

**Migration content:**
```
Schema::create('winter_demo_test', function (Blueprint $table) {
      $table->increments('id');
      $table->timestamps();
  });
```

A form to upload an images exists with a [a fileupload form widget](https://wintercms.com/docs/v1.2/docs/backend/forms#file-upload) that uses the following config:

`plugins/winter/demo/models/test/fields.yaml`
```
# ===================================
#  Form Field Definitions
# ===================================

fields:
    id:
        label: 'winter.demo::lang.models.general.id'
        disabled: true
    image:
        label: 'winter.demo::lang.models.test.image'
        type: fileupload
        mode: image
        imageHeight: 400
        imageWidth: 400
        tab: Display
        span: left
        comment: 'winter.demo::lang.models.test.image_comment'
```

When uploading a new file the initial upload is created:
`storage/app/uploads/public/687/7b1/585/6877b15858e6d708143632.jpg`

And because it's in `mode:image` there is a cropped thumbnail generated in the same path:
`storage/app/uploads/public/687/7b1/585/thumb_1_400_400_0_0_crop.jpg`

And upon save a new DB record is created in the `system_files` table (along with other columns):
| id  | disk_name |
| ------------- | ------------- |
| 1  | 6877b15858e6d708143632.jpg  |


But when running the purge command, the thumbnail is deleted, and because there are no sub-directories, the original uploaded file is also purged.