### PR TITLE
Add comments on risky permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ nbproject
 .vscode
 !.devcontainer/.vscode
 _ide_helper.php
+.zed
 
 # Other ignores
 .DS_Store

--- a/modules/backend/ServiceProvider.php
+++ b/modules/backend/ServiceProvider.php
@@ -178,11 +178,13 @@ class ServiceProvider extends ModuleServiceProvider
                 'backend.manage_users' => [
                     'label' => 'system::lang.permissions.manage_other_administrators',
                     'tab'   => 'system::lang.permissions.name',
+                    'comment' => 'system::lang.permissions.manage_other_administrators_comment',
                     'roles' => [UserRole::CODE_DEVELOPER],
                 ],
                 'backend.impersonate_users' => [
                     'label' => 'system::lang.permissions.impersonate_users',
                     'tab'   => 'system::lang.permissions.name',
+                    'comment' => 'system::lang.permissions.impersonate_users_comment',
                     'roles' => [UserRole::CODE_DEVELOPER],
                 ],
                 'backend.manage_preferences' => [
@@ -203,6 +205,7 @@ class ServiceProvider extends ModuleServiceProvider
                 'backend.manage_branding' => [
                     'label' => 'system::lang.permissions.manage_branding',
                     'tab'   => 'system::lang.permissions.name',
+                    'comment' => 'system::lang.permissions.manage_branding_comment',
                     'roles' => [UserRole::CODE_DEVELOPER],
                 ],
                 'media.manage_media' => [
@@ -213,6 +216,7 @@ class ServiceProvider extends ModuleServiceProvider
                 'backend.allow_unsafe_markdown' => [
                     'label' => 'backend::lang.permissions.allow_unsafe_markdown',
                     'tab' => 'system::lang.permissions.name',
+                    'comment' => 'backend::lang.permissions.allow_unsafe_markdown_comment',
                     'roles' => [UserRole::CODE_DEVELOPER],
                 ],
             ]);

--- a/modules/backend/formwidgets/permissioneditor/partials/_permissioneditor.php
+++ b/modules/backend/formwidgets/permissioneditor/partials/_permissioneditor.php
@@ -1,9 +1,9 @@
 <div class="permissioneditor <?= $this->previewMode ? 'control-disabled' : '' ?>" <?= $field->getAttributes() ?>>
     <table>
         <?php
-            $firstTab = true;
-            $globalIndex = 0;
-            $checkboxMode = !($this->mode === 'radio');
+        $firstTab = true;
+        $globalIndex = 0;
+        $checkboxMode = !($this->mode === 'radio');
         ?>
         <?php foreach ($permissions as $tab => $tabPermissions): ?>
             <tr class="section">
@@ -20,7 +20,7 @@
             </tr>
 
             <?php
-                $lastIndex = count($tabPermissions) - 1;
+            $lastIndex = count($tabPermissions) - 1;
             ?>
             <?php foreach ($tabPermissions as $index => $permission): ?>
 
@@ -55,13 +55,15 @@
 
                     <td class="permission-name">
                         <?= e(trans($permission->label)) ?>
-                        <p class="comment"><?= e(trans($permission->comment)) ?></p>
+                        <?php if ($permission->comment): ?>
+                            <span class="text-info wn-icon-circle-info" data-toggle="tooltip" title="<?= e(trans($permission->comment)) ?>"></span>
+                        <?php endif; ?>
                     </td>
 
                     <?php if ($this->mode === 'radio'): ?>
                         <td class="permission-value">
                             <div class="radio custom-radio">
-                                 <input
+                                <input
                                     id="<?= $allowId ?>"
                                     name="<?= e($baseFieldName) ?>[<?= e($permission->code) ?>]"
                                     value="1"
@@ -75,7 +77,7 @@
                         </td>
                         <td class="permission-value">
                             <div class="radio custom-radio">
-                                 <input
+                                <input
                                     id="<?= $inheritId ?>"
                                     name="<?= e($baseFieldName) ?>[<?= e($permission->code) ?>]"
                                     value="0"
@@ -88,7 +90,7 @@
                         </td>
                         <td class="permission-value">
                             <div class="radio custom-radio">
-                                 <input
+                                <input
                                     id="<?= $denyId ?>"
                                     name="<?= e($baseFieldName) ?>[<?= e($permission->code) ?>]"
                                     value="-1"
@@ -123,7 +125,7 @@
                     <?php else: ?>
                         <td class="permission-value">
                             <div class="checkbox custom-checkbox">
-                                 <input
+                                <input
                                     id="<?= $allowId ?>"
                                     name="<?= e($baseFieldName) ?>[<?= e($permission->code) ?>]"
                                     value="1"

--- a/modules/backend/formwidgets/permissioneditor/partials/_permissioneditor.php
+++ b/modules/backend/formwidgets/permissioneditor/partials/_permissioneditor.php
@@ -56,7 +56,14 @@
                     <td class="permission-name">
                         <?= e(trans($permission->label)) ?>
                         <?php if ($permission->comment): ?>
-                            <span class="text-info wn-icon-circle-info" data-toggle="tooltip" title="<?= e(trans($permission->comment)) ?>"></span>
+                            <span
+                                class="text-info wn-icon-circle-info"
+                                data-toggle="tooltip"
+                                title="<?= e(trans($permission->comment)) ?>"
+                                tabindex="0"
+                                role="img"
+                                aria-label="<?= e(trans($permission->comment)) ?>"
+                            ></span>
                         <?php endif; ?>
                     </td>
 

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -612,7 +612,8 @@ return [
     ],
     'permissions' => [
         'manage_media' => 'Upload and manage media contents - images, videos, sounds, documents',
-        'allow_unsafe_markdown' => 'Use unsafe Markdown (Can include Javascript)',
+        'allow_unsafe_markdown' => 'Allow unsafe Markdown',
+        'allow_unsafe_markdown_comment' => 'Allowing unsafe Markdown will allow HTML tags, including JavaScript, in Markdown content. This can be a security risk if given to an untrusted user.',
     ],
     'mediafinder' => [
         'label' => 'Media Finder',

--- a/modules/cms/ServiceProvider.php
+++ b/modules/cms/ServiceProvider.php
@@ -1,4 +1,6 @@
-<?php namespace Cms;
+<?php
+
+namespace Cms;
 
 use Backend;
 use Backend\Classes\WidgetManager;
@@ -342,24 +344,28 @@ class ServiceProvider extends ModuleServiceProvider
                 'cms.manage_pages' => [
                     'label' => 'cms::lang.permissions.manage_pages',
                     'tab' => 'cms::lang.permissions.name',
+                    'comment' => 'cms::lang.permissions.manage_pages_comment',
                     'roles' => [UserRole::CODE_DEVELOPER],
                     'order' => 100
                 ],
                 'cms.manage_layouts' => [
                     'label' => 'cms::lang.permissions.manage_layouts',
                     'tab' => 'cms::lang.permissions.name',
+                    'comment' => 'cms::lang.permissions.manage_layouts_comment',
                     'roles' => [UserRole::CODE_DEVELOPER],
                     'order' => 100
                 ],
                 'cms.manage_partials' => [
                     'label' => 'cms::lang.permissions.manage_partials',
                     'tab' => 'cms::lang.permissions.name',
+                    'comment' => 'cms::lang.permissions.manage_partials_comment',
                     'roles' => [UserRole::CODE_DEVELOPER],
                     'order' => 100
                 ],
                 'cms.manage_themes' => [
                     'label' => 'cms::lang.permissions.manage_themes',
                     'tab' => 'cms::lang.permissions.name',
+                    'comment' => 'cms::lang.permissions.manage_themes_comment',
                     'roles' => [UserRole::CODE_DEVELOPER],
                     'order' => 100
                 ],

--- a/modules/cms/lang/en/lang.php
+++ b/modules/cms/lang/en/lang.php
@@ -277,9 +277,13 @@ return [
         'manage_content' => 'Manage website content files',
         'manage_assets' => 'Manage website assets - images, JavaScript files, CSS files',
         'manage_pages' => 'Create, modify and delete website pages',
+        'manage_pages_comment' => 'This permission should only be given to trusted users, as it allows direct access to the theme\'s page content files, including PHP code if enabled.',
         'manage_layouts' => 'Create, modify and delete CMS layouts',
+        'manage_layouts_comment' => 'This permission should only be given to trusted users, as it allows direct access to the theme\'s layout files, including PHP code if enabled.',
         'manage_partials' => 'Create, modify and delete CMS partials',
+        'manage_partials_comment' => 'This permission should only be given to trusted users, as it allows direct access to the theme\'s partial files, including PHP code if enabled.',
         'manage_themes' => 'Activate, deactivate and configure CMS themes',
+        'manage_themes_comment' => 'This permission should only be given to trusted users, as it allows the user to change the theme or delete it entirely.',
         'manage_theme_options' => 'Configure customization options for the active theme',
     ],
     'theme_log' => [

--- a/modules/cms/lang/en/lang.php
+++ b/modules/cms/lang/en/lang.php
@@ -283,7 +283,7 @@ return [
         'manage_partials' => 'Create, modify and delete CMS partials',
         'manage_partials_comment' => 'This permission should only be given to trusted users, as it allows direct access to the theme\'s partial files, including PHP code if enabled.',
         'manage_themes' => 'Activate, deactivate and configure CMS themes',
-        'manage_themes_comment' => 'This permission should only be given to trusted users, as it allows the user to change the theme or delete it entirely.',
+        'manage_themes_comment' => 'This permission should only be given to trusted users, as it allows the user to add new themes, change the existing theme, or delete themes entirely.',
         'manage_theme_options' => 'Configure customization options for the active theme',
     ],
     'theme_log' => [

--- a/modules/system/lang/en/lang.php
+++ b/modules/system/lang/en/lang.php
@@ -448,7 +448,7 @@ return [
         'manage_mail_templates' => 'Manage mail templates',
         'manage_mail_settings' => 'Manage mail settings',
         'manage_other_administrators' => 'Manage other administrators',
-        'manage_other_administrators_comment' => 'Allows the user to create, update and delete other administrator accounts. This permission should only be given to trusted users.',
+        'manage_other_administrators_comment' => 'Allows the user to create, update, and delete other administrator accounts. This permission should only be given to trusted users.',
         'impersonate_users' => 'Impersonate users',
         'impersonate_users_comment' => 'Allows the user to impersonate other users at their level of access. This permission should only be given to trusted users.',
         'manage_preferences' => 'Manage backend preferences',

--- a/modules/system/lang/en/lang.php
+++ b/modules/system/lang/en/lang.php
@@ -448,13 +448,16 @@ return [
         'manage_mail_templates' => 'Manage mail templates',
         'manage_mail_settings' => 'Manage mail settings',
         'manage_other_administrators' => 'Manage other administrators',
+        'manage_other_administrators_comment' => 'Allows the user to create, update and delete other administrator accounts. This permission should only be given to trusted users.',
         'impersonate_users' => 'Impersonate users',
+        'impersonate_users_comment' => 'Allows the user to impersonate other users at their level of access. This permission should only be given to trusted users.',
         'manage_preferences' => 'Manage backend preferences',
         'manage_editor' => 'Manage global code editor preferences',
         'manage_own_editor' => 'Manage personal code editor preferences',
         'view_the_dashboard' => 'View the dashboard',
         'manage_default_dashboard' => 'Manage the default dashboard',
         'manage_branding' => 'Customize the back-end',
+        'manage_branding_comment' => 'This permission allows the user to customize the back-end appearance, including custom CSS content. This may be a security risk if given to an untrusted user.'
     ],
     'log' => [
         'menu_label' => 'Log settings',


### PR DESCRIPTION
To assist admins when assigning permissions to users, I have added comments to permissions that should only be given to trusted users. These permissions, if given to untrusted users, may pose a security risk due to being able to negatively manipulate the experience of other users, or could be potentially used to grant themselves more access than intended.

<img width="2970" height="616" alt="image" src="https://github.com/user-attachments/assets/700ff04c-bc7f-4d23-9e59-33e909f69dab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Permission comments now appear as tooltip-enabled info icons next to permission labels for clearer explanations.

* **Documentation**
  * Updated permission labels and added descriptive notes covering unsafe Markdown, administrator/impersonation rights, branding, and CMS permissions to clarify access implications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->