### PR TITLE
Add previous/next record navigation to backend forms

### DIFF
--- a/modules/backend/assets/css/winter.css
+++ b/modules/backend/assets/css/winter.css
@@ -1106,3 +1106,13 @@ html.cssanimations .fancy-layout *:not(.nested-form):not(.modal-body)>.form-widg
 .flyout-toggle:hover i{color:#fff}
 body.flyout-visible{overflow:hidden}
 body.flyout-visible .flyout-overlay{background-color:rgba(0,0,0,0.3)}
+/* Record navigation (formcontroller/partials/_record_navigation.php) */
+.control-breadcrumb{position:relative}
+.form-record-nav{position:absolute;top:0;bottom:0;right:20px;display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-align:center;-webkit-align-items:center;-ms-flex-align:center;align-items:center;gap:9px;font-size:12px}
+.form-record-nav .form-record-nav-position{color:#5a6b7b;font-weight:600;letter-spacing:.3px;white-space:nowrap}
+.form-record-nav .form-record-nav-group{display:-webkit-inline-box;display:-webkit-inline-flex;display:-ms-inline-flexbox;display:inline-flex;-webkit-box-align:center;-webkit-align-items:center;-ms-flex-align:center;align-items:center;background:rgba(255,255,255,.55);border:1px solid rgba(0,0,0,.09);border-radius:6px;overflow:hidden;box-shadow:0 1px 1px rgba(0,0,0,.03)}
+.form-record-nav .form-record-nav-btn{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-box-align:center;-webkit-align-items:center;-ms-flex-align:center;align-items:center;-webkit-box-pack:center;-webkit-justify-content:center;-ms-flex-pack:center;justify-content:center;width:28px;height:24px;color:#5a6b7b;text-decoration:none;-webkit-transition:background-color .12s ease,color .12s ease;transition:background-color .12s ease,color .12s ease}
+.form-record-nav .form-record-nav-btn+.form-record-nav-btn{border-left:1px solid rgba(0,0,0,.09)}
+.form-record-nav .form-record-nav-btn:not(.is-disabled):hover{background-color:#fff;color:#1f2d3d}
+.form-record-nav .form-record-nav-btn.is-disabled{color:#b6bfc7;cursor:default}
+.form-record-nav .form-record-nav-btn svg{display:block}

--- a/modules/backend/assets/less/controls/record-navigation.less
+++ b/modules/backend/assets/less/controls/record-navigation.less
@@ -1,0 +1,69 @@
+//
+// Record navigation
+//
+// Previous/next navigation shown in the breadcrumb row of a form, letting the
+// user step through the sibling records of the controller's list (respecting
+// its active filters, search and sorting). Rendered by the FormController
+// behavior via formcontroller/partials/_record_navigation.php.
+// ========================================================================
+
+.control-breadcrumb {
+    position: relative;
+}
+
+.form-record-nav {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 20px;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    font-size: 12px;
+
+    .form-record-nav-position {
+        color: #5a6b7b;
+        font-weight: 600;
+        letter-spacing: .3px;
+        white-space: nowrap;
+    }
+
+    .form-record-nav-group {
+        display: inline-flex;
+        align-items: center;
+        background: rgba(255, 255, 255, .55);
+        border: 1px solid rgba(0, 0, 0, .09);
+        border-radius: 6px;
+        overflow: hidden;
+        box-shadow: 0 1px 1px rgba(0, 0, 0, .03);
+    }
+
+    .form-record-nav-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 24px;
+        color: #5a6b7b;
+        text-decoration: none;
+        transition: background-color .12s ease, color .12s ease;
+
+        & + .form-record-nav-btn {
+            border-left: 1px solid rgba(0, 0, 0, .09);
+        }
+
+        &:not(.is-disabled):hover {
+            background-color: #fff;
+            color: #1f2d3d;
+        }
+
+        &.is-disabled {
+            color: #b6bfc7;
+            cursor: default;
+        }
+
+        svg {
+            display: block;
+        }
+    }
+}

--- a/modules/backend/assets/less/winter.less
+++ b/modules/backend/assets/less/winter.less
@@ -25,6 +25,7 @@
 @import "controls/namevaluelist.less";
 @import "controls/scrollpad.less";
 @import "controls/svg-icons.less";
+@import "controls/record-navigation.less";
 
 //
 // Winter Storm UI

--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -659,6 +659,101 @@ class FormController extends ControllerBehavior
     }
 
     /**
+     * View helper to render the previous/next record navigation for the record
+     * being edited, relative to its sibling records in the controller's list.
+     *
+     *     <?= $this->formRenderRecordNavigation() ?>
+     *
+     * Renders nothing unless the `recordNavigation` config is enabled (the
+     * default), the controller also implements the ListController behavior, and
+     * an existing record is being viewed.
+     *
+     * @return string HTML markup (empty string when navigation is unavailable)
+     */
+    public function formRenderRecordNavigation(): string
+    {
+        $navigation = $this->formGetRecordNavigation();
+        if ($navigation === null || $navigation['current'] === null) {
+            return '';
+        }
+
+        return $this->formMakePartial('record_navigation', [
+            'navigation' => $navigation,
+            'navigationContext' => $this->context,
+        ]);
+    }
+
+    /**
+     * Resolves the position of the current record within the controller's list
+     * and the neighboring record keys used for previous/next navigation.
+     *
+     * The sibling set comes from the ListController's prepared query, so it
+     * reflects the active filters, search and sorting exactly as the user left
+     * the list. Ordered keys are read with a single portable `pluck` and the
+     * position is resolved in PHP — no driver-specific SQL — so it behaves
+     * identically across every database Winter supports.
+     *
+     * @param \Winter\Storm\Database\Model|null $model
+     * @return array{previous: mixed, next: mixed, current: int|null, total: int}|null
+     */
+    public function formGetRecordNavigation($model = null): ?array
+    {
+        if (!$this->getConfig('recordNavigation', true)) {
+            return null;
+        }
+
+        $model = $model ?: $this->model;
+        if (!$model || !$model->exists) {
+            return null;
+        }
+
+        if (!$this->controller->isClassExtendedWith(\Backend\Behaviors\ListController::class)) {
+            return null;
+        }
+
+        $this->controller->makeLists();
+        $listWidget = $this->controller->listGetWidget();
+        if (!$listWidget) {
+            return null;
+        }
+
+        $keys = $listWidget->prepareQuery()->pluck($model->getQualifiedKeyName())->all();
+
+        return static::resolveRecordPosition($keys, $model->getKey());
+    }
+
+    /**
+     * Pure position math for record navigation: given an ordered list of record
+     * keys and the current key, returns the navigation descriptor. Performs no
+     * database access, so it is trivially unit-testable and identical on every
+     * driver.
+     *
+     * @param array<int, mixed> $keys Ordered list of record keys.
+     * @param mixed $currentKey The key of the record being viewed.
+     * @return array{previous: mixed, next: mixed, current: int|null, total: int}
+     */
+    public static function resolveRecordPosition(array $keys, $currentKey): array
+    {
+        $keys = array_values($keys);
+        $total = count($keys);
+
+        $position = null;
+        foreach ($keys as $index => $key) {
+            if ((string) $key === (string) $currentKey) {
+                $position = $index;
+                break;
+            }
+        }
+
+        return [
+            'previous' => ($position !== null && $position > 0) ? $keys[$position - 1] : null,
+            'next' => ($position !== null && $position < $total - 1) ? $keys[$position + 1] : null,
+            'current' => $position === null ? null : $position + 1,
+            'total' => $total,
+        ];
+    }
+
+    /**
      * Returns the form widget used by this behavior.
      *
      * @return \Backend\Widgets\Form

--- a/modules/backend/behaviors/formcontroller/partials/_record_navigation.php
+++ b/modules/backend/behaviors/formcontroller/partials/_record_navigation.php
@@ -1,0 +1,28 @@
+<?php
+    /** @var array{previous: mixed, next: mixed, current: int, total: int} $navigation */
+    $previousUrl = $navigation['previous'] !== null
+        ? $this->actionUrl($navigationContext, $navigation['previous'])
+        : null;
+    $nextUrl = $navigation['next'] !== null
+        ? $this->actionUrl($navigationContext, $navigation['next'])
+        : null;
+    $chevronUp = '<svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true"><path d="M4 10l4-4 4 4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+    $chevronDown = '<svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true"><path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+?>
+<div class="form-record-nav" role="navigation" aria-label="<?= e(trans('backend::lang.form.record_navigation')) ?>">
+    <span class="form-record-nav-position">
+        <?= e($navigation['current']) ?>&nbsp;/&nbsp;<?= e($navigation['total']) ?>
+    </span>
+    <span class="form-record-nav-group">
+        <?php if ($previousUrl): ?>
+            <a href="<?= e($previousUrl) ?>" class="form-record-nav-btn" title="<?= e(trans('backend::lang.form.previous_record')) ?>" data-hotkey="ctrl+up, cmd+up"><?= $chevronUp ?></a>
+        <?php else: ?>
+            <span class="form-record-nav-btn is-disabled" aria-disabled="true"><?= $chevronUp ?></span>
+        <?php endif ?>
+        <?php if ($nextUrl): ?>
+            <a href="<?= e($nextUrl) ?>" class="form-record-nav-btn" title="<?= e(trans('backend::lang.form.next_record')) ?>" data-hotkey="ctrl+down, cmd+down"><?= $chevronDown ?></a>
+        <?php else: ?>
+            <span class="form-record-nav-btn is-disabled" aria-disabled="true"><?= $chevronDown ?></span>
+        <?php endif ?>
+    </span>
+</div>

--- a/modules/backend/behaviors/formcontroller/views/preview/_fancy.php
+++ b/modules/backend/behaviors/formcontroller/views/preview/_fancy.php
@@ -1,5 +1,6 @@
 <?php Block::put('breadcrumb') ?>
     <?= $this->makeLayoutPartial('breadcrumb') ?>
+    <?= $this->formRenderRecordNavigation() ?>
 <?php Block::endPut() ?>
 
 <?php if (!$this->fatalError): ?>

--- a/modules/backend/behaviors/formcontroller/views/preview/_sidebar.php
+++ b/modules/backend/behaviors/formcontroller/views/preview/_sidebar.php
@@ -1,5 +1,6 @@
 <?php Block::put('breadcrumb') ?>
     <?= $this->makeLayoutPartial('breadcrumb') ?>
+    <?= $this->formRenderRecordNavigation() ?>
 <?php Block::endPut() ?>
 
 <?php if (!$this->fatalError): ?>

--- a/modules/backend/behaviors/formcontroller/views/preview/_standard.php
+++ b/modules/backend/behaviors/formcontroller/views/preview/_standard.php
@@ -1,5 +1,6 @@
 <?php Block::put('breadcrumb') ?>
     <?= $this->makeLayoutPartial('breadcrumb') ?>
+    <?= $this->formRenderRecordNavigation() ?>
 <?php Block::endPut() ?>
 
 <?php if (!$this->fatalError): ?>

--- a/modules/backend/behaviors/formcontroller/views/update/_fancy.php
+++ b/modules/backend/behaviors/formcontroller/views/update/_fancy.php
@@ -1,5 +1,6 @@
 <?php Block::put('breadcrumb') ?>
     <?= $this->makeLayoutPartial('breadcrumb') ?>
+    <?= $this->formRenderRecordNavigation() ?>
 <?php Block::endPut() ?>
 
 <?php if (!$this->fatalError): ?>

--- a/modules/backend/behaviors/formcontroller/views/update/_sidebar.php
+++ b/modules/backend/behaviors/formcontroller/views/update/_sidebar.php
@@ -1,5 +1,6 @@
 <?php Block::put('breadcrumb') ?>
     <?= $this->makeLayoutPartial('breadcrumb') ?>
+    <?= $this->formRenderRecordNavigation() ?>
 <?php Block::endPut() ?>
 
 <?php if (!$this->fatalError): ?>

--- a/modules/backend/behaviors/formcontroller/views/update/_standard.php
+++ b/modules/backend/behaviors/formcontroller/views/update/_standard.php
@@ -1,5 +1,6 @@
 <?php Block::put('breadcrumb') ?>
     <?= $this->makeLayoutPartial('breadcrumb') ?>
+    <?= $this->formRenderRecordNavigation() ?>
 <?php Block::endPut() ?>
 
 <?php if (!$this->fatalError): ?>

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -326,6 +326,9 @@ return [
         'concurrency_file_changed_title' => 'File was changed',
         'concurrency_file_changed_description' => "The file you're editing has been changed on disk by another user. You can either reload the file and lose your changes or override the file on the disk.",
         'return_to_list' => 'Return to the list',
+        'record_navigation' => 'Record navigation',
+        'previous_record' => 'Previous record',
+        'next_record' => 'Next record',
     ],
     'recordfinder' => [
         'find_record' => 'Find Record',

--- a/modules/backend/tests/behaviors/FormControllerRecordNavigationTest.php
+++ b/modules/backend/tests/behaviors/FormControllerRecordNavigationTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Backend\Tests\Behaviors;
+
+use Backend\Behaviors\FormController;
+use System\Tests\Bootstrap\TestCase;
+
+/**
+ * Unit coverage for FormController record navigation.
+ *
+ * The previous/next/current/total math is a pure, database-agnostic helper
+ * (`resolveRecordPosition`) that resolves a record's position within an already
+ * ordered set of keys. Keeping it free of SQL is what lets the navigation work
+ * identically across every database driver Winter supports — the ordered keys
+ * are read once via a portable `pluck`, and the position is worked out here in
+ * PHP rather than with driver-specific window functions or session variables.
+ */
+class FormControllerRecordNavigationTest extends TestCase
+{
+    public function testEmptySet(): void
+    {
+        $this->assertSame(
+            ['previous' => null, 'next' => null, 'current' => null, 'total' => 0],
+            FormController::resolveRecordPosition([], 5)
+        );
+    }
+
+    public function testSingleRecordThatIsCurrent(): void
+    {
+        $this->assertSame(
+            ['previous' => null, 'next' => null, 'current' => 1, 'total' => 1],
+            FormController::resolveRecordPosition([5], 5)
+        );
+    }
+
+    public function testFirstRecordHasNextButNoPrevious(): void
+    {
+        $this->assertSame(
+            ['previous' => null, 'next' => 6, 'current' => 1, 'total' => 3],
+            FormController::resolveRecordPosition([5, 6, 7], 5)
+        );
+    }
+
+    public function testMiddleRecordHasBothNeighbours(): void
+    {
+        $this->assertSame(
+            ['previous' => 5, 'next' => 7, 'current' => 2, 'total' => 3],
+            FormController::resolveRecordPosition([5, 6, 7], 6)
+        );
+    }
+
+    public function testLastRecordHasPreviousButNoNext(): void
+    {
+        $this->assertSame(
+            ['previous' => 6, 'next' => null, 'current' => 3, 'total' => 3],
+            FormController::resolveRecordPosition([5, 6, 7], 7)
+        );
+    }
+
+    public function testCurrentKeyNotInSetYieldsNoPosition(): void
+    {
+        $this->assertSame(
+            ['previous' => null, 'next' => null, 'current' => null, 'total' => 3],
+            FormController::resolveRecordPosition([5, 6, 7], 99)
+        );
+    }
+
+    public function testKeysAreComparedLoosely(): void
+    {
+        // Database drivers may return keys as strings while the current model
+        // key is an integer (or vice versa); comparison must not be type-strict.
+        $this->assertSame(
+            ['previous' => '5', 'next' => '7', 'current' => 2, 'total' => 3],
+            FormController::resolveRecordPosition(['5', '6', '7'], 6)
+        );
+    }
+
+    public function testNonNumericKeysAreSupported(): void
+    {
+        // Works for UUID / string primary keys, not just auto-increment integers.
+        $this->assertSame(
+            ['previous' => 'aaa', 'next' => 'ccc', 'current' => 2, 'total' => 3],
+            FormController::resolveRecordPosition(['aaa', 'bbb', 'ccc'], 'bbb')
+        );
+    }
+
+    public function testGapsInKeysArePreserved(): void
+    {
+        $this->assertSame(
+            ['previous' => 3, 'next' => 40, 'current' => 3, 'total' => 4],
+            FormController::resolveRecordPosition([1, 3, 12, 40], 12)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

<img width="528" height="180" alt="record-nav-closeup" src="https://github.com/user-attachments/assets/1fdb7997-31fc-4f16-b39c-d6e784f75684" />
<img width="1920" height="90" alt="record-nav-in-breadcrumb" src="https://github.com/user-attachments/assets/baffc579-1bc1-4940-a86d-caf5246041a6" />

Adds an optional **record navigation** control to backend forms: a compact `current / total` indicator with previous/next arrows pinned to the right of the breadcrumb row on `update`/`preview` pages. It lets operators step through the sibling records of the controller's list without returning to it, **honouring the list's active filters, search and sorting**.

Enabled by default; opt out per controller with `recordNavigation: false` in `config_form.yaml`. Renders nothing when the controller has no `ListController` behaviour or when creating a new record.

## Why / cross-database

Projects commonly hand-roll this per controller with a MySQL-only `SET @row_num` trick that breaks on SQLite/Postgres/SQL Server. This keeps the position math database-agnostic:

- the ordered keys come from the ListController's already-prepared query, so filters/search/sort are respected for free;
- they're read once with a portable `pluck`, and the current record's neighbours are resolved in PHP via the pure `resolveRecordPosition()` helper — **no driver-specific SQL, no window functions, no session variables**.

## What's included

- `FormController::formGetRecordNavigation()` + `formRenderRecordNavigation()`, and the pure `resolveRecordPosition()` helper
- `formcontroller/partials/_record_navigation.php`, wired into the standard/sidebar/fancy `update` and `preview` layouts
- `backend::lang.form.record_navigation` / `previous_record` / `next_record`
- Styles in `assets/less/controls/record-navigation.less`
- Unit tests: `FormControllerRecordNavigationTest` (empty / first / middle / last / not-found / loose-typed / string keys)

## Screenshots



## Notes

- `recordNavigation` defaults to `true`; set `false` to disable per controller.
- Hotkeys: `ctrl`/`cmd` + up (previous), + down (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
