### PR TITLE
 Add allowClear option to disable it on dropdown

### DIFF
--- a/modules/backend/widgets/form/partials/_field_dropdown.php
+++ b/modules/backend/widgets/form/partials/_field_dropdown.php
@@ -3,6 +3,7 @@ $fieldOptions = $field->options();
 $useSearch = $field->getConfig('showSearch', true);
 $emptyOption = $field->getConfig('emptyOption', $field->placeholder);
 $allowCustom = $field->getConfig('allowCustom', false);
+$allowClear = $field->getConfig('allowClear', true);
 ?>
 
 <!-- Dropdown -->
@@ -15,7 +16,7 @@ $allowCustom = $field->getConfig('allowCustom', false);
     <select
         id="<?= $field->getId() ?>"
         name="<?= $field->getName() ?>"
-        class="form-control custom-select <?= $useSearch ? '' : 'select-no-search' ?> <?= $allowCustom ? 'select-modifiable' : '' ?>"
+        class="form-control custom-select <?= $useSearch ? '' : 'select-no-search' ?> <?= $allowCustom ? 'select-modifiable' : '' ?> <?= !$allowClear ? 'select-no-clearable' : '' ?>"
         <?= $field->getAttributes() ?>
         <?= $field->placeholder ? 'data-placeholder="'.e(trans($field->placeholder)).'"' : '' ?>
         >

--- a/modules/system/assets/ui/js/select.js
+++ b/modules/system/assets/ui/js/select.js
@@ -173,6 +173,10 @@
                 extraOptions.allowClear = true
             }
 
+            if ($element.hasClass('select-no-clearable')) {
+                extraOptions.allowClear = false
+            }
+
             $element.select2($.extend({}, selectOptions, extraOptions))
         })
     })


### PR DESCRIPTION
If a dropdown field is casted as enum class, when the dropdown using `placeholder` option is cleared i get application error `"" is not a valid backing value for enum`

If we force "allow clear" feature to been disabled we can still use `placeholder` config without getting the error and force user to select an allowed value from the dropdown

Docs here https://github.com/wintercms/docs/pull/246