### PR TITLE
Add blade support for cms/backend partials

### DIFF
--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -25,6 +25,7 @@ use Winter\Storm\Exception\AjaxException;
 use Winter\Storm\Exception\ValidationException;
 use Winter\Storm\Parse\Bracket as TextParser;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Blade;
 
 /**
  * The CMS controller class.
@@ -1065,9 +1066,14 @@ class Controller
          * Render the partial
          */
         CmsException::mask($partial, 400);
-        $this->getLoader()->setObject($partial);
-        $template = $this->getTwig()->load($partial->getFilePath());
-        $partialContent = $template->render(array_merge($parameters, $this->vars));
+        if (str_ends_with($partial->fileName, '.blade.php')) {
+            $partialContent = Blade::render($partial->content, $this->vars);
+        }
+        else {
+            $this->getLoader()->setObject($partial);
+            $template = $this->getTwig()->load($partial->getFilePath());
+            $partialContent = $template->render(array_merge($parameters, $this->vars));
+        }
         CmsException::unmask();
 
         if ($partial instanceof Partial) {

--- a/modules/cms/classes/Partial.php
+++ b/modules/cms/classes/Partial.php
@@ -13,6 +13,8 @@ class Partial extends CmsCompoundObject
      */
     protected $dirName = 'partials';
 
+    protected $allowedExtensions = ['htm', 'blade'];
+
     /**
      * Returns name of a PHP class to us a parent for the PHP class created for the object's PHP section.
      * @return string Returns the class name.
@@ -20,5 +22,30 @@ class Partial extends CmsCompoundObject
     public function getCodeClassParent()
     {
         return PartialCode::class;
+    }
+
+    /**
+     * Returns the base file name and extension. Applies a default extension, if none found.
+     */
+    public function getFileNameParts($fileName = null)
+    {
+        if ($fileName === null) {
+            $fileName = $this->fileName;
+        }
+
+        if (!strlen($extension = pathinfo($fileName, PATHINFO_EXTENSION))) {
+            $extension = $this->defaultExtension;
+            $baseFile = $fileName;
+        }
+        elseif (($extension = pathinfo($fileName, PATHINFO_EXTENSION)) === 'blade') {
+            $extension = 'php';
+            $baseFile = $fileName;
+        }
+        else {
+            $pos = strrpos($fileName, '.');
+            $baseFile = substr($fileName, 0, $pos);
+        }
+
+        return [$baseFile, $extension];
     }
 }

--- a/modules/system/traits/ViewMaker.php
+++ b/modules/system/traits/ViewMaker.php
@@ -1,11 +1,12 @@
 <?php namespace System\Traits;
 
-use File;
-use Lang;
 use Block;
+use Config;
+use File;
+use Illuminate\Support\Facades\Blade;
+use Lang;
 use SystemException;
 use Throwable;
-use Config;
 
 /**
  * View Maker Trait
@@ -208,6 +209,10 @@ trait ViewMaker
         // Check the path for an extension
         $ext = pathinfo($fileName, PATHINFO_EXTENSION);
         if (!empty($ext)) {
+            if ($ext === 'blade') {
+                $ext = 'php';
+                $fileName .= ".php";
+            }
             if (!in_array($ext, $allowedExtensions)) {
                 throw new SystemException("$ext is not a valid View extension");
             }
@@ -263,6 +268,11 @@ trait ViewMaker
         }
 
         $vars = array_merge($this->vars, $extraParams);
+
+        if (str_ends_with($filePath, '.blade.php')) {
+            $fileContent = file_get_contents($filePath);
+            return Blade::render($fileContent, $vars);
+        }
 
         $obLevel = ob_get_level();
 


### PR DESCRIPTION
## Usage

### from twig:
```twig
{% partial "my_partial.blade" %}
```

### from PHP:
```php
$cmsController->renderPartial("my_partial.blade");
```
Actual partial file path should be: `/partials/my_partial.blade.php` 

```php
$backendController->makePartial("my_partial.blade", array $vars);
```
Actual partial file path should be: `_my_partial.blade.php` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Blade-style partials in the template system, enabling additional template rendering options alongside existing partials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->