### PR TITLE
Add iconClass config option for fileupload formwidget

### DIFF
--- a/modules/backend/formwidgets/FileUpload.php
+++ b/modules/backend/formwidgets/FileUpload.php
@@ -36,6 +36,11 @@ class FileUpload extends FormWidgetBase
     //
 
     /**
+     * @var string Icon class to use for the upload button.
+     */
+    public $iconClass;
+
+    /**
      * @var string Prompt text to display for the upload button.
      */
     public $prompt;
@@ -105,6 +110,7 @@ class FileUpload extends FormWidgetBase
         $this->maxFilesize = $this->getUploadMaxFilesize();
 
         $this->fillFromConfig([
+            'iconClass',
             'prompt',
             'imageWidth',
             'imageHeight',
@@ -160,6 +166,7 @@ class FileUpload extends FormWidgetBase
         $this->vars['cssDimensions'] = $this->getCssDimensions();
         $this->vars['cssBlockDimensions'] = $this->getCssDimensions('block');
         $this->vars['useCaption'] = $this->useCaption;
+        $this->vars['iconClass'] = $this->iconClass ?? 'icon-upload';
         $this->vars['prompt'] = $this->getPromptText();
     }
 

--- a/modules/backend/formwidgets/fileupload/partials/_file_single.php
+++ b/modules/backend/formwidgets/fileupload/partials/_file_single.php
@@ -17,7 +17,7 @@
 
     <!-- Upload Button -->
     <button type="button" class="btn btn-default upload-button">
-        <i class="icon-upload"></i>
+        <i class="<?= $iconClass ?>"></i>
     </button>
 
     <!-- Existing file -->

--- a/modules/backend/formwidgets/fileupload/partials/_file_single.php
+++ b/modules/backend/formwidgets/fileupload/partials/_file_single.php
@@ -17,7 +17,7 @@
 
     <!-- Upload Button -->
     <button type="button" class="btn btn-default upload-button">
-        <i class="<?= $iconClass ?>"></i>
+        <i class="<?= e($iconClass) ?>"></i>
     </button>
 
     <!-- Existing file -->


### PR DESCRIPTION
This PR adds the `iconClass` config to the fileupload formwidget when `mode = file`. This complements the existing `prompt` config.

The config below:
```yaml
fields:
  upload:
    type: fileupload
    mode: file
    prompt: Attach File
    iconClass: icon-paperclip
```

changes the formwidget look from this:
<img width="1277" height="117" alt="image" src="https://github.com/user-attachments/assets/0974c9f1-dba9-45c6-bb2d-4d682232f891" />

To this:
<img width="1277" height="117" alt="image" src="https://github.com/user-attachments/assets/fc6bbe85-d6e3-425e-a8e6-a4fb8c6f815b" />
