### PR TITLE
[Feature] Option to set connection for database migration

### DIFF
--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -129,6 +129,18 @@ class UpdateManager
     }
 
     /**
+     * Sets the database connection to use for migrations.
+     * @param string $connection
+     * @return self
+     */
+    public function setConnection($connection)
+    {
+        $this->migrator->setConnection($connection);
+
+        return $this;
+    }
+
+    /**
      * Creates the migration table and updates
      * @return self
      */

--- a/modules/system/console/WinterUp.php
+++ b/modules/system/console/WinterUp.php
@@ -20,7 +20,8 @@ class WinterUp extends Command implements Isolatable
      * @var string
      */
     protected $signature = 'winter:up
-                            {--seed : Included for compatibility with Laravel default signature, no effect at this time}';
+                            {--seed : Included for compatibility with Laravel default signature, no effect at this time}
+                            {--connection= : The database connection to use}';
 
     /**
      * The console command description.
@@ -47,6 +48,7 @@ class WinterUp extends Command implements Isolatable
 
         UpdateManager::instance()
             ->setNotesOutput($this->output)
+            ->setConnection($this->option('connection'))
             ->update();
     }
 }


### PR DESCRIPTION
I use one connection for winter migrations and another for general usage throughout the site. (I know you can specify a connection in the update files, but this is more of a application-wide generalization for when not using the default connection for migrations).