### PR TITLE
Fix dropdown yielding options as a collection.

### DIFF
--- a/modules/backend/tests/widgets/FormTest.php
+++ b/modules/backend/tests/widgets/FormTest.php
@@ -14,6 +14,11 @@ namespace Backend\Tests\Widgets
             return ['model', 'custom', 'options'];
         }
 
+        public function collectionOptions()
+        {
+            return collect(['collection', 'options']);
+        }
+
         public function getFieldNameOnModelOptionsMethodOptions()
         {
             return ['model', 'field name', 'options method'];
@@ -167,6 +172,11 @@ namespace Backend\Tests\Widgets
                         'type' => 'dropdown',
                         'options' => [\FormHelper::class, 'staticMethodOptions'],
                         'expect' => ['static', 'method'],
+                    ],
+                    'collection_options' => [
+                        'type' => 'dropdown',
+                        'options' => 'collectionOptions',
+                        'expect' => collect(['collection', 'options']),
                     ],
                     'model_method_options' => [
                         'type' => 'dropdown',

--- a/modules/backend/widgets/form/partials/_field_dropdown.php
+++ b/modules/backend/widgets/form/partials/_field_dropdown.php
@@ -1,8 +1,8 @@
 <?php
-    $fieldOptions = $field->options();
-    if ($fieldOptions instanceof Illuminate\Support\Collection) {
-        $fieldOptions = $fieldOptions->all();
-    }
+$fieldOptions = $field->options();
+if ($fieldOptions instanceof Illuminate\Support\Collection) {
+    $fieldOptions = $fieldOptions->all();
+}
 ?>
 
 <!-- Dropdown -->

--- a/modules/backend/widgets/form/partials/_field_dropdown.php
+++ b/modules/backend/widgets/form/partials/_field_dropdown.php
@@ -1,5 +1,8 @@
 <?php
     $fieldOptions = $field->options();
+    if ($fieldOptions instanceof Illuminate\Support\Collection) {
+        $fieldOptions = $fieldOptions->all();
+    }
 ?>
 
 <!-- Dropdown -->


### PR DESCRIPTION
Fixes #1445 

Restores previous behavior.

Added a unittest that triggers the error in the form rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dropdown form fields now correctly normalize options provided as collections for consistent display.

* **Tests**
  * Added test coverage validating collection-based options handling and the options source used in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->