### PR TITLE
Added basic viewer for event log details

### DIFF
--- a/modules/system/controllers/eventlogs/_field_details.php
+++ b/modules/system/controllers/eventlogs/_field_details.php
@@ -1,5 +1,11 @@
 <?php
 if (!isset($value['logVersion']) || $value['logVersion'] !== 2) {
+    if ($value ?? false) {
+        printf(
+            '<h4>DETAILS</h4><pre style="background: #fff; padding: 10px; border: 1px solid #ddd;">%s</pre>',
+            print_r($value, true)
+        );
+    }
     return;
 }
 

--- a/modules/system/controllers/eventlogs/_field_details.php
+++ b/modules/system/controllers/eventlogs/_field_details.php
@@ -3,7 +3,7 @@ if (!isset($value['logVersion']) || $value['logVersion'] !== 2) {
     if ($value ?? false) {
         printf(
             '<h4>DETAILS</h4><pre style="background: #fff; padding: 10px; border: 1px solid #ddd;">%s</pre>',
-            print_r($value, true)
+            e(print_r($value, true))
         );
     }
     return;


### PR DESCRIPTION
This PR adds a very basic viewer for event log details.

<img width="1217" height="637" alt="image" src="https://github.com/user-attachments/assets/92279837-5ce1-4e7d-8e45-7770055f82c8" />

Should resolve https://github.com/wintercms/winter/issues/1475.

I'd like to add better support for the new log viewer, but don't have time currently. To anybody reading this you can use:
```php
$message = 'My Error Message';
$details = (new EventLog())->getDetails(new \Exception());
$details['exception']['message'] = $message;
$details['exception']['snippet'] = [
    'Something terrible has happened',
];

Log::error($message, $details);
```
To force in custom logs in the new style with fancy stack traces, but use at your own risk because it's fairly easy to break the renderer while doing this.

<img width="1220" height="1204" alt="image" src="https://github.com/user-attachments/assets/3f9f0d60-cce3-4b9d-bb59-4f2a4d3687fb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event Logs field details now include a visible "DETAILS" block displaying the field value when available, providing more contextual information directly in the Event Logs view. No other behavior was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->