### PR TITLE
Quendi6 datatable patch 1

### DIFF
--- a/modules/backend/widgets/table/assets/js/build-min.js
+++ b/modules/backend/widgets/table/assets/js/build-min.js
@@ -19,7 +19,7 @@ this.clickHandler=this.onClick.bind(this)
 this.keydownHandler=this.onKeydown.bind(this)
 this.documentClickHandler=this.onDocumentClick.bind(this)
 this.toolbarClickHandler=this.onToolbarClick.bind(this)
-if(this.options.postback&&this.options.clientDataSourceClass=='client'){if(!this.options.postbackHandlerName){var formHandler=this.$el.closest('form').data('request')
+if(this.options.postback&&this.options.clientDataSourceClass=='client'){if(!this.options.postbackHandlerName.length){var formHandler=this.$el.closest('form').data('request')
 this.options.postbackHandlerName=[formHandler||'onSave']}else if(typeof this.options.postbackHandlerName==='string'){this.options.postbackHandlerName=this.options.postbackHandlerName.split(',')}this.formSubmitHandler=this.onFormSubmit.bind(this)}this.navigation=null
 this.search=null
 this.recordsAddedOrDeleted=0

--- a/modules/backend/widgets/table/assets/js/table.js
+++ b/modules/backend/widgets/table/assets/js/table.js
@@ -72,7 +72,7 @@
         this.toolbarClickHandler = this.onToolbarClick.bind(this)
 
         if (this.options.postback && this.options.clientDataSourceClass == 'client') {
-            if (!this.options.postbackHandlerName) {
+            if (!this.options.postbackHandlerName.length) {
                 var formHandler = this.$el.closest('form').data('request')
                 this.options.postbackHandlerName = [formHandler || 'onSave']
             } else if (typeof this.options.postbackHandlerName === 'string') {


### PR DESCRIPTION
Fix [#1409](https://github.com/wintercms/winter/issues/1409) and [#1399](https://github.com/wintercms/winter/issues/1399).

Replacing `if (!this.options.postbackHandlerName)` with `if (!this.options.postbackHandlerName.length)` is the right way to keep the new postbackHandlerName type and keep the correct behavior for the default empty array value.

[modules/backend/widgets/table/assets/js/table.js](https://github.com/wintercms/winter/commit/59d3199dce9dfdcd86a9e01efc5b1caec246c44c#diff-7c9bd4a62da5eb18d69a023cb1d7d8c04dd2958466c5a707b0c3901e4fd28cc6) Line 75 modification + recompilation of assets.