### PR TITLE
Add fix to inform client when application is not set up

### DIFF
--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -16,6 +16,7 @@ define('LARAVEL_START', microtime(true));
 $helperPath = __DIR__.'/../vendor/winter/storm/src/Support/helpers.php';
 
 if (!file_exists($helperPath)) {
+    header('HTTP/1.0 500 Internal Server Error');
     echo 'Missing vendor files, try running "composer install" or use the Wizard installer.'.PHP_EOL;
     exit(1);
 }


### PR DESCRIPTION
If the application has not been correctly set up, we are currently `exit(1)` and then returning a 200.

This change ensures that if the context of the request is web, we inform the client that things are not okay.