### PR TITLE
Fix: prevent keyup propagation from Monaco editor triggering false dirty state (#1495)

### DIFF
--- a/modules/backend/formwidgets/codeeditor/assets/js/codeeditor.js
+++ b/modules/backend/formwidgets/codeeditor/assets/js/codeeditor.js
@@ -455,6 +455,10 @@ registerHTMLLanguageService('twig', undefined, {
          *  - A visibility change listener
          */
         attachListeners() {
+            // Prevent jQuery from capturing keyup events via event bubbling
+            const editorNode = this.editor.getDomNode();
+            editorNode.addEventListener('keyup', (e) => e.stopPropagation(), true);
+
             this.model = this.editor.getModel();
 
             this.disposables.push(this.model.onDidChangeContent(() => {


### PR DESCRIPTION
Fixes #1495

## Summary
On macOS, pressing the Command key alone while focused on the backend Code Editor (Monaco Editor) incorrectly marks the form as "dirty" (unsaved changes), even though no content was edited.

## Root cause
`keyup` events fired inside the Monaco Editor's DOM node bubble up and are captured by jQuery, which triggers the backend form's dirty-state handler.

## Fix
Stop the propagation of `keyup` events at the editor's DOM node level. This prevents unrelated key events (such as pressing Command alone) from reaching the form's dirty-state handler, while actual content edits still flow through Monaco's `onDidChangeContent` event as before:
Monaco model change → CodeEditor input event → Winter CMS dirty state

## Testing
- Confirmed pressing Command alone no longer marks the field as dirty (macOS, Safari & Chrome)
- Confirmed actual content edits still correctly mark the field as dirty

## Note on compiled assets
I attempted to run `mix:compile` locally to update the compiled bundle, but this produced a large number of unrelated changes (chunk naming, minified worker files) likely due to differences between my local Node/webpack environment and the one used to produce the current build. To keep this PR focused and reviewable, I've only included the source change in `codeeditor.js`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard interaction in the code editor so `keyup` events are no longer intercepted by surrounding page behavior while editing.
  * This helps the editor respond more reliably when typing and using shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->