### PR TITLE
Preserve clearing of Repeater form widgets on model save

### DIFF
--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -215,10 +215,6 @@ class Repeater extends FormWidgetBase
      */
     public function getSaveValue($value)
     {
-        if (empty($value)) {
-            return [];
-        }
-
         return $this->processSaveValue($value);
     }
 

--- a/modules/backend/formwidgets/Repeater.php
+++ b/modules/backend/formwidgets/Repeater.php
@@ -215,6 +215,10 @@ class Repeater extends FormWidgetBase
      */
     public function getSaveValue($value)
     {
+        if (empty($value)) {
+            return [];
+        }
+
         return $this->processSaveValue($value);
     }
 

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -9,6 +9,7 @@ use Backend\Classes\WidgetManager;
 use BackendAuth;
 use Exception;
 use Form as FormHelper;
+use Illuminate\Support\Str;
 use Lang;
 use Winter\Storm\Database\Model;
 use Winter\Storm\Html\Helper as HtmlHelper;
@@ -1224,7 +1225,14 @@ class Form extends WidgetBase
             // Exclude fields that didn't provide any value
             $fieldValue = $this->dataArrayGet($result, $parts, FormField::NO_SAVE_DATA);
             if ($fieldValue === FormField::NO_SAVE_DATA) {
-                continue;
+                // Check if the widget was loaded but submitted no data
+                $loadedFlagKey = 'form' . Str::studly($field) . '_loaded';
+                if (post($loadedFlagKey)) {
+                    // Widget form was loaded but no data submitted - treat as empty
+                    $fieldValue = null;
+                } else {
+                    continue;
+                }
             }
 
             // Exclude fields where the widget returns NO_SAVE_DATA


### PR DESCRIPTION
Issue:
When a user removes all values from a Repeater widget, the widget submits no POST data. This causes the form save process to skip the field entirely, unintentionally preserving old data.

Suggested Improvement:
Detect when a widget was rendered (`_loaded` flag present) but submitted no data. In these cases, interpret the absence of data as the user intentionally clearing the field, and persist this empty state in the database.

Example:
A backend form has a Repeater widget to manage a list of links:

```
# ===================================
#  Form Field Definitions
# ===================================


links:
    label: Useful Links
    type: repeater
    form:
        fields:
            label:
                label: Label
                type: text
            url:
                label: URL
                type: text
```
Adding one or multiple items works as expected.

Removing a few items also works as expected.

Removing **all** items previously did nothing and the old data was retained.

With this change, removing all items should now correctly clear the field on model save.