### PR TITLE
Move Vite rendering to `styles` twig directive

### DIFF
--- a/modules/cms/twig/ScriptsNode.php
+++ b/modules/cms/twig/ScriptsNode.php
@@ -26,7 +26,6 @@ class ScriptsNode extends TwigNode
         $compiler
             ->addDebugInfo($this)
             ->write("echo \$this->env->getExtension('Cms\Twig\Extension')->assetsFunction('js');\n")
-            ->write("echo \$this->env->getExtension('Cms\Twig\Extension')->assetsFunction('vite');\n")
             ->write("echo \$this->env->getExtension('Cms\Twig\Extension')->displayBlock('scripts');\n")
         ;
     }

--- a/modules/cms/twig/StylesNode.php
+++ b/modules/cms/twig/StylesNode.php
@@ -26,6 +26,7 @@ class StylesNode extends TwigNode
         $compiler
             ->addDebugInfo($this)
             ->write("echo \$this->env->getExtension('Cms\Twig\Extension')->assetsFunction('css');\n")
+            ->write("echo \$this->env->getExtension('Cms\Twig\Extension')->assetsFunction('vite');\n")
             ->write("echo \$this->env->getExtension('Cms\Twig\Extension')->displayBlock('styles');\n")
         ;
     }


### PR DESCRIPTION
If the recommendations are followed, the page architecture should be: 
```html
<!DOCTYPE html>
<html lang="en">
<head>
    /* Website metas */

    {% styles %}
</head>
<body>
    /* Website content */

    {% scripts %}
</body>
</html>
```
This avoids FOUC (Flash of Unstyled Content), the browser renders the content progressively, and the experience is better, scripts doesn't block content rendering and all nodes are availables for manipulation.

If a component uses $this->addVite(...) to include the required resources, those resources are rendered in the site's Twig tag {% scripts %}.
In this case, this can cause FOUC issues because the styles are rendered after the entire DOM.

Proposed fix: 
The idea is to render Vite's `<style />` and `<script />` elements from the `{% styles %}` twig directive: 
- No more FOUC
- No issues with scripts that could be blocking because the `type=“module”` attribute is added automatically and acts like the `defer` attribute.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
* Modified asset loading sequences for stylesheets and scripts to streamline the resource compilation pipeline
* Adjusted asset processing order during page generation for improved resource management and efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->