### PR TITLE
Support Laravel 13

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install PHP and PHP Code Sniffer
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           extensions: curl, fileinfo, gd, mbstring, openssl, pdo, pdo_sqlite, sqlite3, xml, zip
           tools: phpcs
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           extensions: curl, fileinfo, gd, mbstring, openssl, pdo, pdo_sqlite, sqlite3, xml, zip
 
       - name: Install Node
@@ -66,7 +66,7 @@ jobs:
       max-parallel: 8
       matrix:
         operatingSystem: [ubuntu-latest, windows-latest]
-        phpVersion: ['8.2', '8.3', '8.4', '8.5']
+        phpVersion: ['8.3', '8.4', '8.5']
       fail-fast: false
     runs-on: ${{ matrix.operatingSystem }}
     name: ${{ matrix.operatingSystem }} / PHP ${{ matrix.phpVersion }}

--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
         "source": "https://github.com/wintercms/winter"
     },
     "require": {
-        "php": "^8.2",
-        "winter/storm": "dev-wip/1.3 as 1.3",
-        "winter/wn-system-module": "dev-wip/1.3",
-        "winter/wn-backend-module": "dev-wip/1.3",
-        "winter/wn-cms-module": "dev-wip/1.3",
-        "laravel/framework": "^12.0",
+        "php": "^8.3",
+        "winter/storm": "dev-wip/1.3-laravel-13 as 1.3",
+        "winter/wn-system-module": "dev-wip/1.3-laravel-13",
+        "winter/wn-backend-module": "dev-wip/1.3-laravel-13",
+        "winter/wn-cms-module": "dev-wip/1.3-laravel-13",
+        "laravel/framework": "^13.0",
         "wikimedia/composer-merge-plugin": "~2.1.0"
     },
     "require-dev": {
@@ -48,7 +48,28 @@
      "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/pieterocp/phpunit-arraysubset-asserts"
+            "url": "https://github.com/austinderrick/storm",
+            "no-api": true
+        },
+        {
+            "type": "path",
+            "url": "modules/system",
+            "options": { "symlink": true, "versions": { "winter/wn-system-module": "dev-wip/1.3-laravel-13" } }
+        },
+        {
+            "type": "path",
+            "url": "modules/backend",
+            "options": { "symlink": true, "versions": { "winter/wn-backend-module": "dev-wip/1.3-laravel-13" } }
+        },
+        {
+            "type": "path",
+            "url": "modules/cms",
+            "options": { "symlink": true, "versions": { "winter/wn-cms-module": "dev-wip/1.3-laravel-13" } }
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/pieterocp/phpunit-arraysubset-asserts",
+            "no-api": true
         }
     ],
     "scripts": {

--- a/modules/backend/composer.json
+++ b/modules/backend/composer.json
@@ -23,9 +23,9 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "composer/installers": "~1.11.0",
-        "laravel/framework": "^12.0"
+        "laravel/framework": "^13.0"
     },
     "replace": {
         "october/backend": "1.1.*"

--- a/modules/cms/composer.json
+++ b/modules/cms/composer.json
@@ -23,9 +23,9 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "composer/installers": "~1.11.0",
-        "laravel/framework": "^12.0"
+        "laravel/framework": "^13.0"
     },
     "replace": {
         "october/cms": "1.1.*"

--- a/modules/system/classes/VersionManager.php
+++ b/modules/system/classes/VersionManager.php
@@ -8,6 +8,7 @@ use Illuminate\Console\View\Components\Error;
 use Illuminate\Console\View\Components\Info;
 use Illuminate\Console\View\Components\Task;
 use Winter\Storm\Database\Updater;
+use Winter\Storm\Support\Arr;
 
 /**
  * Version manager
@@ -715,9 +716,9 @@ class VersionManager
     {
         $code = $this->pluginManager->getIdentifier($plugin);
         $histories = $this->getDatabaseHistory($code);
-        $lastHistory = array_last(array_where($histories, function ($history) {
+        $lastHistory = Arr::last($histories, function ($history) {
             return $history->type === self::HISTORY_TYPE_COMMENT;
-        }));
+        });
         return $lastHistory ? $lastHistory->detail : '';
     }
 }

--- a/modules/system/composer.json
+++ b/modules/system/composer.json
@@ -23,9 +23,9 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "composer/installers": "~1.11.0",
-        "laravel/framework": "^12.0",
+        "laravel/framework": "^13.0",
         "composer/semver": "^3.2"
     },
     "replace": {


### PR DESCRIPTION
**Depends on wintercms/storm#228** (Storm Laravel 13 support). Until that lands on `wintercms/storm`, this PR resolves Storm from the `austinderrick/storm` `wip/1.3-laravel-13` branch via a temporary VCS repository in `composer.json`.

Builds on #1366 (Laravel 12 support). Adds **Laravel 13** support on top of the Laravel 12 work.

## Summary

Targets Laravel 13 (released 2026-03-17, PHP 8.3+ minimum). No module **code** changes were required — the system, backend and cms PHPUnit suites all pass on Laravel 13 unchanged. The change is dependency + CI only.

### Dependency changes
- Root `composer.json`: `php` `^8.2` → `^8.3`; `laravel/framework` `^12.0` → `^13.0`
- `modules/{system,backend,cms}/composer.json`: same `php` / `laravel/framework` bumps
- `winter/storm` and the three modules now target `dev-wip/1.3-laravel-13`
- Added path repositories for the in-repo `modules/{system,backend,cms}` so composer resolves the Laravel 13 module manifests directly from the checkout (the published split packages still pin Laravel 12). The CI "Reset modules" step keeps the committed modules; composer reports "Source already present" rather than overwriting them.
- Added a VCS repository for the Storm Laravel 13 branch until it is published.

### CI
- `tests.yml` PHP matrix: dropped 8.2 → `['8.3', '8.4']`; frontend job PHP `8.2` → `8.3`
- `code-quality.yaml`: PHP `8.2` → `8.3`
- `manifest.yml` already runs on PHP 8.4 (unchanged)

## Breaking changes

These are the breaking changes surfaced while upgrading WinterCMS (and a real downstream app) to Laravel 13. Plugin and theme authors should review these.

### PHP 8.3 minimum
Laravel 13 requires **PHP 8.3+** (the 1.3 / Laravel 12 line allowed 8.2). CI matrices drop 8.2.

### Models may not be instantiated while booting (`LogicException`)
Laravel 13 throws `LogicException: The [Model::bootIfNotBooted] method may not be called on model [X] while it is being booted` when a model is instantiated **during its own boot** — i.e. `new static`, `new self`, `(new self())`, `self::instance()`, or anything that constructs the model (including `static::insert()` / `static::query()`) inside that model's `boot()` or a trait's `boot<TraitName>()` method.
- Storm's own `ArraySource` trait was affected — fixed in wintercms/storm#228 (datasource setup deferred to first connection resolution).
- **Plugin/model authors:** move boot-time instantiation out of the boot cycle. Register it via `static::extend(fn ($model) => ...)` (runs per instance after construction) or a deferred `booted` event. (In a real downstream app this hit several model traits that did `(new self())->hasRelation(...)` / `self::instance()` validation in `boot<Trait>()`.)

### Laravel Debugbar 4 required (Winter.Debugbar)
Laravel 13 requires `barryvdh/laravel-debugbar ^4`, a significant break for anything integrating with it — fixed for the plugin in wintercms/wn-debugbar-plugin#27:
- **Namespace rebrand:** `Barryvdh\Debugbar\*` → `Fruitcake\LaravelDebugbar\*` (the Composer package name stays `barryvdh/laravel-debugbar`). Any code using `Barryvdh\Debugbar\Facades\Debugbar`, `Barryvdh\Debugbar\LaravelDebugbar`, `Barryvdh\Debugbar\DataCollector\*`, etc. must switch to `Fruitcake\LaravelDebugbar\...`.
- `Barryvdh\Debugbar\SymfonyHttpDriver` removed (v4 configures its own `LaravelHttpDriver`).
- `LaravelDebugbar::__construct()` now requires `(Application $app, Request $request)` — resolve via the container, not `new LaravelDebugbar($app)`.
- php-debugbar's `DataCollectorInterface` is now typed: `collect(): array`, `getName(): string`, `getWidgets(): array`. Custom collectors must add these return types.
- The `formatDuration()` convenience method was removed from php-debugbar's `DataCollector` base; use `$this->getDataFormatter()->formatDuration()`.
- php-debugbar no longer bundles a Twig profile collector (`DebugBar\Bridge\TwigProfileCollector` / `NamespacedTwigProfileCollector`); guard with `class_exists()`.

### Storm container `log` alias
Storm aliased the `'log'` service to `Illuminate\Log\Logger`, but `'log'` is a `LogManager`. Laravel 13 (and Laravel Debugbar 4's log collector, which type-hints `Illuminate\Log\Logger`) expose this — resolving `Illuminate\Log\Logger` returned a `LogManager`, throwing a `TypeError`. Fixed in wintercms/storm#228 to alias `'log'` to `Illuminate\Log\LogManager` (matching Laravel core), so `Illuminate\Log\Logger` autowires to a real `Logger`.

### General Laravel 13 changes
Also review the upstream [Laravel 12 → 13 upgrade guide](https://laravel.com/docs/13.x/upgrade): CSRF middleware renamed `VerifyCsrfToken` → `PreventRequestForgery` (deprecated aliases kept); `symfony/polyfill-php85` now defines global `array_first()` / `array_last()` (single-arg — prefer `Winter\Storm\Support\Arr::first()` / `Arr::last()`); cache `serializable_classes` now defaults to `false`; Bootstrap pagination view names renamed; `down --with-secret` handling.

## Testing
- `php artisan winter:test -m system`: 280 tests, 0 failures
- `php artisan winter:test -m backend`: 72 tests, 0 failures
- `php artisan winter:test -m cms`: 113 tests, 0 failures
- (run with the project's `vendor/bin/phpunit`, i.e. PHPUnit 11.5.x)

## Notes for reviewers
- The `library-switcher` CI steps only fire for `develop`/`1.x` base branches; this PR targets `wip/1.3`, so the Storm requirement in `composer.json` is used as-is (no switch).
- PHPUnit is kept on 11.5.x (Laravel 13 + testbench 11 accept it); moving to PHPUnit 12 is deferred until the `dms/phpunit-arraysubset-asserts` / `meyfa/phpunit-assert-gd` helpers support it.

## Related WinterCMS Laravel 13 PRs
- wintercms/storm#228 — Storm Laravel 13 support
- wintercms/winter#1487 — WinterCMS Laravel 13 support (this PR)
- wintercms/wn-debugbar-plugin#27 — Laravel Debugbar 4 support (needed for Laravel 13)
