### PR TITLE
Add current form data as second argument to RecordFinder scope method

### DIFF
--- a/modules/backend/formwidgets/RecordFinder.php
+++ b/modules/backend/formwidgets/RecordFinder.php
@@ -353,7 +353,8 @@ class RecordFinder extends FormWidgetBase
         }
         elseif ($scopeMethod = $this->scope) {
             $widget->bindEvent('list.extendQueryBefore', function ($query) use ($scopeMethod) {
-                $query->$scopeMethod($this->model);
+                $formData = $this->getParentForm()->getSaveData();
+                $query->$scopeMethod($this->model, $formData);
             });
         }
         else {


### PR DESCRIPTION
It can be useful if the record finder needs some other fields in the form to filter its values.

Related: https://github.com/wintercms/docs/pull/256

E.g. fields definition:

```yaml
country:
    type: dropdown

state:
    type: recordfinder
    list: $/author/plugin/models/state/columns.yaml
    scope: statesByCountry
```

```php
class State extends model
{
    public function scopeStatesByCountry($query, $model, $formData)
    {
        if ($country_id = array_get($formData, 'country')) {
            $query->where('country_id', $country_id);
        }
    }
}
```