### PR TITLE
Add Twig environment events

### DIFF
--- a/modules/cms/ServiceProvider.php
+++ b/modules/cms/ServiceProvider.php
@@ -158,7 +158,9 @@ class ServiceProvider extends ModuleServiceProvider
             }
 
             $twig = MarkupManager::makeBaseTwigEnvironment(new CmsTwigLoader, $options);
-            $twig->addExtension(new CmsTwigExtension);
+
+            CmsTwigExtension::addExtensionToTwig($twig);
+
             if ($isDebugMode) {
                 $twig->addExtension(new DebugExtension);
             }

--- a/modules/cms/twig/Extension.php
+++ b/modules/cms/twig/Extension.php
@@ -2,11 +2,11 @@
 
 use Block;
 use Cms\Classes\Controller;
-use Event;
 use System\Classes\Asset\Vite;
 use Twig\Extension\AbstractExtension as TwigExtension;
 use Twig\TwigFilter as TwigSimpleFilter;
 use Twig\TwigFunction as TwigSimpleFunction;
+use Winter\Storm\Support\Facades\Event;
 
 /**
  * The CMS Twig extension class implements the basic CMS Twig functions and filters.
@@ -19,7 +19,15 @@ class Extension extends TwigExtension
     /**
      * The instanciated CMS controller
      */
-    protected Controller $controller;
+    protected ?Controller $controller;
+
+    /**
+     * __construct the extension instance.
+     */
+    public function __construct(?Controller $controller = null)
+    {
+        $this->controller = $controller;
+    }
 
     /**
      * Sets the CMS controller instance
@@ -35,6 +43,27 @@ class Extension extends TwigExtension
     public function getController(): Controller
     {
         return $this->controller;
+    }
+
+    /**
+     * Registers this extension with the Twig environment and dispatches an event.
+     */
+    public static function addExtensionToTwig(\Twig\Environment $twig, ?Controller $controller = null)
+    {
+        $twig->addExtension(new static($controller));
+
+        /**
+         * @event cms.extendTwig
+         * Provides an opportunity to extend the Twig environment used by the cms
+         *
+         * Example usage:
+         *
+         *     Event::listen('cms.extendTwig', function ((Twig\Environment) $twig) {
+         *         $twig->addExtension(new \Twig\Extension\StringLoaderExtension);
+         *     });
+         *
+         */
+        Event::fire('cms.extendTwig', [$twig]);
     }
 
     /**

--- a/modules/system/classes/MarkupManager.php
+++ b/modules/system/classes/MarkupManager.php
@@ -63,7 +63,9 @@ class MarkupManager
         ], $options);
 
         $twig = new TwigEnvironment($loader, $options);
-        $twig->addExtension(new SystemTwigExtension);
+
+        SystemTwigExtension::addExtensionToTwig($twig);
+
         $twig->addExtension(new SandboxExtension(new TwigSecurityPolicy, true));
         return $twig;
     }

--- a/modules/system/twig/Extension.php
+++ b/modules/system/twig/Extension.php
@@ -1,12 +1,14 @@
 <?php namespace System\Twig;
 
-use Url;
 use System\Classes\ImageResizer;
-use System\Classes\MediaLibrary;
 use System\Classes\MarkupManager;
+use System\Classes\MediaLibrary;
+use Twig\Environment as TwigEnvironment;
+use Twig\Extension\AbstractExtension as TwigExtension;
 use Twig\TwigFilter as TwigSimpleFilter;
 use Twig\TwigFunction as TwigSimpleFunction;
-use Twig\Extension\AbstractExtension as TwigExtension;
+use Url;
+use Winter\Storm\Support\Facades\Event;
 
 /**
  * The System Twig extension class implements common Twig functions and filters.
@@ -27,6 +29,27 @@ class Extension extends TwigExtension
     public function __construct()
     {
         $this->markupManager = MarkupManager::instance();
+    }
+
+    /**
+     * Registers this extension with the Twig environment and dispatches an event.
+     */
+    public static function addExtensionToTwig(TwigEnvironment $twig)
+    {
+        $twig->addExtension(new static);
+
+        /**
+         * @event system.extendTwig
+         * Provides an opportunity to extend the Twig environment used by the system
+         *
+         * Example usage:
+         *
+         *     Event::listen('system.extendTwig', function ((Twig\Environment) $twig) {
+         *         $twig->addExtension(new \Twig\Extension\StringLoaderExtension);
+         *     });
+         *
+         */
+        Event::fire('system.extendTwig', [$twig]);
     }
 
     /**


### PR DESCRIPTION
This PR adds `cms.extendTwig` and `system.extendTwig` events.  

If a plugin wanted to register new Twig extensions, it had to use the `cms.page.beforeRenderPage` event:
```php
Event::listen('cms.page.beforeRenderPage', function($controller, $page) {
    $twig = $controller->getTwig();

    $extensions = [
        'Twig\Extra\Cache\CacheExtension',
        // ...
        'Twig\Extra\String\StringExtension'
    ];

    foreach ($extensions as $extension) {
        if (!$twig->hasExtension($extension)) {
            $twig->addExtension(new $extension);
        }
    }
});
```

Thanks to these new events, the plugin can register Twig extensions even if a page is not rendered:
```php
Event::listen('system.extendTwig', function(\Twig\Environment $twig) {
    $extensions = [
        'Twig\Extra\Cache\CacheExtension',
        // ...
        'Twig\Extra\String\StringExtension'
    ];

    foreach ($extensions as $extension) {
        if (!$twig->hasExtension($extension)) {
            $twig->addExtension(new $extension);
        }
    }
});
```
and same can be done with `cms.extendTwig`.

The plugin itself can then test the successful implementation of the new extensions:
```php
<?php

namespace Hounddd\TwigExtraBundle\Tests\Feature;

use System\Tests\Bootstrap\PluginTestCase;
use Cms\Classes\Controller;
use Cms\Classes\Theme;

class TwigExtraTest extends PluginTestCase
{
    /**
     * Test singular filter in english.
     */
    public function test_singular_partitions_english(): void
    {
        $value = trim($this->renderTwigInCmsController('{{ "partitions"|singular() }}'));
        $this->assertEquals('partition', $value);
    }

    /**
     * Test singular filter in french.
     */
    public function test_singular_partitions_french(): void
    {
        $value = trim($this->renderTwigInCmsController('{{ "partitions"|singular("fr") }}'));
        $this->assertEquals('partition', $value);
    }

    /**
     * Test singular filter in french - "animaux".
     */
    public function test_singular_animaux_french(): void
    {
        $value = trim($this->renderTwigInCmsController('{{ "animaux"|singular("fr") }}'));
        $this->assertEquals('animal', $value);
    }


    /**
     * Test plural filter in english.
     */
    public function test_plural_animal_english(): void
    {
        $value = trim($this->renderTwigInCmsController('{{ "animal"|plural() }}'));
        $this->assertEquals('animals', $value);
    }

    /**
     * Test plural filter in french.
     */
    public function test_plural_animal_french(): void
    {
        $value = trim($this->renderTwigInCmsController('{{ "animal"|plural("fr") }}'));
        $this->assertEquals('animaux', $value);
    }


    /**
     * Renders a Twig template string within a simulated CMS controller context.
     *
     * This method creates a temporary instance of `Controller`, retrieves its Twig
     * environment, and renders the provided `$source` string as a Twig template.
     * It automatically injects standard CMS controller variables (including 'theme')
     * into the template's 'this' variable, which can be merged or overridden by
     * the optional `$vars` array.
     *
     * @param string $source The Twig template content as a string.
     * @param array $vars Optional variables to pass to the template, which will be merged with the default 'this' context variables.
     * @return string The rendered HTML content from the Twig template.
     */
    protected function renderTwigInCmsController(string $source, array $vars = []): string
    {
        $controller = new Controller();
        $twig = $controller->getTwig();
        $template = $twig->createTemplate($source, 'test.case');

        return $twig->render($template, [
            'this' => array_merge($controller->getControllerGlobalVars(), [
                'theme' => new Theme(),
            ]),
        ] + $vars);
    }
}

```