### PR TITLE
fix(php): resolve PHP 8.4/8.5 deprecations

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -422,7 +422,7 @@ class ListController extends ControllerBehavior
      *
      * @return array The list element selector as the key, and the list contents are the value.
      */
-    public function listRefresh(string $definition = null)
+    public function listRefresh(?string $definition = null)
     {
         if (!count($this->listWidgets)) {
             $this->makeLists();
@@ -439,7 +439,7 @@ class ListController extends ControllerBehavior
      * Returns the widget used by this behavior.
      * @return \Backend\Classes\WidgetBase
      */
-    public function listGetWidget(string $definition = null)
+    public function listGetWidget(?string $definition = null)
     {
         if (!$definition) {
             $definition = $this->primaryDefinition;
@@ -452,7 +452,7 @@ class ListController extends ControllerBehavior
      * Returns the configuration used by this behavior.
      * @return stdClass
      */
-    public function listGetConfig(string $definition = null)
+    public function listGetConfig(?string $definition = null)
     {
         if (!$definition) {
             $definition = $this->primaryDefinition;

--- a/modules/backend/facades/Backend.php
+++ b/modules/backend/facades/Backend.php
@@ -4,12 +4,12 @@ use Winter\Storm\Support\Facade;
 
 /**
  * @method static string uri()
- * @method static string url(string $path = null, array $parameters = [], bool $secure = null)
- * @method static string baseUrl(string $path = null)
- * @method static string skinAsset(string $path = null)
- * @method static \Illuminate\Http\RedirectResponse redirect(string $path, int $status = 302, array $headers = [], bool $secure = null)
- * @method static \Illuminate\Http\RedirectResponse redirectGuest(string $path, int $status = 302, array $headers = [], bool $secure = null)
- * @method static \Illuminate\Http\RedirectResponse redirectIntended(string $path, int $status = 302, array $headers = [], bool $secure = null)
+ * @method static string url(?string $path = null, array $parameters = [], ?bool $secure = null)
+ * @method static string baseUrl(?string $path = null)
+ * @method static string skinAsset(?string $path = null)
+ * @method static \Illuminate\Http\RedirectResponse redirect(string $path, int $status = 302, array $headers = [], ?bool $secure = null)
+ * @method static \Illuminate\Http\RedirectResponse redirectGuest(string $path, int $status = 302, array $headers = [], ?bool $secure = null)
+ * @method static \Illuminate\Http\RedirectResponse redirectIntended(string $path, int $status = 302, array $headers = [], ?bool $secure = null)
  * @method static string date($dateTime, array $options = [])
  * @method static string dateTime($dateTime, array $options = [])
  *

--- a/modules/backend/traits/PreferenceMaker.php
+++ b/modules/backend/traits/PreferenceMaker.php
@@ -42,7 +42,7 @@ trait PreferenceMaker
      * @param mixed $default A default value to use when value is not found.
      * @return mixed
      */
-    public function getUserPreference(string $key = null, $default = null)
+    public function getUserPreference(?string $key = null, $default = null)
     {
         $preferences = $this->getUserPreferences();
 

--- a/modules/backend/widgets/MediaManager.php
+++ b/modules/backend/widgets/MediaManager.php
@@ -1192,7 +1192,7 @@ class MediaManager extends WidgetBase
     /**
      * Returns thumbnail parameters
      */
-    protected function getThumbnailParams(string $viewMode = null): array
+    protected function getThumbnailParams(?string $viewMode = null): array
     {
         $result = [
             'mode' => 'crop'
@@ -1316,7 +1316,7 @@ class MediaManager extends WidgetBase
      *
      * @todo Consider moving this into the File helper and accepting a $disk instance
      */
-    protected function deduplicatePath(string $path, string $suffix = null): string
+    protected function deduplicatePath(string $path, ?string $suffix = null): string
     {
         $parts = pathinfo($path);
         $i = 1;

--- a/modules/cms/classes/CmsException.php
+++ b/modules/cms/classes/CmsException.php
@@ -42,7 +42,7 @@ class CmsException extends ApplicationException
      * Error 400: Mask the exception as Twig content.
      * @param Throwable $previous Previous exception.
      */
-    public function __construct($message = null, $code = 100, Throwable $previous = null)
+    public function __construct($message = null, $code = 100, ?Throwable $previous = null)
     {
         if ($message instanceof CmsCompoundObject || $message instanceof ComponentPartial) {
             $this->compoundObject = $message;

--- a/modules/cms/classes/ComponentBase.php
+++ b/modules/cms/classes/ComponentBase.php
@@ -82,7 +82,7 @@ abstract class ComponentBase extends Extendable
      * @param null|CodeBase $cmsObject
      * @param array $properties
      */
-    public function __construct(CodeBase $cmsObject = null, $properties = [])
+    public function __construct(?CodeBase $cmsObject = null, $properties = [])
     {
         if ($cmsObject !== null) {
             $this->page = $cmsObject;

--- a/modules/cms/classes/Controller.php
+++ b/modules/cms/classes/Controller.php
@@ -1586,7 +1586,7 @@ class Controller
      * @param ComponentBase $component
      * @return void
      */
-    public function setComponentContext(ComponentBase $component = null)
+    public function setComponentContext(?ComponentBase $component = null)
     {
         $this->componentContext = $component;
     }

--- a/modules/cms/classes/Page.php
+++ b/modules/cms/classes/Page.php
@@ -83,7 +83,7 @@ class Page extends CmsCompoundObject
 
         $layouts = Layout::listInTheme($theme, true);
         $result = [];
-        $result[null] = Lang::get('cms::lang.page.no_layout');
+        $result[''] = Lang::get('cms::lang.page.no_layout');
 
         foreach ($layouts as $layout) {
             $baseName = $layout->getBaseFileName();

--- a/modules/cms/controllers/ThemeOptions.php
+++ b/modules/cms/controllers/ThemeOptions.php
@@ -102,7 +102,7 @@ class ThemeOptions extends Controller
      * @param string $dirName
      * @return string
      */
-    protected function getDirName(string $dirName = null)
+    protected function getDirName(?string $dirName = null)
     {
         /*
          * Only the active theme can be managed without this permission

--- a/modules/cms/facades/Cms.php
+++ b/modules/cms/facades/Cms.php
@@ -3,7 +3,7 @@
 use Winter\Storm\Support\Facade;
 
 /**
- * @method static string url(string $path = null)
+ * @method static string url(?string $path = null)
  *
  * @see \Cms\Helpers\Cms
  */

--- a/modules/cms/models/ThemeExport.php
+++ b/modules/cms/models/ThemeExport.php
@@ -59,7 +59,7 @@ class ThemeExport extends Model
      *
      * @return void
      */
-    public function save(array $options = null, $sessionKey = null)
+    public function save(?array $options = null, $sessionKey = null)
     {
         throw new ApplicationException(sprintf("The % model is not intended to be saved, please use %s instead", get_class($this), 'ThemeData'));
     }

--- a/modules/cms/models/ThemeImport.php
+++ b/modules/cms/models/ThemeImport.php
@@ -64,7 +64,7 @@ class ThemeImport extends Model
      *
      * @return void
      */
-    public function save(array $options = null, $sessionKey = null)
+    public function save(?array $options = null, $sessionKey = null)
     {
         throw new ApplicationException(sprintf("The % model is not intended to be saved, please use %s instead", get_class($this), 'ThemeData'));
     }

--- a/modules/cms/twig/Extension.php
+++ b/modules/cms/twig/Extension.php
@@ -128,7 +128,7 @@ class Extension extends TwigExtension
     /**
      * Renders registered assets of a given type or all types if $type not provided
      */
-    public function assetsFunction(string $type = null): ?string
+    public function assetsFunction(?string $type = null): ?string
     {
         return $this->controller->makeAssets($type);
     }
@@ -136,7 +136,7 @@ class Extension extends TwigExtension
     /**
      * Renders placeholder content, without removing the block, must be called before the placeholder tag itself
      */
-    public function placeholderFunction(string $name, string $default = null): ?string
+    public function placeholderFunction(string $name, ?string $default = null): ?string
     {
         if (($result = Block::get($name)) === null) {
             return null;
@@ -196,7 +196,7 @@ class Extension extends TwigExtension
     /**
      * Returns a layout block contents (or null if it doesn't exist) and removes the block.
      */
-    public function displayBlock(string $name, string $default = null): ?string
+    public function displayBlock(string $name, ?string $default = null): ?string
     {
         if (($result = Block::placeholder($name)) === null) {
             return $default;

--- a/modules/system/classes/FileManifest.php
+++ b/modules/system/classes/FileManifest.php
@@ -54,7 +54,7 @@ class FileManifest
     /**
      * Constructor.
      */
-    public function __construct(string $root = null, array $modules = null)
+    public function __construct(?string $root = null, ?array $modules = null)
     {
         $this->setRoot($root ?? base_path());
         $this->setModules($modules ?? Config::get('cms.loadModules', ['System', 'Backend', 'Cms']));

--- a/modules/system/classes/MarkupManager.php
+++ b/modules/system/classes/MarkupManager.php
@@ -52,7 +52,7 @@ class MarkupManager
     /**
      * Make an instance of the base TwigEnvironment to extend further
      */
-    public static function makeBaseTwigEnvironment(LoaderInterface $loader = null, array $options = []): TwigEnvironment
+    public static function makeBaseTwigEnvironment(?LoaderInterface $loader = null, array $options = []): TwigEnvironment
     {
         if (!$loader) {
             $loader = new SystemTwigLoader();

--- a/modules/system/classes/SourceManifest.php
+++ b/modules/system/classes/SourceManifest.php
@@ -43,7 +43,7 @@ class SourceManifest
     /**
      * Constructor
      */
-    public function __construct(string $source = null, string $forks = null, bool $autoload = true)
+    public function __construct(?string $source = null, ?string $forks = null, bool $autoload = true)
     {
         $this->setSource($source ?? Config::get(
             'cms.sourceManifestUrl',

--- a/modules/system/console/PluginRollback.php
+++ b/modules/system/console/PluginRollback.php
@@ -76,7 +76,7 @@ class PluginRollback extends Command
     /**
      * Suggest values for the optional version argument
      */
-    public function suggestVersionValues(string $value = null, array $allInput): array
+    public function suggestVersionValues(?string $value, array $allInput): array
     {
         // Get the currently selected plugin
         $pluginName = $this->getPluginIdentifier($allInput['arguments']['plugin']);

--- a/modules/system/tests/fixtures/plugins/winter/tester/components/Categories.php
+++ b/modules/system/tests/fixtures/plugins/winter/tester/components/Categories.php
@@ -5,7 +5,7 @@ use Cms\Classes\CodeBase;
 
 class Categories extends ComponentBase
 {
-    public function __construct(CodeBase $cmsObject = null, $properties = [])
+    public function __construct(?CodeBase $cmsObject = null, $properties = [])
     {
         parent::__construct($cmsObject, $properties);
     }

--- a/modules/system/tests/fixtures/plugins/winter/tester/components/Comments.php
+++ b/modules/system/tests/fixtures/plugins/winter/tester/components/Comments.php
@@ -8,7 +8,7 @@ class Comments extends ComponentBase
 {
     private $users;
 
-    public function __construct(CodeBase $cmsObject = null, $properties = [], Users $users = null)
+    public function __construct(?CodeBase $cmsObject = null, $properties = [], ?Users $users = null)
     {
         parent::__construct($cmsObject, $properties);
         $this->users = $users;


### PR DESCRIPTION
## Summary

Audited the codebase for [PHP 8.4](https://www.php.net/manual/en/migration84.deprecated.php) and [PHP 8.5](https://www.php.net/manual/en/migration85.deprecated.php) deprecations by running `php84 -l` on every PHP file under `modules/` and `plugins/` (1,075 files) and grepping for documented deprecation patterns. All fixes use the `?Type` syntax available since PHP 7.1 and remain compatible with the project's `php >=8.1` floor.

### PHP 8.4 — implicit nullable parameters

PHP 8.4 deprecates parameters with a default of `null` that don't explicitly declare `?Type`. Fixed in:

| File | Method |
|---|---|
| `modules/backend/traits/PreferenceMaker.php:45` | `getUserPreference(?string $key = null, …)` |
| `modules/backend/behaviors/ListController.php:425,442,455` | `listRefresh`, `listGetWidget`, `listGetConfig` |
| `modules/backend/widgets/MediaManager.php:1195,1319` | `getThumbnailParams`, `deduplicatePath` |
| `modules/system/classes/FileManifest.php:57` | `__construct(?string $root = null, ?array $modules = null)` |
| `modules/system/classes/SourceManifest.php:46` | `__construct(?string $source = null, ?string $forks = null, …)` |
| `modules/system/classes/MarkupManager.php:55` | `makeBaseTwigEnvironment(?LoaderInterface $loader = null, …)` |
| `modules/system/tests/fixtures/plugins/winter/tester/components/Categories.php:8` | `__construct(?CodeBase $cmsObject = null, …)` |
| `modules/system/tests/fixtures/plugins/winter/tester/components/Comments.php:11` | `__construct(?CodeBase $cmsObject = null, …, ?Users $users = null)` |
| `modules/cms/classes/Controller.php:1589` | `setComponentContext(?ComponentBase $component = null)` |
| `modules/cms/classes/ComponentBase.php:85` | `__construct(?CodeBase $cmsObject = null, …)` |
| `modules/cms/classes/CmsException.php:45` | `__construct(…, ?Throwable $previous = null)` |
| `modules/cms/classes/Page.php` (see 8.5 section) | — |
| `modules/cms/models/ThemeExport.php:62` | `save(?array $options = null, …)` |
| `modules/cms/models/ThemeImport.php:67` | `save(?array $options = null, …)` |
| `modules/cms/controllers/ThemeOptions.php:105` | `getDirName(?string $dirName = null)` |
| `modules/cms/twig/Extension.php:131,139,199` | `assetsFunction`, `placeholderFunction`, `displayBlock` |

### PHP 8.4 — optional-before-required parameter

`modules/system/console/PluginRollback.php:79`: `suggestVersionValues(string $value = null, array $allInput)` had **two** deprecations stacked — implicit nullable type **and** optional parameter before a required one (deprecated since PHP 8.0). The PHP 8.4 migration guide's recommended fix is to drop the default and keep the nullable type. Laravel's Console always invokes `suggestValues` with both arguments, so the default was never needed:

```diff
-public function suggestVersionValues(string $value = null, array $allInput): array
+public function suggestVersionValues(?string $value, array $allInput): array
```

### PHP 8.5 — `null` array offset

`modules/cms/classes/Page.php:86` used `$result[null] = Lang::get('cms::lang.page.no_layout')`. PHP 8.5 deprecates `null` as an array offset; PHP already coerced it to `''` at runtime, so the behavior is identical:

```diff
-$result[null] = Lang::get('cms::lang.page.no_layout');
+$result[''] = Lang::get('cms::lang.page.no_layout');
```

### Docblock hygiene

Also updated `@method` annotations on the `Backend` and `Cms` facades to match the new nullable syntax for clarity (no runtime impact):

- `modules/backend/facades/Backend.php:7-12`
- `modules/cms/facades/Cms.php:6`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type declarations across backend, CMS, and system framework modules. Multiple method signatures now explicitly declare nullable parameter types where previously they defaulted to `null`, enabling enhanced IDE autocomplete, more accurate static type analysis, and clearer API contracts for developers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wintercms/winter/pull/1486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->