### PR TITLE
Add search widget options to relation controller

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -613,8 +613,12 @@ class RelationController extends ControllerBehavior
         $useSearch = $this->viewMode === 'multi' && $this->getConfig('view[showSearch]');
 
         if ($useSearch) {
+            $searchConfig = $this->getConfig('view[search]');
             $toolbarConfig->search = [
-                'prompt' => 'backend::lang.list.search_prompt'
+                'prompt' => array_get($searchConfig, 'prompt', 'backend::lang.list.search_prompt'),
+                'mode' => array_get($searchConfig, 'mode', 'all'),
+                'scope' => array_get($searchConfig, 'scope'),
+                'searchOnEnter' => array_get($searchConfig, 'searchOnEnter', false),
             ];
         }
 
@@ -638,9 +642,15 @@ class RelationController extends ControllerBehavior
         }
 
         $config = $this->makeConfig();
+        $searchConfig = $this->getConfig('view[search]');
+
         $config->alias = $this->alias . 'ManageSearch';
         $config->growable = false;
-        $config->prompt = 'backend::lang.list.search_prompt';
+        $config->prompt = array_get($searchConfig, 'prompt', 'backend::lang.list.search_prompt');
+        $config->mode = array_get($searchConfig, 'mode', 'all');
+        $config->scope = array_get($searchConfig, 'scope');
+        $config->searchOnEnter = array_get($searchConfig, 'searchOnEnter', false);
+
         $widget = $this->makeWidget('Backend\Widgets\Search', $config);
         $widget->cssClasses[] = 'recordfinder-search';
 
@@ -760,6 +770,11 @@ class RelationController extends ControllerBehavior
                     return $widget->onRefresh();
                 });
 
+                $widget->setSearchOptions([
+                    'mode' => $searchWidget->mode,
+                    'scope' => $searchWidget->scope,
+                ]);
+
                 /*
                  * Persist the search term across AJAX requests only
                  */
@@ -877,6 +892,11 @@ class RelationController extends ControllerBehavior
                     $widget->setSearchTerm($this->searchWidget->getActiveTerm());
                     return $widget->onRefresh();
                 });
+
+                $widget->setSearchOptions([
+                    'mode' => $this->searchWidget->mode,
+                    'scope' => $this->searchWidget->scope,
+                ]);
 
                 /*
                  * Persist the search term across AJAX requests only

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -613,13 +613,7 @@ class RelationController extends ControllerBehavior
         $useSearch = $this->viewMode === 'multi' && $this->getConfig('view[showSearch]');
 
         if ($useSearch) {
-            $searchConfig = $this->getConfig('view[search]');
-            $toolbarConfig->search = [
-                'prompt' => array_get($searchConfig, 'prompt', 'backend::lang.list.search_prompt'),
-                'mode' => array_get($searchConfig, 'mode', 'all'),
-                'scope' => array_get($searchConfig, 'scope'),
-                'searchOnEnter' => array_get($searchConfig, 'searchOnEnter', false),
-            ];
+            $toolbarConfig->search = $this->getSearchConfig('view[search]');
         }
 
         /*
@@ -635,21 +629,28 @@ class RelationController extends ControllerBehavior
         return $toolbarWidget;
     }
 
+    protected function getSearchConfig($key)
+    {
+        $config = $this->getConfig($key);
+        $searchConfig = $this->makeConfig();
+
+        $searchConfig->prompt = array_get($config, 'prompt', 'backend::lang.list.search_prompt');
+        $searchConfig->mode = array_get($config, 'mode', 'all');
+        $searchConfig->scope = array_get($config, 'scope');
+        $searchConfig->searchOnEnter = array_get($config, 'searchOnEnter', false);
+
+        return $searchConfig;
+    }
+
     protected function makeSearchWidget()
     {
         if (!$this->getConfig('manage[showSearch]')) {
             return null;
         }
 
-        $config = $this->makeConfig();
-        $searchConfig = $this->getConfig('view[search]');
-
+        $config = $this->getSearchConfig('manage[search]');
         $config->alias = $this->alias . 'ManageSearch';
         $config->growable = false;
-        $config->prompt = array_get($searchConfig, 'prompt', 'backend::lang.list.search_prompt');
-        $config->mode = array_get($searchConfig, 'mode', 'all');
-        $config->scope = array_get($searchConfig, 'scope');
-        $config->searchOnEnter = array_get($searchConfig, 'searchOnEnter', false);
 
         $widget = $this->makeWidget('Backend\Widgets\Search', $config);
         $widget->cssClasses[] = 'recordfinder-search';


### PR DESCRIPTION
Related: https://github.com/wintercms/docs/pull/248

Add search widget options to RelationController config:

```yaml
relation:
    label: Relation
    view:
        list: $/r4l/backend/models/contact/short-columns.yaml
        toolbarButtons: add|create|remove
        showSearch: true
        search:
          prompt: View Search Prompt
          mode: any
          scope: viewSearchScope
          searchOnEnter: true
    manage:
        search:
          prompt: Manage Search Prompt
          mode: exact
          scope: manageSearchScope
          searchOnEnter: false
```