### PR TITLE
Render the page after a non-AJAX postback

### DIFF
--- a/modules/backend/classes/Controller.php
+++ b/modules/backend/classes/Controller.php
@@ -64,6 +64,11 @@ class Controller extends ControllerBase
     public $suppressView = false;
 
     /**
+     * @var bool Whether the page action has been executed during this request.
+     */
+    protected $actionExecuted = false;
+
+    /**
      * @var array Routed parameters.
      */
     protected $params;
@@ -307,6 +312,8 @@ class Controller extends ControllerBase
          */
         $this->setNavigationContext($action, $params);
 
+        $result = null;
+
         /*
          * Execute AJAX event
          */
@@ -328,6 +335,23 @@ class Controller extends ControllerBase
                 $handlerResponse !== true
             ) {
                 $result = $handlerResponse;
+            }
+            elseif (!$this->actionExecuted && strtolower($handler) !== strtolower($action)) {
+                // The handler produced no response and the action has not run, so render
+                // the page as a normal request would. Previously this errored on an
+                // undefined variable.
+                $result = $this->execPageAction($action, $params);
+            }
+            else {
+                // The action already ran while dispatching the handler: through widget or
+                // handler discovery with its view suppressed, or because the handler names
+                // the action itself. Running it again would repeat its side effects, and
+                // its result was not retained, so fail visibly as this path always has,
+                // with a message in place of an undefined variable error.
+                throw new SystemException(sprintf(
+                    'The %s postback handler produced no response.',
+                    $handler
+                ));
             }
         }
 
@@ -429,6 +453,8 @@ class Controller extends ControllerBase
      */
     protected function execPageAction($actionName, $parameters)
     {
+        $this->actionExecuted = true;
+
         $result = null;
 
         if (!$this->actionExists($actionName)) {

--- a/modules/backend/tests/classes/ControllerPostbackTest.php
+++ b/modules/backend/tests/classes/ControllerPostbackTest.php
@@ -3,6 +3,7 @@
 namespace Backend\Tests\Classes;
 
 use Backend\Controllers\Auth;
+use Backend\Tests\Fixtures\Controllers\PostbackTestController;
 use Backend\Tests\Fixtures\Models\UserFixture;
 use Illuminate\Support\Facades\Request;
 use System\Tests\Bootstrap\PluginTestCase;
@@ -142,6 +143,105 @@ class ControllerPostbackTest extends PluginTestCase
         $this->expectException(SystemException::class);
         $this->expectExceptionMessage('Invalid AJAX handler name: generatePermissionsField.');
         $controller->run('signin');
+    }
+
+    public function testPostbackWithoutAResponseStillRendersThePage(): void
+    {
+        $this->actingAs((new UserFixture)->asSuperUser());
+        Config::set('cms.enableCsrfProtection', false);
+
+        $controller = new PostbackTestController;
+        Request::swap($this->configPostbackRequestMock('onNoop'));
+
+        $response = $controller->run('index');
+        $content = is_object($response) && method_exists($response, 'getContent')
+            ? $response->getContent()
+            : (string) $response;
+
+        $this->assertStringContainsString(
+            'POSTBACK_FIXTURE_INDEX',
+            $content,
+            'A postback whose handler returns no response must still render the action page.'
+        );
+        $this->assertSame(1, $controller->handlerRuns, 'the handler must run exactly once');
+        $this->assertSame(1, $controller->actionRuns, 'the action must run exactly once');
+    }
+
+    public function testWidgetPostbackDoesNotRunTheActionTwice(): void
+    {
+        $this->actingAs((new UserFixture)->asSuperUser());
+        Config::set('cms.enableCsrfProtection', false);
+
+        $controller = new PostbackTestController;
+        Request::swap($this->configPostbackRequestMock('postbackwidget::onWidgetNoop'));
+
+        $caught = null;
+
+        try {
+            $controller->run('index');
+        }
+        catch (SystemException $ex) {
+            $caught = $ex;
+        }
+
+        $this->assertSame(
+            1,
+            $controller->actionRuns,
+            'widget handler dispatch already ran the action; it must not run again'
+        );
+        $this->assertSame(1, $controller->widget->postbackwidget->handlerRuns, 'the widget handler must run exactly once');
+        $this->assertInstanceOf(SystemException::class, $caught, 'the unrenderable postback must fail visibly');
+        $this->assertStringContainsString('produced no response', $caught->getMessage());
+    }
+
+    public function testMissingHandlerDiscoveryDoesNotRunTheActionTwice(): void
+    {
+        $this->actingAs((new UserFixture)->asSuperUser());
+        Config::set('cms.enableCsrfProtection', false);
+
+        $controller = new PostbackTestController;
+        Request::swap($this->configPostbackRequestMock('onNotDefinedAnywhere'));
+
+        $caught = null;
+
+        try {
+            $controller->run('index');
+        }
+        catch (SystemException $ex) {
+            $caught = $ex;
+        }
+
+        $this->assertSame(
+            1,
+            $controller->actionRuns,
+            'handler discovery already ran the action while searching widgets; it must not run again'
+        );
+        $this->assertInstanceOf(SystemException::class, $caught, 'the unrenderable postback must fail visibly');
+    }
+
+    public function testHandlerNamingTheActionItselfDoesNotRunTwice(): void
+    {
+        $this->actingAs((new UserFixture)->asSuperUser());
+        Config::set('cms.enableCsrfProtection', false);
+
+        $controller = new PostbackTestController;
+        Request::swap($this->configPostbackRequestMock('onSelfHandled'));
+
+        $caught = null;
+
+        try {
+            $controller->run('onSelfHandled');
+        }
+        catch (SystemException $ex) {
+            $caught = $ex;
+        }
+
+        $this->assertSame(
+            1,
+            $controller->actionRuns,
+            'the handler already ran the method; the page action must not run it again'
+        );
+        $this->assertInstanceOf(SystemException::class, $caught, 'the unrenderable postback must fail visibly');
     }
 
     public function testPostbackPathRejectsActionPrefixedHandler(): void

--- a/modules/backend/tests/fixtures/controllers/PostbackTestController.php
+++ b/modules/backend/tests/fixtures/controllers/PostbackTestController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Backend\Tests\Fixtures\Controllers;
+
+use Backend\Classes\Controller;
+use Backend\Tests\Fixtures\Widgets\PostbackTestWidget;
+
+class PostbackTestController extends Controller
+{
+    /**
+     * @var bool Render the bare view so the fixture needs no layout scaffolding.
+     */
+    public $suppressLayout = true;
+
+    /**
+     * @var int Number of times the index action ran.
+     */
+    public $actionRuns = 0;
+
+    /**
+     * @var int Number of times the controller handler ran.
+     */
+    public $handlerRuns = 0;
+
+    public function index()
+    {
+        $this->actionRuns++;
+
+        (new PostbackTestWidget($this))->bindToController();
+    }
+
+    public function onNoop()
+    {
+        $this->handlerRuns++;
+    }
+
+    public function onSelfHandled()
+    {
+        $this->actionRuns++;
+    }
+}

--- a/modules/backend/tests/fixtures/controllers/postbacktestcontroller/index.php
+++ b/modules/backend/tests/fixtures/controllers/postbacktestcontroller/index.php
@@ -1,0 +1,2 @@
+<?php /* Rendered by PostbackTestController::index() so the postback tests can assert the page rendered. */ ?>
+POSTBACK_FIXTURE_INDEX

--- a/modules/backend/tests/fixtures/widgets/PostbackTestWidget.php
+++ b/modules/backend/tests/fixtures/widgets/PostbackTestWidget.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Backend\Tests\Fixtures\Widgets;
+
+use Backend\Classes\WidgetBase;
+
+class PostbackTestWidget extends WidgetBase
+{
+    /**
+     * @var string
+     */
+    protected $defaultAlias = 'postbackwidget';
+
+    /**
+     * @var int Number of times the widget handler ran.
+     */
+    public $handlerRuns = 0;
+
+    public function render()
+    {
+        return '';
+    }
+
+    public function onWidgetNoop()
+    {
+        $this->handlerRuns++;
+    }
+}


### PR DESCRIPTION
Submitting a backend form without AJAX runs the handler and then returns a blank page. The handler result normalizes to `true`, so the dispatch chain skips the page action entirely.

The CMS controller already falls through to its page render in this case, and the backend controller now does the same. The new regression test fails without the fix, and a second test covers handlers that suppress the view.
