### PR TITLE
Disable AutoDataSource caching in debug mode

### DIFF
--- a/modules/cms/classes/AutoDatasource.php
+++ b/modules/cms/classes/AutoDatasource.php
@@ -10,6 +10,7 @@ use Winter\Storm\Halcyon\Datasource\DatasourceInterface;
 use Winter\Storm\Halcyon\Exception\DeleteFileException;
 use Winter\Storm\Halcyon\Model;
 use Winter\Storm\Halcyon\Processors\Processor;
+use Winter\Storm\Support\Facades\Config;
 
 /**
  * Datasource that loads from other data sources automatically
@@ -76,9 +77,7 @@ class AutoDatasource extends Datasource implements DatasourceInterface
     public function appendDatasource(string $key, DatasourceInterface $datasource): void
     {
         $this->datasources[$key] = $datasource;
-        $this->pathCache[] = Cache::rememberForever($datasource->getPathsCacheKey(), function () use ($datasource) {
-            return $datasource->getAvailablePaths();
-        });
+        $this->pathCache[] = $this->fetchPathCache($datasource);
     }
 
     /**
@@ -87,9 +86,7 @@ class AutoDatasource extends Datasource implements DatasourceInterface
     public function prependDatasource(string $key, DatasourceInterface $datasource): void
     {
         $this->datasources = array_prepend($this->datasources, $datasource, $key);
-        $this->pathCache = array_prepend($this->pathCache, Cache::rememberForever($datasource->getPathsCacheKey(), function () use ($datasource) {
-            return $datasource->getAvailablePaths();
-        }), $key);
+        $this->pathCache = array_prepend($this->pathCache, $this->fetchPathCache($datasource), $key);
     }
 
     /**
@@ -122,11 +119,22 @@ class AutoDatasource extends Datasource implements DatasourceInterface
             }
 
             // Load the cache
-            $pathCache[] = Cache::rememberForever($datasource->getPathsCacheKey(), function () use ($datasource) {
+            $pathCache[] = $this->fetchPathCache($datasource);
+        }
+        $this->pathCache = $pathCache;
+    }
+
+    protected function fetchPathCache($datasource): array
+    {
+        $pathCache = [];
+        if (Config::get('app.debug', false)) {
+            $pathCache = $datasource->getAvailablePaths();
+        } else {
+            $pathCache = Cache::rememberForever($datasource->getPathsCacheKey(), function () use ($datasource) {
                 return $datasource->getAvailablePaths();
             });
         }
-        $this->pathCache = $pathCache;
+        return $pathCache;
     }
 
     /**

--- a/modules/cms/classes/AutoDatasource.php
+++ b/modules/cms/classes/AutoDatasource.php
@@ -124,7 +124,7 @@ class AutoDatasource extends Datasource implements DatasourceInterface
         $this->pathCache = $pathCache;
     }
 
-    protected function fetchPathCache($datasource): array
+    protected function fetchPathCache(DatasourceInterface $datasource): array
     {
         $pathCache = [];
         if (Config::get('app.debug', false)) {


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and simplified data source path caching: caching behavior is now handled in one place, improving maintainability and performance.
  * Cache selection respects debug/runtime mode to ensure accurate development vs. production behavior.
  * Callers receive computed path data rather than managing caching themselves, reducing duplication and potential inconsistencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->