### PR TITLE
Fix: include array indexes in FormData for Request.js

### DIFF
--- a/modules/system/assets/js/snowboard/ajax/Request.js
+++ b/modules/system/assets/js/snowboard/ajax/Request.js
@@ -821,8 +821,8 @@ export default class Request extends PluginBase {
         }
 
         if (Array.isArray(data) && prefix !== '') {
-            data.forEach((item) => {
-                this.createFormData(formData, item, `${prefix}[]`);
+            data.forEach((item, index) => {
+                this.createFormData(formData, item, `${prefix}[${index}]`);
             });
             return;
         }


### PR DESCRIPTION
### Problem
When sending arrays of objects via `Snowboard.request()`, the generated FormData omits array indexes. This results in duplicate `[]` keys like:

```
people[][id] = 123
people[][name] = John
```

Which causes problems when parsing on the backend or when trying to associate data with the correct index.

---

### Solution

This PR modifies the `createFormData()` function in `request.js` to include array indexes when serializing arrays into FormData:

```
people[0][id] = 123
people[0][name] = John
```

This matches standard conventions for array serialization and ensures the backend can properly reconstruct the original structure.

---

### Behavior

- Arrays of objects now include the index in each key
- Regular objects and nested objects remain unchanged
- `null` and `undefined` values are still skipped, as per previous fix #1386 

---

### Example

#### Input:

```js
payload = {
  people: [
    { id: 1, name: 'Anne' },
    { id: 2, name: 'Helena' }
  ],
  payment: {
    id: 'abc-123'
  }
};
```

Output FormData (after fix):

```
people[0][id] = 1
people[0][name] = Anne
people[1][id] = 2
people[1][name] = Helena
payment[id] = abc-123
```

Let me know if you'd like any changes!

