### PR TITLE
Vite Base Rework

### DIFF
--- a/modules/system/console/asset/AssetCompile.php
+++ b/modules/system/console/asset/AssetCompile.php
@@ -208,11 +208,15 @@ abstract class AssetCompile extends Command
     {
         $this->beforeExecution($configPath);
         $command = $this->createCommand($configPath);
+        $commandEnv = $this->createCommandEnv($configPath);
 
         $process = new Process(
             $command,
             $this->getPackagePath($configPath),
-            ['NODE_ENV' => $this->option('production', false) ? 'production' : 'development'],
+            [
+                'NODE_ENV' => $this->option('production', false) ? 'production' : 'development',
+                ...$commandEnv
+            ],
             null,
             null
         );
@@ -256,4 +260,12 @@ abstract class AssetCompile extends Command
      * Create the command array to create a Process object with
      */
     abstract protected function createCommand(string $configPath): array;
+
+    /**
+     * Return values to append to the command env
+     */
+    protected function createCommandEnv(string $configPath): array
+    {
+        return [];
+    }
 }

--- a/modules/system/console/asset/fixtures/config/vite/vite.config.mjs.fixture
+++ b/modules/system/console/asset/fixtures/config/vite/vite.config.mjs.fixture
@@ -1,14 +1,17 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 
+const defaultOutDir = 'assets/dist';
+
 export default defineConfig({
+    base: `${process.env.VITE_BASE}/${defaultOutDir}`,
     build: {
-        outDir: 'assets/dist',
+        outDir: defaultOutDir,
         assetsDir: '',
     },
     plugins: [
         laravel({
-            publicDirectory: 'assets/dist',
+            publicDirectory: defaultOutDir,
             input: [
                 'assets/src/css/{{packageName}}.css',
                 'assets/src/js/{{packageName}}.js',

--- a/modules/system/console/asset/vite/ViteCompile.php
+++ b/modules/system/console/asset/vite/ViteCompile.php
@@ -62,7 +62,6 @@ class ViteCompile extends AssetCompile
             $basePath . sprintf('%1$snode_modules%1$s.bin%1$svite', DIRECTORY_SEPARATOR),
             'build',
             $this->option('silent') ? '--logLevel=silent' : '',
-            '--base=' . Str::after($this->getPackagePath($configPath), base_path())
         );
 
         return $command;

--- a/modules/system/console/asset/vite/ViteCompile.php
+++ b/modules/system/console/asset/vite/ViteCompile.php
@@ -66,4 +66,14 @@ class ViteCompile extends AssetCompile
 
         return $command;
     }
+
+    /**
+     * Return values to append to the command env
+     */
+    protected function createCommandEnv(string $configPath): array
+    {
+        return [
+            'VITE_BASE' => Str::after($this->getPackagePath($configPath), base_path()),
+        ];
+    }
 }


### PR DESCRIPTION
See: https://github.com/wintercms/winter/pull/1377 (I couldn't push changes onto that PR so brought the changes here)

This PR moves the base generated by Winter into an env, which is now used by the default fixture, but also allows for modification by the end user.