### PR TITLE
Use FormBuilder to build backend form dropdown

### DIFF
--- a/modules/backend/widgets/form/partials/_field_dropdown.php
+++ b/modules/backend/widgets/form/partials/_field_dropdown.php
@@ -13,7 +13,7 @@ $fieldOptions = $field->options();
     $options = $field->getAttributes(htmlBuild:false);
     $options['id'] = $field->getId();
     $options['class'] = 'form-control custom-select';
-    if ($field->getConfig('showSearch', true)) {
+    if ($field->getConfig('showSearch', true) === false) {
         $options['class'] .= ' select-no-search';
     }
     if ($field->getConfig('allowCustom', false)) {

--- a/modules/backend/widgets/form/partials/_field_dropdown.php
+++ b/modules/backend/widgets/form/partials/_field_dropdown.php
@@ -26,5 +26,10 @@ $fieldOptions = $field->options();
         $options['data-placeholder'] = e(trans($field->placeholder));
     }
     ?>
-    <?= Form::select(name:$field->getName(), list:$fieldOptions, selected:$field->value, options:$options) ?>
+    <?= Form::select(
+        name: $field->getName(),
+        list: $fieldOptions,
+        selected: $field->value,
+        options: $options
+    ) ?>
 <?php endif ?>

--- a/modules/backend/widgets/form/partials/_field_dropdown.php
+++ b/modules/backend/widgets/form/partials/_field_dropdown.php
@@ -1,8 +1,5 @@
 <?php
 $fieldOptions = $field->options();
-$useSearch = $field->getConfig('showSearch', true);
-$emptyOption = $field->getConfig('emptyOption', $field->placeholder);
-$allowCustom = $field->getConfig('allowCustom', false);
 ?>
 
 <!-- Dropdown -->
@@ -11,30 +8,22 @@ $allowCustom = $field->getConfig('allowCustom', false);
         <?= (isset($fieldOptions[$field->value])) ? e(trans($fieldOptions[$field->value])) : '' ?>
     </div>
     <input type="hidden" name="<?= $field->getName() ?>" value="<?= $field->value ?>">
-<?php else: ?>
-    <select
-        id="<?= $field->getId() ?>"
-        name="<?= $field->getName() ?>"
-        class="form-control custom-select <?= $useSearch ? '' : 'select-no-search' ?> <?= $allowCustom ? 'select-modifiable' : '' ?>"
-        <?= $field->getAttributes() ?>
-        <?= $field->placeholder ? 'data-placeholder="'.e(trans($field->placeholder)).'"' : '' ?>
-        >
-        <?php if ($emptyOption): ?>
-            <option value=""><?= e(trans($emptyOption)) ?></option>
-        <?php endif ?>
-        <?php foreach ($fieldOptions as $value => $option): ?>
-            <?php
-            if (!is_array($option)) {
-                $option = [$option];
-            }
-            ?>
-            <option
-                <?= $field->isSelected($value) ? 'selected="selected"' : '' ?>
-                <?php if (isset($option[1])): ?>
-                    data-<?= strpos($option[1], '.') ? 'image' : 'icon' ?>="<?= $option[1] ?>"
-                <?php endif ?>
-                value="<?= e($value) ?>"
-            ><?= e(trans($option[0])) ?></option>
-        <?php endforeach ?>
-    </select>
+<?php else:
+    $options = $field->getAttributes(htmlBuild:false);
+    $options['id'] = $field->getId();
+    $options['class'] = 'form-control custom-select';
+    if ($field->getConfig('showSearch', true)) {
+        $options['class'] .= ' select-no-search';
+    }
+    if ($field->getConfig('allowCustom', false)) {
+        $options['class'] .= ' select-modifiable';
+    }
+    if ($emptyOption = $field->getConfig('emptyOption', $field->placeholder)) {
+        $options['emptyOption'] = e(trans($emptyOption));
+    }
+    if ($field->placeholder) {
+        $options['data-placeholder'] = e(trans($field->placeholder));
+    }
+?>
+    <?= Form::select(name:$field->getName(), list:$fieldOptions, selected:$field->value, options:$options) ?>
 <?php endif ?>

--- a/modules/backend/widgets/form/partials/_field_dropdown.php
+++ b/modules/backend/widgets/form/partials/_field_dropdown.php
@@ -9,6 +9,7 @@ $fieldOptions = $field->options();
     </div>
     <input type="hidden" name="<?= $field->getName() ?>" value="<?= $field->value ?>">
 <?php else:
+    $emptyOption = $field->getConfig('emptyOption', $field->placeholder);
     $options = $field->getAttributes(htmlBuild:false);
     $options['id'] = $field->getId();
     $options['class'] = 'form-control custom-select';
@@ -18,12 +19,12 @@ $fieldOptions = $field->options();
     if ($field->getConfig('allowCustom', false)) {
         $options['class'] .= ' select-modifiable';
     }
-    if ($emptyOption = $field->getConfig('emptyOption', $field->placeholder)) {
+    if ($emptyOption) {
         $options['emptyOption'] = e(trans($emptyOption));
     }
     if ($field->placeholder) {
         $options['data-placeholder'] = e(trans($field->placeholder));
     }
-?>
+    ?>
     <?= Form::select(name:$field->getName(), list:$fieldOptions, selected:$field->value, options:$options) ?>
 <?php endif ?>


### PR DESCRIPTION
Depends on https://github.com/wintercms/storm/pull/222
Related to https://github.com/wintercms/docs/pull/253

This also adds support for optGroup in dropdown through the FormBuilder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated dropdown rendering into a single, consistent path for improved reliability and easier maintenance.
  * Preserves user-facing behaviors: placeholder, optional search, custom-option entry, empty-option handling, and preview/read-only display.
  * Error and accessibility handling unified to reduce rendering inconsistencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->