### PR TITLE
Fix TypeError when removing a non-existent plugin

### DIFF
--- a/modules/system/classes/UpdateManager.php
+++ b/modules/system/classes/UpdateManager.php
@@ -615,6 +615,11 @@ class UpdateManager
             return $this;
         }
 
+        if (!$plugin) {
+            $this->write(Error::class, sprintf('Unable to find plugin %s', $name));
+            return $this;
+        }
+
         if ($stopOnVersion && !$this->versionManager->hasDatabaseVersion($plugin, $stopOnVersion)) {
             throw new ApplicationException(Lang::get('system::lang.updates.plugin_version_not_found'));
         }

--- a/modules/system/console/PluginRemove.php
+++ b/modules/system/console/PluginRemove.php
@@ -4,6 +4,7 @@ use File;
 use Winter\Storm\Console\Command;
 use System\Classes\UpdateManager;
 use System\Classes\PluginManager;
+use System\Classes\VersionManager;
 
 /**
  * Console command to remove a plugin.
@@ -49,6 +50,14 @@ class PluginRemove extends Command
     {
         $pluginName = $this->getPluginIdentifier();
         $pluginManager = PluginManager::instance();
+
+        if (
+            !$pluginManager->hasPlugin($pluginName)
+            && !VersionManager::instance()->getDatabaseHistory($pluginName)
+        ) {
+            $this->error(sprintf('Plugin "%s" could not be found.', $pluginName));
+            return 1;
+        }
 
         $confirmQuestion = sprintf('This will remove the files for the "%s" plugin.', $pluginName);
         if (!$this->option('no-rollback')) {


### PR DESCRIPTION
## Problem

When running `plugin:remove` with a plugin identifier that does not exist anywhere on the system (no files on disk, no database records), the command would:

1. Display the confirmation banner asking the user to type the plugin name
2. Crash with a `TypeError` after confirmation instead of giving a meaningful error

**Before:**

<img width="1474" height="219" alt="Screenshot_1" src="https://github.com/user-attachments/assets/06dfe69f-20bc-4e09-a04c-b2bd79808cf3" />

```
In PluginManager.php line 556:

  System\Classes\PluginManager::getIdentifier(): Argument #1 ($plugin) must be of type
  System\Classes\PluginBase|string, null given, called in VersionManager.php on line 232
```

## Root Cause

In `UpdateManager::rollbackPlugin()`, when `findByIdentifier()` returns `null` (plugin not registered) **and** `purgePlugin()` returns `false` (no database records to clean up), execution would fall through to `VersionManager::removePlugin(null, ...)`, which expects either a `PluginBase` instance or a `string` — causing the `TypeError`.

## Fix

Two changes were made:

**1. `modules/system/classes/UpdateManager.php` — null guard in `rollbackPlugin()`**

Added an early return after the purge check when `$plugin` is still `null`, preventing the call to `removePlugin()` with a `null` argument and surfacing a proper error message instead.

**2. `modules/system/console/PluginRemove.php` — early validation before confirmation prompt**

Added a check before the confirmation question using `PluginManager::hasPlugin()` (covers plugins on disk, both enabled and disabled) combined with `VersionManager::getDatabaseHistory()` (covers plugins that were manually removed from disk but still have leftover database records). If neither condition is met, the command exits immediately with a clear error — before the user is asked to type anything.

**After:**

<img width="633" height="90" alt="Screenshot_2" src="https://github.com/user-attachments/assets/01e73c97-fcce-4599-a7ab-62856c7728b3" />

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Plugin not found anywhere | TypeError crash after confirmation | `ERROR Plugin "X" could not be found.` before confirmation |
| Plugin on disk only (enabled or disabled) | Works normally | Works normally |
| Plugin with DB records only (files manually deleted) | Purges DB records | Purges DB records |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when a plugin cannot be found during rollback operations, with explicit error messaging.
  * Enhanced plugin removal validation to verify plugin existence before proceeding, preventing incomplete removal operations and providing clearer feedback when a plugin is not found.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wintercms/winter/pull/1484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->