### PR TITLE
Remove Repeater titleFrom input type=text requirement.

### DIFF
--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -327,7 +327,7 @@
                 selector = 'input, select:first, ul:first'
             }
         }
-        if (!$target.length) {
+        if (!$target || !$target.length) {
             $target = $item
         }
 

--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -314,7 +314,8 @@
     Repeater.prototype.getCollapseTitle = function($item) {
         var $target,
             defaultText = '',
-            explicitText = $item.data('collapse-title')
+            explicitText = $item.data('collapse-title'),
+            selector = 'input[type=text], select:first, ul:first'
 
         if (explicitText) {
             return explicitText
@@ -322,15 +323,15 @@
 
         if (this.options.titleFrom) {
             $target = $('[data-field-name="'+this.options.titleFrom+'"]', $item)
-            if (!$target.length) {
-                $target = $item
+            if ($target.length) {
+                selector = 'input, select:first, ul:first'
             }
         }
-        else {
+        if (!$target.length) {
             $target = $item
         }
 
-        var $textInput = $('input:first, select:first, ul:first', $target).first()
+        var $textInput = $(selector, $target).first()
         if ($textInput.length) {
             switch($textInput.prop("tagName")) {
                 case 'SELECT':

--- a/modules/backend/formwidgets/repeater/assets/js/repeater.js
+++ b/modules/backend/formwidgets/repeater/assets/js/repeater.js
@@ -330,7 +330,7 @@
             $target = $item
         }
 
-        var $textInput = $('input[type=text]:first, select:first, ul:first', $target).first()
+        var $textInput = $('input:first, select:first, ul:first', $target).first()
         if ($textInput.length) {
             switch($textInput.prop("tagName")) {
                 case 'SELECT':


### PR DESCRIPTION
Allow any input element as titleFrom, leave responsibility to user not to choose a type that doesn't make sense (e.g. button)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repeater widget more reliably derives collapse titles from a broader set of form elements (no longer limited to plain text inputs), improving display consistency.
  * Enhanced fallback logic when a collapse title isn’t found, so items show meaningful labels more often across varied input types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->