### PR TITLE
Remove unnecessary closure argument passed to array_first()

### DIFF
--- a/modules/backend/controllers/Index.php
+++ b/modules/backend/controllers/Index.php
@@ -72,10 +72,7 @@ class Index extends Controller
     protected function checkPermissionRedirect()
     {
         if (!$this->user->hasAccess('backend.access_dashboard')) {
-            $true = function () {
-                return true;
-            };
-            if ($first = array_first(BackendMenu::listMainMenuItems(), $true)) {
+            if ($first = array_first(BackendMenu::listMainMenuItems())) {
                 return Redirect::intended($first->url);
             }
             return Backend::redirect('backend/users/myaccount');


### PR DESCRIPTION
The array_first function takes only one parameter: https://www.php.net/manual/en/function.array-first.php

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization to simplify permission redirect logic. No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->