### PR TITLE
Improve grouped repeater UX by adding search and multiple columns

### DIFF
--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -139,6 +139,78 @@
             })
 
         $('[data-repeater-add]', $container).data('request-form', $form)
+
+        // Setup search functionality
+        var $searchInput = $('.repeater-group-search', $container)
+        var $clearButton = $('.repeater-group-search-clear', $container)
+        var $noResults = $('.repeater-group-no-results', $container)
+        var $itemsContainer = $('.repeater-group-items-container', $container)
+        var $listItems = $('.repeater-group-item', $container)
+
+        // Add hover effects to grid items
+        $listItems.on('mouseenter', 'a', function() {
+            $(this).css({
+                'border-color': '#3498db',
+                'box-shadow': '0 2px 8px rgba(0,0,0,0.1)',
+                'transform': 'translateY(-2px)'
+            })
+        }).on('mouseleave', 'a', function() {
+            $(this).css({
+                'border-color': '#e0e0e0',
+                'box-shadow': 'none',
+                'transform': 'translateY(0)'
+            })
+        })
+
+        $searchInput.on('input', function() {
+            var searchTerm = $(this).val().toLowerCase().trim()
+
+            // Show/hide clear button
+            $clearButton.toggle(searchTerm.length > 0)
+
+            if (searchTerm === '') {
+                // Show all items
+                $listItems.show()
+                $noResults.hide()
+                $itemsContainer.show()
+                return
+            }
+
+            var visibleCount = 0
+
+            // Filter items
+            $listItems.each(function() {
+                var $item = $(this)
+                var title = $('.title', $item).text().toLowerCase()
+                var description = $('.description', $item).text().toLowerCase()
+
+                if (title.indexOf(searchTerm) !== -1 || description.indexOf(searchTerm) !== -1) {
+                    $item.show()
+                    visibleCount++
+                } else {
+                    $item.hide()
+                }
+            })
+
+            // Show/hide no results message and adjust container height
+            if (visibleCount === 0) {
+                $noResults.show()
+                $itemsContainer.hide()
+            } else {
+                $noResults.hide()
+                $itemsContainer.show()
+            }
+        })
+
+        // Clear search functionality
+        $clearButton.on('click', function() {
+            $searchInput.val('').trigger('input').focus()
+        })
+
+        // Focus search input when popover opens
+        setTimeout(function() {
+            $searchInput.focus()
+        }, 100)
     }
 
     Repeater.prototype.onRemoveItemSuccess = function(ev) {

--- a/modules/backend/formwidgets/repeater/partials/_repeater.php
+++ b/modules/backend/formwidgets/repeater/partials/_repeater.php
@@ -42,8 +42,10 @@
         </div>
         <div class="repeater-group-search-container" style="padding: 10px 15px; border-bottom: 1px solid #e0e0e0;">
             <div style="position: relative;">
+                <label for="repeater-group-search-<?= $this->getId() ?>" class="sr-only">Search items</label>
                 <i class="icon-search" style="position: absolute; left: 10px; top: 50%; transform: translateY(-50%); color: #999; pointer-events: none; z-index: 10;"></i>
                 <input type="text"
+                    id="repeater-group-search-<?= $this->getId() ?>"
                     class="form-control repeater-group-search"
                     placeholder="Search items..."
                     autocomplete="off"
@@ -69,7 +71,7 @@
                                     data-request="<?= $this->getEventHandler('onAddItem') ?>"
                                     data-request-data="_repeater_group: '<?= $item['code'] ?>'"
                                     style="display: flex; height: 100%; align-items: center; gap: 16px; padding: 12px 12px 12px 16px; border: 1px solid #e0e0e0; border-radius: 4px; text-decoration: none; color: inherit; transition: all 0.2s;">
-                                    <i class="<?= $item['icon'] ?>" style="width: 1em; text: center; font-size: 24px; color: #666; margin-top: 2px; flex-shrink: 0;"></i>
+                                    <i class="<?= $item['icon'] ?>" style="width: 1em; text-align: center; font-size: 24px; color: #666; margin-top: 2px; flex-shrink: 0;"></i>
                                     <div style="flex: 1; min-width: 0;">
                                         <span class="title" style="font-weight: 600; font-size: 13px; display: block; margin-bottom: 2px;"><?= e(trans($item['name'])) ?></span>
                                         <span class="description" style="font-size: 11px; color: #999; display: block; line-height: 1.3;"><?= e(trans($item['description'])) ?></span>

--- a/modules/backend/formwidgets/repeater/partials/_repeater.php
+++ b/modules/backend/formwidgets/repeater/partials/_repeater.php
@@ -40,27 +40,43 @@
                 data-dismiss="popover"
                 aria-hidden="true">&times;</button>
         </div>
-        <div class="popover-fixed-height w-300">
+        <div class="repeater-group-search-container" style="padding: 10px 15px; border-bottom: 1px solid #e0e0e0;">
+            <div style="position: relative;">
+                <i class="icon-search" style="position: absolute; left: 10px; top: 50%; transform: translateY(-50%); color: #999; pointer-events: none; z-index: 10;"></i>
+                <input type="text"
+                    class="form-control repeater-group-search"
+                    placeholder="Search items..."
+                    autocomplete="off"
+                    style="padding-left: 32px; padding-right: 32px; width: 100%;">
+                <button type="button" class="repeater-group-search-clear" style="position: absolute; right: 8px; top: 50%; transform: translateY(-50%); background: transparent; border: none; padding: 4px 6px; cursor: pointer; display: none; z-index: 10; color: #999;">
+                    <i class="icon-close" style="font-size: 14px;"></i>
+                </button>
+            </div>
+        </div>
+        <div class="repeater-group-no-results" style="display: none; padding: 20px; text-align: center; color: #999;">
+            No items found
+        </div>
+        <div class="popover-fixed-height repeater-group-items-container" style="min-width: 500px; max-width: 800px;">
             <div class="control-scrollpad" data-control="scrollpad">
                 <div class="scroll-wrapper">
 
-                    <div class="control-filelist filelist-hero" data-control="filelist">
-                        <ul>
-                            <?php foreach ($groupDefinitions as $item): ?>
-                                <li>
-                                    <a
-                                        href="javascript:;"
-                                        data-repeater-add
-                                        data-request="<?= $this->getEventHandler('onAddItem') ?>"
-                                        data-request-data="_repeater_group: '<?= $item['code'] ?>'">
-                                        <i class="list-icon <?= $item['icon'] ?>"></i>
-                                        <span class="title"><?= e(trans($item['name'])) ?></span>
-                                        <span class="description"><?= e(trans($item['description'])) ?></span>
-                                        <span class="borders"></span>
-                                    </a>
-                                </li>
-                            <?php endforeach ?>
-                        </ul>
+                    <div class="control-filelist filelist-hero repeater-group-grid" data-control="filelist" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 8px; padding: 15px;">
+                        <?php foreach ($groupDefinitions as $item): ?>
+                            <div class="repeater-group-item">
+                                <a
+                                    href="javascript:;"
+                                    data-repeater-add
+                                    data-request="<?= $this->getEventHandler('onAddItem') ?>"
+                                    data-request-data="_repeater_group: '<?= $item['code'] ?>'"
+                                    style="display: flex; height: 100%; align-items: center; gap: 16px; padding: 12px 12px 12px 16px; border: 1px solid #e0e0e0; border-radius: 4px; text-decoration: none; color: inherit; transition: all 0.2s;">
+                                    <i class="<?= $item['icon'] ?>" style="width: 1em; text: center; font-size: 24px; color: #666; margin-top: 2px; flex-shrink: 0;"></i>
+                                    <div style="flex: 1; min-width: 0;">
+                                        <span class="title" style="font-weight: 600; font-size: 13px; display: block; margin-bottom: 2px;"><?= e(trans($item['name'])) ?></span>
+                                        <span class="description" style="font-size: 11px; color: #999; display: block; line-height: 1.3;"><?= e(trans($item['description'])) ?></span>
+                                    </div>
+                                </a>
+                            </div>
+                        <?php endforeach ?>
                     </div>
 
                 </div>


### PR DESCRIPTION
<img width="538" height="325" alt="Screenshot 2025-12-28 at 4 18 03 PM" src="https://github.com/user-attachments/assets/36e20ffa-c959-4c73-8eaf-b4568fbff7ab" />
<img width="525" height="250" alt="Screenshot 2025-12-28 at 4 18 09 PM" src="https://github.com/user-attachments/assets/ced4bdf3-9d37-465d-8971-f99bddc3ae4b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side search UI with live filtering by title or description, clear button, no-results messaging, and autofocus behavior.
  * Redesigned repeater items from a vertical list to a responsive grid of clickable cards with improved hover styling and visual hierarchy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->