### PR TITLE
Add fields property to FieldSet class

### DIFF
--- a/modules/backend/formwidgets/FieldSet.php
+++ b/modules/backend/formwidgets/FieldSet.php
@@ -27,6 +27,11 @@ class FieldSet extends FormWidgetBase
     public $form;
 
     /**
+     * @var array Field configuration
+     */
+    public $fields;
+
+    /**
      * @var bool Determines if this form field should display comments and labels.
      */
     public $showLabels = false;


### PR DESCRIPTION
Seems to work with a small fix, even with fieldsets within fieldsets!

> Out of the box the fieldsets rendered empty — legend only, zero fields. Root cause: FieldSet::init() calls fillFromConfig(['fields']), but WidgetBase::fillFromConfig() only fills properties that exist on the class (property_exists check), and FieldSet declares public $form but not public $fields. So the inner form always got fields => null, silently. I added public $fields; to FieldSet.php:27 locally and everything came to life. Claude

<img width="1085" height="427" alt="image" src="https://github.com/user-attachments/assets/e7a60919-2e09-4569-b049-9b2d1dc39e8b" />

The dark scheme might need some adjusting
```
@media (prefers-color-scheme: dark) {
    .fieldset {
        background: #000;
    }
}
```
<img width="938" height="176" alt="image" src="https://github.com/user-attachments/assets/05c99a49-5104-46d0-8a0a-58ac4a7d33b3" />