### PR TITLE
fix: Add common License filenames

### DIFF
--- a/modules/system/controllers/Updates.php
+++ b/modules/system/controllers/Updates.php
@@ -127,7 +127,7 @@ class Updates extends Controller
 
             $readmeFiles = ['README.md', 'readme.md'];
             $upgradeFiles = ['UPGRADE.md', 'upgrade.md'];
-            $licenceFiles = ['LICENCE.md', 'licence.md', 'LICENSE.md', 'license.md'];
+            $licenceFiles = ['LICENCE.md', 'licence.md', 'LICENSE.md', 'license.md', 'LICENCE', 'LICENSE'];
 
             $readme = $changelog = $upgrades = $licence = $name = null;
             $code = str_replace('-', '.', $urlCode);


### PR DESCRIPTION
Small thing I just noted when I went to prepare a new plugin for release: The Winter CMS backend doesn't check the filenames "LICENSE" and "LICENCE" when providing plugin details. This PR adds them.

(I didn't check how common these are, but I have seen quite a bit of repositories — including my own — that omit the filename extension.)

Nota bene: We might want to also refactor the Markdown-parsing step since extensionless files usually are supposed to be rendered as plain text. That is less of an issue, though, but if you're up to it, I can draft up another PR quickly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced license file detection to recognize additional naming variations, improving system compatibility with diverse project structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->