### PR TITLE
Move backend user authorization guards to the actual write events

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1569,10 +1569,9 @@ class RelationController extends ControllerBehavior
             $hydratedModels = $this->relationObject->whereIn($foreignKeyName, $foreignIds)->get();
 
             foreach ($hydratedModels as $hydratedModel) {
-                $modelsToSave = $this->prepareModelsToSave($hydratedModel, $saveData);
-                foreach ($modelsToSave as $modelToSave) {
-                    $modelToSave->save(null, $this->pivotWidget->getSessionKey());
-                }
+                $this->relationSavePivotModels(
+                    $this->prepareModelsToSave($hydratedModel, $saveData)
+                );
             }
         });
 
@@ -1583,14 +1582,17 @@ class RelationController extends ControllerBehavior
     {
         $this->beforeAjax();
 
-        $foreignKeyName = $this->relationModel->getQualifiedKeyName();
         $hydratedModel = $this->pivotWidget->model;
         $saveData = $this->pivotWidget->getSaveData();
 
-        $modelsToSave = $this->prepareModelsToSave($hydratedModel, $saveData);
-        foreach ($modelsToSave as $modelToSave) {
-            $modelToSave->save(null, $this->pivotWidget->getSessionKey());
-        }
+        /*
+         * If any of the models fail to save, abort the whole update
+         */
+        Db::transaction(function () use ($hydratedModel, $saveData) {
+            $this->relationSavePivotModels(
+                $this->prepareModelsToSave($hydratedModel, $saveData)
+            );
+        });
 
         return ['#'.$this->relationGetId('view') => $this->relationRenderView()];
     }
@@ -1676,6 +1678,29 @@ class RelationController extends ControllerBehavior
     //
     // Helpers
     //
+
+    /**
+     * Saves the models prepared from a pivot form submission.
+     *
+     * Models that already exist and have no changed attributes are skipped. `prepareModelsToSave()`
+     * always queues the related model, so a submission containing nothing but pivot data would
+     * otherwise trigger that model's save events - including authorization guards such as
+     * `Backend\Models\User::beforeSave()`. Their deferred bindings are still committed so that
+     * relation widgets on the pivot form continue to work.
+     */
+    protected function relationSavePivotModels(array $modelsToSave): void
+    {
+        $sessionKey = $this->pivotWidget->getSessionKey();
+
+        foreach ($modelsToSave as $modelToSave) {
+            if ($modelToSave->exists && !$modelToSave->isDirty()) {
+                $modelToSave->commitDeferred($sessionKey);
+                continue;
+            }
+
+            $modelToSave->save(null, $sessionKey);
+        }
+    }
 
     /**
      * Returns the existing record IDs for the relation.

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1569,9 +1569,10 @@ class RelationController extends ControllerBehavior
             $hydratedModels = $this->relationObject->whereIn($foreignKeyName, $foreignIds)->get();
 
             foreach ($hydratedModels as $hydratedModel) {
-                $this->relationSavePivotModels(
-                    $this->prepareModelsToSave($hydratedModel, $saveData)
-                );
+                $modelsToSave = $this->prepareModelsToSave($hydratedModel, $saveData);
+                foreach ($modelsToSave as $modelToSave) {
+                    $modelToSave->save(null, $this->pivotWidget->getSessionKey());
+                }
             }
         });
 
@@ -1589,9 +1590,10 @@ class RelationController extends ControllerBehavior
          * If any of the models fail to save, abort the whole update
          */
         Db::transaction(function () use ($hydratedModel, $saveData) {
-            $this->relationSavePivotModels(
-                $this->prepareModelsToSave($hydratedModel, $saveData)
-            );
+            $modelsToSave = $this->prepareModelsToSave($hydratedModel, $saveData);
+            foreach ($modelsToSave as $modelToSave) {
+                $modelToSave->save(null, $this->pivotWidget->getSessionKey());
+            }
         });
 
         return ['#'.$this->relationGetId('view') => $this->relationRenderView()];
@@ -1678,50 +1680,6 @@ class RelationController extends ControllerBehavior
     //
     // Helpers
     //
-
-    /**
-     * Saves the models prepared from a pivot form submission.
-     *
-     * Models that already exist and have nothing pending are skipped. `prepareModelsToSave()`
-     * always queues the related model, so a submission containing nothing but pivot data would
-     * otherwise trigger that model's save events - including authorization guards such as
-     * `Backend\Models\User::beforeSave()`.
-     *
-     * A model with deferred bindings is never skipped, even when its own attributes are clean:
-     * committing those bindings is a change to the model's relations, so it must go through the
-     * normal save pipeline and be authorized like any other.
-     */
-    protected function relationSavePivotModels(array $modelsToSave): void
-    {
-        $sessionKey = $this->pivotWidget->getSessionKey();
-
-        foreach ($modelsToSave as $modelToSave) {
-            if (
-                $modelToSave->exists
-                && !$modelToSave->isDirty()
-                && !$this->relationHasDeferredBindings($modelToSave, $sessionKey)
-            ) {
-                continue;
-            }
-
-            $modelToSave->save(null, $sessionKey);
-        }
-    }
-
-    /**
-     * Returns whether the model has any deferred bindings pending for the given session key.
-     */
-    protected function relationHasDeferredBindings($model, string $sessionKey): bool
-    {
-        $binding = new DeferredBinding;
-
-        $binding->setConnection($model->getConnectionName());
-
-        return $binding
-            ->where('master_type', get_class($model))
-            ->where('session_key', $sessionKey)
-            ->exists();
-    }
 
     /**
      * Returns the existing record IDs for the relation.

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -1682,24 +1682,45 @@ class RelationController extends ControllerBehavior
     /**
      * Saves the models prepared from a pivot form submission.
      *
-     * Models that already exist and have no changed attributes are skipped. `prepareModelsToSave()`
+     * Models that already exist and have nothing pending are skipped. `prepareModelsToSave()`
      * always queues the related model, so a submission containing nothing but pivot data would
      * otherwise trigger that model's save events - including authorization guards such as
-     * `Backend\Models\User::beforeSave()`. Their deferred bindings are still committed so that
-     * relation widgets on the pivot form continue to work.
+     * `Backend\Models\User::beforeSave()`.
+     *
+     * A model with deferred bindings is never skipped, even when its own attributes are clean:
+     * committing those bindings is a change to the model's relations, so it must go through the
+     * normal save pipeline and be authorized like any other.
      */
     protected function relationSavePivotModels(array $modelsToSave): void
     {
         $sessionKey = $this->pivotWidget->getSessionKey();
 
         foreach ($modelsToSave as $modelToSave) {
-            if ($modelToSave->exists && !$modelToSave->isDirty()) {
-                $modelToSave->commitDeferred($sessionKey);
+            if (
+                $modelToSave->exists
+                && !$modelToSave->isDirty()
+                && !$this->relationHasDeferredBindings($modelToSave, $sessionKey)
+            ) {
                 continue;
             }
 
             $modelToSave->save(null, $sessionKey);
         }
+    }
+
+    /**
+     * Returns whether the model has any deferred bindings pending for the given session key.
+     */
+    protected function relationHasDeferredBindings($model, string $sessionKey): bool
+    {
+        $binding = new DeferredBinding;
+
+        $binding->setConnection($model->getConnectionName());
+
+        return $binding
+            ->where('master_type', get_class($model))
+            ->where('session_key', $sessionKey)
+            ->exists();
     }
 
     /**

--- a/modules/backend/models/User.php
+++ b/modules/backend/models/User.php
@@ -78,6 +78,23 @@ class User extends UserBase
      */
     public static $loginAttribute = 'login';
 
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        // Guard relation writes at the point they actually happen: direct
+        // attach()/detach(), deferred binding commits and queued relation
+        // syncs all funnel through these relation events.
+        $guard = function (string $relationName) {
+            $this->authorizeRelationChange($relationName);
+        };
+
+        $this->bindEvent('model.relation.beforeAttach', $guard);
+        $this->bindEvent('model.relation.beforeDetach', $guard);
+        $this->bindEvent('model.relation.beforeAdd', $guard);
+        $this->bindEvent('model.relation.beforeRemove', $guard);
+    }
+
     /**
      * @return string Returns the user's full name.
      */
@@ -156,9 +173,33 @@ class User extends UserBase
     }
 
     /**
-     * Before save event — enforce authorization rules to prevent privilege escalation.
+     * Before create event — enforce authorization rules to prevent privilege escalation.
      */
-    public function beforeSave()
+    public function beforeCreate()
+    {
+        $this->authorizeChange();
+    }
+
+    /**
+     * Before update event — enforce authorization rules to prevent privilege escalation.
+     *
+     * Bound to update rather than save so that a save with nothing to write (e.g. a
+     * pivot form submission re-saving an untouched related record) requires no
+     * permission: the update event only fires when attributes have actually changed,
+     * after purgeable attributes have been stripped. Relation writes (group
+     * membership, avatar) are guarded separately by authorizeRelationChange().
+     */
+    public function beforeUpdate()
+    {
+        $this->authorizeChange();
+    }
+
+    /**
+     * Enforce authorization rules for a change to this record's attributes.
+     *
+     * @throws AuthorizationException if the current user lacks permission
+     */
+    protected function authorizeChange(): void
     {
         $actor = BackendAuth::getUser();
         if (!$actor) {
@@ -170,6 +211,31 @@ class User extends UserBase
         if ($isCurrentUser && $this->isDirty(['role_id', 'is_superuser', 'permissions'])) {
             throw new AuthorizationException(Lang::get('backend::lang.user.self_escalation_denied'));
         }
+
+        if (!$isCurrentUser && !$this->canBeManagedByUser($actor)) {
+            throw new AuthorizationException(Lang::get('backend::lang.user.cannot_manage_user'));
+        }
+    }
+
+    /**
+     * Enforce authorization rules for a change to one of this record's relations
+     * (group membership, avatar, etc.).
+     *
+     * Changes to your own record's relations are allowed: groups do not carry
+     * permissions out of the box, so they are not an escalation vector. Plugins
+     * that hang authorization semantics on a relation can bind a stricter guard
+     * to the same `model.relation.*` events.
+     *
+     * @throws AuthorizationException if the current user lacks permission
+     */
+    protected function authorizeRelationChange(string $relationName): void
+    {
+        $actor = BackendAuth::getUser();
+        if (!$actor) {
+            return;
+        }
+
+        $isCurrentUser = $this->exists && $actor->getKey() === $this->getKey();
 
         if (!$isCurrentUser && !$this->canBeManagedByUser($actor)) {
             throw new AuthorizationException(Lang::get('backend::lang.user.cannot_manage_user'));

--- a/modules/backend/models/User.php
+++ b/modules/backend/models/User.php
@@ -78,6 +78,15 @@ class User extends UserBase
      */
     public static $loginAttribute = 'login';
 
+    /**
+     * @var array<string> Relations on this model that require `backend.manage_users`
+     * to change on another user's record. Deliberately limited to the relations this
+     * model owns: authorization semantics for plugin-added relations belong to the
+     * plugin, which can append to this list or bind its own guard to the
+     * `model.relation.*` events.
+     */
+    public array $permissionGuardedRelations = ['groups', 'avatar', 'throttle'];
+
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);
@@ -218,18 +227,22 @@ class User extends UserBase
     }
 
     /**
-     * Enforce authorization rules for a change to one of this record's relations
-     * (group membership, avatar, etc.).
+     * Enforce authorization rules for a change to one of this record's relations.
      *
-     * Changes to your own record's relations are allowed: groups do not carry
-     * permissions out of the box, so they are not an escalation vector. Plugins
-     * that hang authorization semantics on a relation can bind a stricter guard
-     * to the same `model.relation.*` events.
+     * Only the relations listed in $permissionGuardedRelations are guarded, so
+     * plugin-added relations (e.g. records that reference a user) behave normally.
+     *
+     * Changes to your own record's guarded relations are allowed: groups do not
+     * carry permissions out of the box, so they are not an escalation vector.
      *
      * @throws AuthorizationException if the current user lacks permission
      */
     protected function authorizeRelationChange(string $relationName): void
     {
+        if (!in_array($relationName, $this->permissionGuardedRelations)) {
+            return;
+        }
+
         $actor = BackendAuth::getUser();
         if (!$actor) {
             return;

--- a/modules/backend/tests/behaviors/RelationControllerPivotTest.php
+++ b/modules/backend/tests/behaviors/RelationControllerPivotTest.php
@@ -84,7 +84,7 @@ class RelationControllerPivotTest extends PluginTestCase
     {
         return $this->fixture->users()
             ->where('backend_users.id', $this->targetUser->id)
-            ->first();
+            ->firstOrFail();
     }
 
     /**
@@ -202,7 +202,7 @@ class RelationControllerPivotTest extends PluginTestCase
      * Skipping the save must not drop pending relation work. A deferred binding leaves the
      * owning model clean, so it would be lost if the model were simply passed over.
      */
-    public function testDeferredBindingsAreCommittedForSkippedModels(): void
+    public function testDeferredBindingsAreCommittedForOtherwiseCleanModels(): void
     {
         $this->actingAs((new UserFixture)->withPermission('backend.manage_users', true));
 
@@ -222,5 +222,29 @@ class RelationControllerPivotTest extends PluginTestCase
 
         $this->assertEquals(1, $hydrated->groups()->count(), 'The deferred binding was committed');
         $this->assertEquals(1, $this->getPivotValue());
+    }
+
+    /**
+     * Skipping the save must not become an authorization bypass. A deferred binding leaves the
+     * owning model clean, so a naive skip would commit relation changes - such as adding a user
+     * to a group, which carries permissions - without ever consulting `User::beforeSave()`.
+     */
+    public function testDeferredBindingsAreStillAuthorizedForOtherwiseCleanModels(): void
+    {
+        $this->actingAs((new UserFixture)->withPermission('backend.manage_users', false));
+
+        $hydrated = $this->getHydratedRelatedUser();
+
+        $group = UserGroup::create([
+            'name' => 'Test Group',
+            'code' => 'test-group',
+        ]);
+        $hydrated->groups()->add($group, 'pivottestsessionkey');
+
+        $this->assertFalse($hydrated->isDirty(), 'The deferred binding leaves the user clean');
+
+        $this->expectException(AuthorizationException::class);
+
+        $this->savePivotForm($hydrated, ['pivot' => ['is_default' => true]]);
     }
 }

--- a/modules/backend/tests/behaviors/RelationControllerPivotTest.php
+++ b/modules/backend/tests/behaviors/RelationControllerPivotTest.php
@@ -16,12 +16,20 @@ use Winter\Storm\Database\Model;
  * Regression coverage for wintercms/winter#1464.
  *
  * `prepareModelsToSave()` always queues the related model, so a pivot form submission that
- * contains nothing but pivot data used to save the related model too. For a belongsToMany
- * relation to `Backend\Models\User` that no-op save tripped `User::beforeSave()`, locking
- * operators without `backend.manage_users` out of editing pivot data entirely.
+ * contains nothing but pivot data saves the related model too. For a belongsToMany relation
+ * to `Backend\Models\User` that no-op save used to trip the authorization guard in
+ * `User::beforeSave()`, locking operators without `backend.manage_users` out of editing
+ * pivot data entirely.
+ *
+ * The fix moves the guard onto the events that correspond to actual writes — create/update
+ * for attributes, the `model.relation.*` events for relation changes — so the pivot handlers
+ * can save every prepared model unconditionally: a save with nothing to write is authorized
+ * for anyone, while any real change is still guarded at the point it happens.
  */
 class RelationControllerPivotTest extends PluginTestCase
 {
+    protected const SESSION_KEY = 'pivottestsessionkey';
+
     protected User $targetUser;
     protected PivotRelationFixture $fixture;
     protected RelationController $behavior;
@@ -48,7 +56,7 @@ class RelationControllerPivotTest extends PluginTestCase
         $this->fixture = PivotRelationFixture::create(['name' => 'Test Fixture']);
         $this->fixture->users()->add($this->targetUser, null, ['is_default' => false]);
 
-        $this->behavior = $this->makeBehavior();
+        $this->behavior = (new \ReflectionClass(RelationController::class))->newInstanceWithoutConstructor();
     }
 
     public function tearDown(): void
@@ -56,24 +64,6 @@ class RelationControllerPivotTest extends PluginTestCase
         PivotRelationFixture::migrateDown();
 
         parent::tearDown();
-    }
-
-    /**
-     * Builds the behavior without its controller, then supplies the only collaborator
-     * `relationSavePivotModels()` uses: the pivot widget's session key.
-     */
-    protected function makeBehavior(): RelationController
-    {
-        $behavior = (new \ReflectionClass(RelationController::class))->newInstanceWithoutConstructor();
-
-        static::setProtectedProperty($behavior, 'pivotWidget', new class {
-            public function getSessionKey(): string
-            {
-                return 'pivottestsessionkey';
-            }
-        });
-
-        return $behavior;
     }
 
     /**
@@ -88,7 +78,8 @@ class RelationControllerPivotTest extends PluginTestCase
     }
 
     /**
-     * Runs the production sequence used by both pivot handlers.
+     * Runs the production sequence used by both pivot handlers: prepare the models
+     * from the submitted data, then save each one under the pivot session key.
      */
     protected function savePivotForm(User $hydratedModel, array $saveData): void
     {
@@ -98,7 +89,9 @@ class RelationControllerPivotTest extends PluginTestCase
             [$hydratedModel, $saveData]
         );
 
-        static::callProtectedMethod($this->behavior, 'relationSavePivotModels', [$modelsToSave]);
+        foreach ($modelsToSave as $modelToSave) {
+            $modelToSave->save(null, static::SESSION_KEY);
+        }
     }
 
     protected function getPivotValue()
@@ -110,8 +103,8 @@ class RelationControllerPivotTest extends PluginTestCase
 
     /**
      * The related model is queued for saving even when the form only submitted pivot data.
-     * This is the underlying cause and is expected — the fix is in what gets saved, not
-     * in what gets queued.
+     * This is expected — a save with nothing to write is harmless now that authorization
+     * happens on the actual write events.
      */
     public function testPrepareModelsToSaveQueuesTheRelatedModelForPivotOnlyData(): void
     {
@@ -167,7 +160,7 @@ class RelationControllerPivotTest extends PluginTestCase
 
     /**
      * A pivot form may also edit fields on the related model. Those changes must still be
-     * written — the fix only skips models that nothing changed.
+     * written.
      */
     public function testRelatedModelIsStillSavedWhenItsOwnFieldsAreEdited(): void
     {
@@ -183,8 +176,7 @@ class RelationControllerPivotTest extends PluginTestCase
     }
 
     /**
-     * The fix must not become an authorization bypass: editing the related model's own
-     * fields without the permission is still refused.
+     * Editing the related model's own fields without the permission is still refused.
      */
     public function testRelatedModelSaveIsStillAuthorizedWhenItsOwnFieldsAreEdited(): void
     {
@@ -199,8 +191,52 @@ class RelationControllerPivotTest extends PluginTestCase
     }
 
     /**
-     * Skipping the save must not drop pending relation work. A deferred binding leaves the
-     * owning model clean, so it would be lost if the model were simply passed over.
+     * A relation field on the related model (saved via `setSimpleValue()`, e.g. a
+     * checkboxlist bound to `groups`) leaves the model's attributes clean and is applied
+     * as a queued sync during the save. The unconditional save must carry it through.
+     */
+    public function testRelatedModelRelationFieldIsStillApplied(): void
+    {
+        $this->actingAs((new UserFixture)->withPermission('backend.manage_users', true));
+
+        $group = UserGroup::create([
+            'name' => 'Test Group',
+            'code' => 'test-group',
+        ]);
+
+        $this->savePivotForm($this->getHydratedRelatedUser(), [
+            'groups' => [$group->id],
+            'pivot' => ['is_default' => true],
+        ]);
+
+        $this->assertEquals(1, $this->targetUser->groups()->count(), 'The queued relation sync was applied');
+        $this->assertEquals(1, $this->getPivotValue());
+    }
+
+    /**
+     * The same queued relation sync is refused without the permission: the guard fires on
+     * the relation write itself, even though the model's attributes are clean.
+     */
+    public function testRelatedModelRelationFieldIsStillAuthorized(): void
+    {
+        $group = UserGroup::create([
+            'name' => 'Test Group',
+            'code' => 'test-group',
+        ]);
+
+        $this->actingAs((new UserFixture)->withPermission('backend.manage_users', false));
+
+        $this->expectException(AuthorizationException::class);
+
+        $this->savePivotForm($this->getHydratedRelatedUser(), [
+            'groups' => [$group->id],
+            'pivot' => ['is_default' => true],
+        ]);
+    }
+
+    /**
+     * A deferred binding leaves the owning model clean; committing it during the save must
+     * still work when the operator is authorized.
      */
     public function testDeferredBindingsAreCommittedForOtherwiseCleanModels(): void
     {
@@ -208,12 +244,12 @@ class RelationControllerPivotTest extends PluginTestCase
 
         $hydrated = $this->getHydratedRelatedUser();
 
-        // Bind a group to the untouched user under the pivot widget's session key
+        // Bind a group to the untouched user under the pivot session key
         $group = UserGroup::create([
             'name' => 'Test Group',
             'code' => 'test-group',
         ]);
-        $hydrated->groups()->add($group, 'pivottestsessionkey');
+        $hydrated->groups()->add($group, static::SESSION_KEY);
 
         $this->assertFalse($hydrated->isDirty(), 'The deferred binding leaves the user clean');
         $this->assertEquals(0, $hydrated->groups()->count(), 'Nothing committed yet');
@@ -225,23 +261,23 @@ class RelationControllerPivotTest extends PluginTestCase
     }
 
     /**
-     * Skipping the save must not become an authorization bypass. A deferred binding leaves the
-     * owning model clean, so a naive skip would commit relation changes - such as adding a user
-     * to a group, which carries permissions - without ever consulting `User::beforeSave()`.
+     * Committing a deferred binding is a relation change to another user's record and must
+     * still be refused without the permission, even though the owning model's attributes
+     * are clean.
      */
     public function testDeferredBindingsAreStillAuthorizedForOtherwiseCleanModels(): void
     {
-        $this->actingAs((new UserFixture)->withPermission('backend.manage_users', false));
-
         $hydrated = $this->getHydratedRelatedUser();
 
         $group = UserGroup::create([
             'name' => 'Test Group',
             'code' => 'test-group',
         ]);
-        $hydrated->groups()->add($group, 'pivottestsessionkey');
+        $hydrated->groups()->add($group, static::SESSION_KEY);
 
         $this->assertFalse($hydrated->isDirty(), 'The deferred binding leaves the user clean');
+
+        $this->actingAs((new UserFixture)->withPermission('backend.manage_users', false));
 
         $this->expectException(AuthorizationException::class);
 

--- a/modules/backend/tests/behaviors/RelationControllerPivotTest.php
+++ b/modules/backend/tests/behaviors/RelationControllerPivotTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace Backend\Tests\Behaviors;
+
+use Backend\Behaviors\RelationController;
+use Backend\Models\User;
+use Backend\Models\UserGroup;
+use Backend\Tests\Fixtures\Models\PivotRelationFixture;
+use Backend\Tests\Fixtures\Models\UserFixture;
+use Db;
+use System\Tests\Bootstrap\PluginTestCase;
+use Winter\Storm\Auth\AuthorizationException;
+use Winter\Storm\Database\Model;
+
+/**
+ * Regression coverage for wintercms/winter#1464.
+ *
+ * `prepareModelsToSave()` always queues the related model, so a pivot form submission that
+ * contains nothing but pivot data used to save the related model too. For a belongsToMany
+ * relation to `Backend\Models\User` that no-op save tripped `User::beforeSave()`, locking
+ * operators without `backend.manage_users` out of editing pivot data entirely.
+ */
+class RelationControllerPivotTest extends PluginTestCase
+{
+    protected User $targetUser;
+    protected PivotRelationFixture $fixture;
+    protected RelationController $behavior;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        PivotRelationFixture::migrateUp();
+
+        Model::unguard();
+        $this->targetUser = User::create([
+            'first_name' => 'Target',
+            'last_name' => 'User',
+            'login' => 'targetuser',
+            'email' => 'target@test.com',
+            'password' => 'TestPassword1',
+            'password_confirmation' => 'TestPassword1',
+            'is_activated' => true,
+            'is_superuser' => false,
+        ]);
+        Model::reguard();
+
+        $this->fixture = PivotRelationFixture::create(['name' => 'Test Fixture']);
+        $this->fixture->users()->add($this->targetUser, null, ['is_default' => false]);
+
+        $this->behavior = $this->makeBehavior();
+    }
+
+    public function tearDown(): void
+    {
+        PivotRelationFixture::migrateDown();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Builds the behavior without its controller, then supplies the only collaborator
+     * `relationSavePivotModels()` uses: the pivot widget's session key.
+     */
+    protected function makeBehavior(): RelationController
+    {
+        $behavior = (new \ReflectionClass(RelationController::class))->newInstanceWithoutConstructor();
+
+        static::setProtectedProperty($behavior, 'pivotWidget', new class {
+            public function getSessionKey(): string
+            {
+                return 'pivottestsessionkey';
+            }
+        });
+
+        return $behavior;
+    }
+
+    /**
+     * Loads the related user *through the relation*, exactly as
+     * `onRelationManagePivotUpdate()` does via `$this->pivotWidget->model`.
+     */
+    protected function getHydratedRelatedUser(): User
+    {
+        return $this->fixture->users()
+            ->where('backend_users.id', $this->targetUser->id)
+            ->first();
+    }
+
+    /**
+     * Runs the production sequence used by both pivot handlers.
+     */
+    protected function savePivotForm(User $hydratedModel, array $saveData): void
+    {
+        $modelsToSave = static::callProtectedMethod(
+            $this->behavior,
+            'prepareModelsToSave',
+            [$hydratedModel, $saveData]
+        );
+
+        static::callProtectedMethod($this->behavior, 'relationSavePivotModels', [$modelsToSave]);
+    }
+
+    protected function getPivotValue()
+    {
+        return Db::table('backend_test_pivot_relation_users')
+            ->where('user_id', $this->targetUser->id)
+            ->value('is_default');
+    }
+
+    /**
+     * The related model is queued for saving even when the form only submitted pivot data.
+     * This is the underlying cause and is expected — the fix is in what gets saved, not
+     * in what gets queued.
+     */
+    public function testPrepareModelsToSaveQueuesTheRelatedModelForPivotOnlyData(): void
+    {
+        $modelsToSave = static::callProtectedMethod(
+            $this->behavior,
+            'prepareModelsToSave',
+            [$this->getHydratedRelatedUser(), ['pivot' => ['is_default' => true]]]
+        );
+
+        $this->assertContains(User::class, array_map('get_class', $modelsToSave));
+    }
+
+    /**
+     * A pivot-only submission leaves the related model completely unchanged.
+     */
+    public function testPivotOnlySaveDataLeavesTheRelatedModelClean(): void
+    {
+        $hydrated = $this->getHydratedRelatedUser();
+
+        static::callProtectedMethod(
+            $this->behavior,
+            'prepareModelsToSave',
+            [$hydrated, ['pivot' => ['is_default' => true]]]
+        );
+
+        $this->assertFalse($hydrated->isDirty(), 'The related user has no changed attributes');
+        $this->assertTrue($hydrated->pivot->isDirty(), 'Only the pivot changed');
+    }
+
+    /**
+     * #1464: an operator without `backend.manage_users` can edit pivot data.
+     */
+    public function testPivotOnlyUpdateSucceedsWithoutManageUsersPermission(): void
+    {
+        $this->actingAs((new UserFixture)->withPermission('backend.manage_users', false));
+
+        $this->savePivotForm($this->getHydratedRelatedUser(), ['pivot' => ['is_default' => true]]);
+
+        $this->assertEquals(1, $this->getPivotValue());
+    }
+
+    /**
+     * The same operation keeps working for an operator who does have the permission.
+     */
+    public function testPivotOnlyUpdateSucceedsWithManageUsersPermission(): void
+    {
+        $this->actingAs((new UserFixture)->withPermission('backend.manage_users', true));
+
+        $this->savePivotForm($this->getHydratedRelatedUser(), ['pivot' => ['is_default' => true]]);
+
+        $this->assertEquals(1, $this->getPivotValue());
+    }
+
+    /**
+     * A pivot form may also edit fields on the related model. Those changes must still be
+     * written — the fix only skips models that nothing changed.
+     */
+    public function testRelatedModelIsStillSavedWhenItsOwnFieldsAreEdited(): void
+    {
+        $this->actingAs((new UserFixture)->withPermission('backend.manage_users', true));
+
+        $this->savePivotForm($this->getHydratedRelatedUser(), [
+            'first_name' => 'Renamed',
+            'pivot' => ['is_default' => true],
+        ]);
+
+        $this->assertEquals('Renamed', User::find($this->targetUser->id)->first_name);
+        $this->assertEquals(1, $this->getPivotValue());
+    }
+
+    /**
+     * The fix must not become an authorization bypass: editing the related model's own
+     * fields without the permission is still refused.
+     */
+    public function testRelatedModelSaveIsStillAuthorizedWhenItsOwnFieldsAreEdited(): void
+    {
+        $this->actingAs((new UserFixture)->withPermission('backend.manage_users', false));
+
+        $this->expectException(AuthorizationException::class);
+
+        $this->savePivotForm($this->getHydratedRelatedUser(), [
+            'first_name' => 'Renamed',
+            'pivot' => ['is_default' => true],
+        ]);
+    }
+
+    /**
+     * Skipping the save must not drop pending relation work. A deferred binding leaves the
+     * owning model clean, so it would be lost if the model were simply passed over.
+     */
+    public function testDeferredBindingsAreCommittedForSkippedModels(): void
+    {
+        $this->actingAs((new UserFixture)->withPermission('backend.manage_users', true));
+
+        $hydrated = $this->getHydratedRelatedUser();
+
+        // Bind a group to the untouched user under the pivot widget's session key
+        $group = UserGroup::create([
+            'name' => 'Test Group',
+            'code' => 'test-group',
+        ]);
+        $hydrated->groups()->add($group, 'pivottestsessionkey');
+
+        $this->assertFalse($hydrated->isDirty(), 'The deferred binding leaves the user clean');
+        $this->assertEquals(0, $hydrated->groups()->count(), 'Nothing committed yet');
+
+        $this->savePivotForm($hydrated, ['pivot' => ['is_default' => true]]);
+
+        $this->assertEquals(1, $hydrated->groups()->count(), 'The deferred binding was committed');
+        $this->assertEquals(1, $this->getPivotValue());
+    }
+}

--- a/modules/backend/tests/fixtures/models/PivotRelationFixture.php
+++ b/modules/backend/tests/fixtures/models/PivotRelationFixture.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Backend\Tests\Fixtures\Models;
+
+use Backend\Models\User;
+use Illuminate\Support\Facades\Schema;
+use Winter\Storm\Database\Model;
+
+/**
+ * Self-contained model fixture holding a belongsToMany relation to Backend\Models\User
+ * with editable pivot data.
+ *
+ * Owns its own tables so the backend test suite has no dependency on any plugin.
+ */
+class PivotRelationFixture extends Model
+{
+    public $table = 'backend_test_pivot_relation_fixtures';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public $belongsToMany = [
+        'users' => [
+            User::class,
+            'table' => 'backend_test_pivot_relation_users',
+            'key' => 'fixture_id',
+            'otherKey' => 'user_id',
+            'pivot' => ['is_default'],
+        ],
+    ];
+
+    /**
+     * Create the backing tables if they do not already exist.
+     */
+    public static function migrateUp(): void
+    {
+        if (!Schema::hasTable('backend_test_pivot_relation_fixtures')) {
+            Schema::create('backend_test_pivot_relation_fixtures', function ($table) {
+                $table->increments('id');
+                $table->string('name')->nullable();
+            });
+        }
+
+        if (!Schema::hasTable('backend_test_pivot_relation_users')) {
+            Schema::create('backend_test_pivot_relation_users', function ($table) {
+                $table->integer('fixture_id')->unsigned();
+                $table->integer('user_id')->unsigned();
+                $table->boolean('is_default')->default(false);
+                $table->primary(['fixture_id', 'user_id']);
+            });
+        }
+    }
+
+    /**
+     * Drop the backing tables.
+     */
+    public static function migrateDown(): void
+    {
+        Schema::dropIfExists('backend_test_pivot_relation_users');
+        Schema::dropIfExists('backend_test_pivot_relation_fixtures');
+    }
+}

--- a/modules/backend/tests/models/UserAuthorizationTest.php
+++ b/modules/backend/tests/models/UserAuthorizationTest.php
@@ -260,6 +260,24 @@ class UserAuthorizationTest extends PluginTestCase
         $this->targetUser->save();
     }
 
+    public function testPluginAddedRelationIsNotGuarded(): void
+    {
+        $group = $this->makeGroup();
+
+        // Simulate a plugin-added relation on the user model; only the relations
+        // core owns (listed in $permissionGuardedRelations) require the permission
+        $this->targetUser->belongsToMany['memberships'] = [
+            UserGroup::class,
+            'table' => 'backend_users_groups',
+        ];
+
+        $actor = new UserFixture;
+        $this->actingAs($actor);
+
+        $this->targetUser->memberships()->add($group);
+        $this->assertEquals(1, $this->targetUser->memberships()->count());
+    }
+
     public function testSelfGroupChangeAllowed(): void
     {
         $group = $this->makeGroup();

--- a/modules/backend/tests/models/UserAuthorizationTest.php
+++ b/modules/backend/tests/models/UserAuthorizationTest.php
@@ -4,6 +4,7 @@ namespace Backend\Tests\Models;
 
 use Backend\Facades\BackendAuth;
 use Backend\Models\User;
+use Backend\Models\UserGroup;
 use Backend\Tests\Fixtures\Models\UserFixture;
 use System\Tests\Bootstrap\PluginTestCase;
 use Winter\Storm\Auth\AuthorizationException;
@@ -92,10 +93,10 @@ class UserAuthorizationTest extends PluginTestCase
     }
 
     //
-    // beforeSave()
+    // beforeCreate() / beforeUpdate()
     //
 
-    public function testBeforeSaveAllowsCliContext(): void
+    public function testUpdateAllowsCliContext(): void
     {
         BackendAuth::logout();
         $this->targetUser->first_name = 'Updated';
@@ -103,7 +104,7 @@ class UserAuthorizationTest extends PluginTestCase
         $this->assertEquals('Updated', $this->targetUser->first_name);
     }
 
-    public function testBeforeSaveAllowsSelfNonEscalatingChanges(): void
+    public function testUpdateAllowsSelfNonEscalatingChanges(): void
     {
         $this->actingAs($this->targetUser);
         $this->targetUser->first_name = 'NewName';
@@ -111,7 +112,7 @@ class UserAuthorizationTest extends PluginTestCase
         $this->assertEquals('NewName', $this->targetUser->first_name);
     }
 
-    public function testBeforeSaveBlocksSelfEscalation(): void
+    public function testUpdateBlocksSelfEscalation(): void
     {
         $this->actingAs($this->targetUser);
         $this->targetUser->is_superuser = true;
@@ -120,7 +121,7 @@ class UserAuthorizationTest extends PluginTestCase
         $this->targetUser->save();
     }
 
-    public function testBeforeSaveBlocksUnauthorizedUserModifyingOthers(): void
+    public function testUpdateBlocksUnauthorizedUserModifyingOthers(): void
     {
         $actor = new UserFixture;
         $this->actingAs($actor);
@@ -130,7 +131,7 @@ class UserAuthorizationTest extends PluginTestCase
         $this->targetUser->save();
     }
 
-    public function testBeforeSaveAllowsManageUsersActorModifyingOthers(): void
+    public function testUpdateAllowsManageUsersActorModifyingOthers(): void
     {
         $actor = (new UserFixture)->withPermission('backend.manage_users', true);
         $this->actingAs($actor);
@@ -140,7 +141,39 @@ class UserAuthorizationTest extends PluginTestCase
         $this->assertEquals('AdminUpdated', $this->targetUser->first_name);
     }
 
-    public function testBeforeSaveBlocksNonSuperuserModifyingSuperuser(): void
+    public function testSaveWithNoChangesRequiresNoPermission(): void
+    {
+        $actor = new UserFixture;
+        $this->actingAs($actor);
+
+        // The guard fires on create/update, which only happen when there is
+        // something to write — a no-op save is allowed for anyone (#1464)
+        try {
+            $this->targetUser->save();
+        } catch (AuthorizationException $e) {
+            $this->fail('Should not throw AuthorizationException for a save with no changes');
+        }
+        $this->assertTrue(true);
+    }
+
+    public function testCreateBlocksUnauthorizedUser(): void
+    {
+        $actor = new UserFixture;
+        $this->actingAs($actor);
+
+        $user = new User;
+        $user->first_name = 'New';
+        $user->last_name = 'User';
+        $user->login = 'newuser';
+        $user->email = 'new@test.com';
+        $user->password = 'TestPassword1';
+        $user->password_confirmation = 'TestPassword1';
+
+        $this->expectException(AuthorizationException::class);
+        $user->save();
+    }
+
+    public function testUpdateBlocksNonSuperuserModifyingSuperuser(): void
     {
         // Make the target a superuser via direct DB update to bypass model events
         $this->targetUser->newQuery()->where('id', $this->targetUser->id)->update(['is_superuser' => true]);
@@ -156,7 +189,7 @@ class UserAuthorizationTest extends PluginTestCase
         $superTarget->save();
     }
 
-    public function testBeforeSaveSuperuserCanModifyAnyone(): void
+    public function testUpdateSuperuserCanModifyAnyone(): void
     {
         $actor = (new UserFixture)->asSuperUser();
         $this->actingAs($actor);
@@ -164,6 +197,79 @@ class UserAuthorizationTest extends PluginTestCase
         $this->targetUser->first_name = 'SuperUpdated';
         $this->targetUser->save();
         $this->assertEquals('SuperUpdated', $this->targetUser->first_name);
+    }
+
+    //
+    // Group membership (model.relation.* guard)
+    //
+
+    protected function makeGroup(): UserGroup
+    {
+        return UserGroup::create([
+            'name' => 'Test Group',
+            'code' => 'test-group',
+        ]);
+    }
+
+    public function testGroupAttachAllowsManageUsersActor(): void
+    {
+        $group = $this->makeGroup();
+
+        $actor = (new UserFixture)->withPermission('backend.manage_users', true);
+        $this->actingAs($actor);
+
+        $this->targetUser->groups()->add($group);
+        $this->assertEquals(1, $this->targetUser->groups()->count());
+    }
+
+    public function testGroupAttachBlocksUnauthorizedUser(): void
+    {
+        $group = $this->makeGroup();
+
+        $actor = new UserFixture;
+        $this->actingAs($actor);
+
+        $this->expectException(AuthorizationException::class);
+        $this->targetUser->groups()->add($group);
+    }
+
+    public function testGroupDetachBlocksUnauthorizedUser(): void
+    {
+        $group = $this->makeGroup();
+        $this->targetUser->groups()->add($group);
+
+        $actor = new UserFixture;
+        $this->actingAs($actor);
+
+        $this->expectException(AuthorizationException::class);
+        $this->targetUser->groups()->remove($group);
+    }
+
+    public function testGroupSyncAssignmentBlocksUnauthorizedUser(): void
+    {
+        $group = $this->makeGroup();
+
+        $actor = new UserFixture;
+        $this->actingAs($actor);
+
+        // Assigning a relation value queues a sync that runs during save without
+        // dirtying any attributes — the relation guard must still catch it
+        $this->targetUser->groups = [$group->id];
+
+        $this->expectException(AuthorizationException::class);
+        $this->targetUser->save();
+    }
+
+    public function testSelfGroupChangeAllowed(): void
+    {
+        $group = $this->makeGroup();
+
+        $this->actingAs($this->targetUser);
+
+        // Groups carry no permissions out of the box, so changing your own
+        // membership is not an escalation vector and needs no permission
+        $this->targetUser->groups()->add($group);
+        $this->assertEquals(1, $this->targetUser->groups()->count());
     }
 
     //


### PR DESCRIPTION
Fixes #1464

## Problem

`RelationController`'s pivot handlers save every model returned by `prepareModelsToSave()`. That list always includes the related model — `FormModelSaver::setModelAttributes()` pushes it before it even looks at `$saveData` — so a submission containing nothing but pivot data still saves the related record.

For a `belongsToMany` relation to `Backend\Models\User`, that no-op save fired `User::beforeSave()`, which throws for any operator lacking `backend.manage_users`. The relation became unusable for them. This is a regression against 1.2.9, surfaced by the user authorization guards added since.

## Fix

An earlier revision of this PR taught the pivot handlers to skip models with nothing to write. Review showed that approach is inherently brittle — the save pipeline has several independent write channels (attribute updates, deferred binding commits, relation syncs queued by `setSimpleValue()`, purgeable attributes that look dirty but aren't), and any skip heuristic must re-derive all of them. Two gaps were confirmed: relation-widget fields on the related model were silently dropped, and `_`-prefixed helper fields defeated the `isDirty()` check.

This revision moves the guard instead, onto the events that only fire for **actual writes**:

- **`beforeCreate()` / `beforeUpdate()`** guard attribute writes. Eloquent's update event only fires when attributes have genuinely changed — after purgeable attributes are stripped — so a save with nothing to write requires no permission.
- **`model.relation.beforeAttach` / `beforeDetach` / `beforeAdd` / `beforeRemove`** guard relation writes. Direct `attach()`/`detach()`, deferred binding commits (`commitDeferredAfter` → `add()` → `attach()`) and queued `setSimpleValue()` syncs (afterSave → `sync()` → `attach()`/`detach()`) all funnel through these events, so the guard fires at the moment the relation write happens rather than trying to predict it.

The pivot handlers save every prepared model unconditionally again — restoring pre-1.2.10 behavior for plugin `afterSave` hooks and relation-widget fields — and `onRelationManagePivotUpdate()` is wrapped in `Db::transaction()` to match `onRelationManagePivotCreate()`.

### Guard semantics

- Attribute changes: unchanged rules (self non-escalating edits allowed; others' records need `backend.manage_users`; superuser targets need a superuser actor; CLI/queue contexts exempt).
- Relation changes are guarded only for the relations the user model **owns** — `groups`, `avatar`, `throttle`, listed in the public `$permissionGuardedRelations` property. Changing them on **another user's** record requires `backend.manage_users`, now even via direct `attach()`/`detach()` — those paths previously bypassed the save-based guard entirely.
- Plugin-added relations on the user model are deliberately **not** guarded: a plugin writing its own user-side relation (e.g. assigning a user to a support ticket via `$user->tickets()->add()`) keeps working for unprivileged operators, since that relation is the plugin's domain. Plugins with genuinely sensitive relations can append to `$permissionGuardedRelations` or bind their own guard to the same `model.relation.*` events. (Relations that merely reference users from the other side — `$ticket->users()->attach()` — never touched the guard, since the events fire on the parent model.)
- Relation changes to **your own** record are allowed: backend groups carry no permissions out of the box (`getMergedPermissions()` merges only role + user permissions), so group membership is not an escalation vector.

## Tests

`RelationControllerPivotTest` (10 cases) exercises the production pivot save sequence end-to-end: pivot-only saves with and without the permission, related-field edits (applied and refused), relation-widget fields via the `setSimpleValue()` path (applied and refused), and deferred binding commits (applied and refused). `UserAuthorizationTest` grows from 31 to 39 cases: no-op saves need no permission, creates are guarded, group attach/detach/sync are guarded for other users' records, self group changes stay allowed, and a plugin-style relation added to the user model is not guarded.

Negative control: with the `model.relation.*` bindings commented out, all six unauthorized-relation-change tests fail — the coverage bites.

Full core suite passes (backend: 169 tests / 371 assertions; the only failures elsewhere are 3 pre-existing environmental failures in `cms/ControllerTest` caused by a local asset-URL config, present on the unmodified branch too). phpcs clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved many-to-many pivot persistence by ensuring related model prep and saves run atomically.
  - Pivot updates now reliably handle authorization: pivot-only changes succeed without requiring permission to edit the related record, while related record field edits remain protected.
  - Deferred relation bindings are committed during pivot updates when authorized.

- **New Features**
  - Stricter user update authorization, including guarded relation changes (e.g., group membership), with clearer denial behavior.

- **Tests**
  - Added pivot regression coverage and expanded user/group authorization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
