### PR TITLE
Guard the backend password reset against an unknown user id

### DIFF
--- a/modules/backend/controllers/Auth.php
+++ b/modules/backend/controllers/Auth.php
@@ -224,7 +224,7 @@ class Auth extends Controller
         $code = post('code');
         $user = BackendAuth::findUserById(post('id'));
 
-        if (!$user->checkResetPasswordCode($code)) {
+        if (!$user || !$user->checkResetPasswordCode($code)) {
             throw new ApplicationException(trans('backend::lang.account.reset_error'));
         }
 

--- a/modules/backend/tests/controllers/AuthResetTest.php
+++ b/modules/backend/tests/controllers/AuthResetTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Backend\Tests\Controllers;
+
+use Backend\Controllers\Auth;
+use Backend\Facades\BackendAuth;
+use Illuminate\Http\Request as HttpRequest;
+use Illuminate\Support\Facades\Request;
+use System\Tests\Bootstrap\PluginTestCase;
+use Winter\Storm\Exception\ApplicationException;
+
+class AuthResetTest extends PluginTestCase
+{
+    /**
+     * A reset submission for a user id that matches nobody must produce the generic reset
+     * error, not a fatal null dereference.
+     */
+    public function testResetWithUnknownUserIdFailsGracefully(): void
+    {
+        $this->assertNull(BackendAuth::findUserById(999999), 'Expected user id 999999 to be absent');
+
+        Request::swap(HttpRequest::create('/', 'POST', [
+            'id' => 999999,
+            'code' => 'bogus-code',
+            'password' => 'newpassword',
+        ]));
+
+        $this->expectException(ApplicationException::class);
+        $this->expectExceptionMessage(trans('backend::lang.account.reset_error'));
+
+        (new Auth)->reset_onSubmit();
+    }
+}


### PR DESCRIPTION
`findUserById()` returns null for a bogus `id`, and `reset_onSubmit()` dereferenced it, so junk POSTed to the reset form by bots turned into 500s. The guard reuses the generic reset error, which also avoids confirming whether an id exists. The regression test reproduces the null dereference without the fix.

Fixes #1509


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account password reset requests with an unknown user ID now fail gracefully with a generic reset error instead of causing an unexpected failure.

* **Tests**
  * Added coverage to verify the corrected behavior for unknown user IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->