### PR TITLE
Double-encode dots as %252E for NGINX compatibility

### DIFF
--- a/modules/system/classes/ImageResizer.php
+++ b/modules/system/classes/ImageResizer.php
@@ -583,6 +583,9 @@ class ImageResizer
         // Slashes in URL params have to be double encoded to survive Laravel's router
         // @see https://github.com/octobercms/october/issues/3592#issuecomment-671017380
         $resizedUrl = rawurlencode(rawurlencode($this->getResizedUrl()));
+        // Double-encode dots (rawurlencode() skips them) to avoid issues in certain NGINX
+        // configurations where dots may trigger asset-serving rules, resulting in 404 errors
+        $resizedUrl = str_replace('.', '%252E', $resizedUrl);
 
         // Get the current configuration's identifier
         $identifier = $this->getIdentifier();

--- a/modules/system/classes/SystemController.php
+++ b/modules/system/classes/SystemController.php
@@ -80,6 +80,9 @@ class SystemController extends ControllerBase
             throw $ex;
         }
 
-        return redirect()->to($resizedUrl);
+        // Redirect permanently as a resizer URL can only ever target the resized URL
+        // embedded and signed within it, and crawlers should index the resized URL
+        // rather than the temporary resizer URL
+        return redirect()->to($resizedUrl, 301);
     }
 }

--- a/modules/system/tests/classes/ImageResizerTest.php
+++ b/modules/system/tests/classes/ImageResizerTest.php
@@ -8,6 +8,7 @@ use Cms\Classes\Theme;
 use Config;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Event;
+use Storage;
 use System\Classes\ImageResizer;
 use System\Classes\MediaLibrary;
 use System\Models\File as FileModel;
@@ -405,6 +406,34 @@ class ImageResizerTest extends PluginTestCase
             $imageResizer->getResizedUrl(),
             ImageResizer::getValidResizedUrl($identifier, rawurldecode($encodedUrl))
         );
+    }
+
+    public function testResizerRedirect()
+    {
+        if (!in_array('Cms', Config::get('cms.loadModules', []))) {
+            $this->markTestSkipped('The CMS module is not active.');
+        }
+
+        $this->setUpStorage();
+        $this->copyMedia();
+        Config::set('cms.storage.resized', [
+            'disk'   => 'test_local',
+            'folder' => 'resized',
+            'path'   => '/storage/temp/app/resized',
+        ]);
+
+        $imageResizer = new ImageResizer((new CmsController())->themeUrl('assets/images/winter.png'), 50, 50);
+
+        // The resizer route responds with a permanent redirect as a resizer URL can
+        // only ever target the resized URL embedded and signed within it, and this
+        // also exercises the full round-trip of the double-encoded URL parameter
+        // through the actual router
+        $response = $this->get($imageResizer->getResizerUrl());
+        $response->assertStatus(301);
+        $response->assertRedirect($imageResizer->getResizedUrl());
+
+        // Clean up the generated image
+        Storage::disk('test_local')->deleteDirectory('resized');
     }
 
     protected function setUpStorage()

--- a/modules/system/tests/classes/ImageResizerTest.php
+++ b/modules/system/tests/classes/ImageResizerTest.php
@@ -373,6 +373,10 @@ class ImageResizerTest extends PluginTestCase
         Config::set('cms.linkPolicy', 'detect');
         $url = $imageResizer->getResizedUrl();
         $this->assertTrue(starts_with($url, Config::get('cms.storage.resized.path', '/storage/tests/app/resized')));
+
+        // test dots' double-decoding
+        // @see https://github.com/wintercms/winter/pull/1493
+        $this->assertTrue(ends_with($url, '.png'));
     }
 
     public function testGetResizerUrl()
@@ -390,6 +394,10 @@ class ImageResizerTest extends PluginTestCase
         Config::set('cms.linkPolicy', 'detect');
         $url = $imageResizer->getResizerUrl();
         $this->assertTrue(starts_with($url, '/resizer/'));
+
+        // test dots' double-encoding
+        // @see https://github.com/wintercms/winter/pull/1493
+        $this->assertTrue(ends_with($url, '%252Epng'));
     }
 
     protected function setUpStorage()

--- a/modules/system/tests/classes/ImageResizerTest.php
+++ b/modules/system/tests/classes/ImageResizerTest.php
@@ -373,10 +373,6 @@ class ImageResizerTest extends PluginTestCase
         Config::set('cms.linkPolicy', 'detect');
         $url = $imageResizer->getResizedUrl();
         $this->assertTrue(starts_with($url, Config::get('cms.storage.resized.path', '/storage/tests/app/resized')));
-
-        // test dots' double-decoding
-        // @see https://github.com/wintercms/winter/pull/1493
-        $this->assertTrue(ends_with($url, '.png'));
     }
 
     public function testGetResizerUrl()
@@ -398,6 +394,17 @@ class ImageResizerTest extends PluginTestCase
         // test dots' double-encoding
         // @see https://github.com/wintercms/winter/pull/1493
         $this->assertTrue(ends_with($url, '%252Epng'));
+
+        // Verify the encoded URL round-trips through the resizer route's decoding and
+        // signature verification. A fresh instance is required as the identifier is
+        // cached on first generation and the link policy has changed since then. The
+        // router decodes the parameter once before it reaches getValidResizedUrl().
+        $imageResizer = new ImageResizer((new CmsController())->themeUrl('assets/images/winter.png'));
+        [$identifier, $encodedUrl] = array_slice(explode('/', $imageResizer->getResizerUrl()), 2);
+        $this->assertSame(
+            $imageResizer->getResizedUrl(),
+            ImageResizer::getValidResizedUrl($identifier, rawurldecode($encodedUrl))
+        );
     }
 
     protected function setUpStorage()


### PR DESCRIPTION
In certain NGINX configurations, unencoded dots in URLs may trigger asset-serving rules, resulting in 404 errors. rawurlencode() skips dots, but RFC 3986 allows dot encoding, so we manually double-encode them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated resizer URLs to handle dot (`.`) characters safely, preventing resized images from returning 404s in certain server setups.
  * Adjusted the resizer redirect behavior to use a permanent (301) redirect for the final resized asset URL.
* **Tests**
  * Updated resizer URL tests to confirm the doubly-encoded file suffix and validate correct round-trip URL handling.
  * Added end-to-end coverage to verify the resizer route redirects to the expected resized output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->