### PR TITLE
Update Font Awesome API URL to specific release - 6.7.2

### DIFF
--- a/modules/system/console/WinterUtil.php
+++ b/modules/system/console/WinterUtil.php
@@ -161,7 +161,7 @@ class WinterUtil extends Command
         ) {
             $this->comment('Downloading Font Awesome icons...');
 
-            $releases = Http::get('https://api.github.com/repos/FortAwesome/Font-Awesome/releases/latest', function (NetworkHttp $http) {
+            $releases = Http::get('https://api.github.com/repos/FortAwesome/Font-Awesome/releases/191042913', function (NetworkHttp $http) {
                 $http->header('Accept', 'application/json');
                 $http->header('User-Agent', 'Winter CMS');
             });


### PR DESCRIPTION
Fixes issue with FA v7 breaking the asset compiler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Font Awesome asset sourcing to use a pinned release version for improved consistency during asset compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->