### PR TITLE
Add PHP 8.5 to the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
       max-parallel: 8
       matrix:
         operatingSystem: [ubuntu-latest, windows-latest]
-        phpVersion: ['8.1', '8.2', '8.3', '8.4']
+        phpVersion: ['8.1', '8.2', '8.3', '8.4', '8.5']
       fail-fast: false
     runs-on: ${{ matrix.operatingSystem }}
     name: ${{ matrix.operatingSystem }} / PHP ${{ matrix.phpVersion }}


### PR DESCRIPTION
Adds PHP 8.5 to the PHPUnit test matrix on both Ubuntu and Windows.

Verified locally on PHP 8.5.5 against current `develop` (with `winter/storm` `dev-develop`):

```
Running tests for module: system
OK, but incomplete, skipped, or risky tests!
Tests: 286, Assertions: 1599, Skipped: 29.
Running tests for module: backend
OK (144 tests, 332 assertions)
Running tests for module: cms
OK (206 tests, 662 assertions)
```

`composer lint` (parallel-lint) is also clean on 8.5: `Checked 1100 files in 5.1 seconds - No syntax error found`.

Companion PR for the library: wintercms/storm#232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added PHP 8.5 to the continuous integration testing matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->