### PR TITLE
Make error messages translatable.

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -174,7 +174,7 @@ class ListController extends ControllerBehavior
             if (!in_array(\Winter\Storm\Database\Traits\Sortable::class, class_uses_recursive($model))) {
                 throw new ApplicationException(Lang::get('backend::lang.lists.sortable_requirements', [
                     'model' => get_class($model),
-                    trait' => \Winter\Storm\Database\Traits\Sortable::class,
+                    'trait' => \Winter\Storm\Database\Traits\Sortable::class,
                 ]));
             }
 

--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -172,11 +172,10 @@ class ListController extends ControllerBehavior
          */
         if (!empty($listConfig->sortable)) {
             if (!in_array(\Winter\Storm\Database\Traits\Sortable::class, class_uses_recursive($model))) {
-                throw new ApplicationException(sprintf(
-                    'To use "sortable" on a list, the model "%s" must use the %s trait.',
-                    get_class($model),
-                    \Winter\Storm\Database\Traits\Sortable::class
-                ));
+                throw new ApplicationException(Lang::get('backend::lang.lists.sortable_requirements', [
+                    'model' => get_class($model),
+                    trait' => \Winter\Storm\Database\Traits\Sortable::class,
+                ]));
             }
 
             /*
@@ -192,10 +191,9 @@ class ListController extends ControllerBehavior
                 'defaultSort'    => $listConfig->defaultSort ?? null,
             ]));
             if ($conflicts) {
-                throw new ApplicationException(sprintf(
-                    'A "sortable" list cannot also use: %s. Drag-and-drop reordering requires the whole list in a fixed order. Remove these options, or use the ReorderController for a dedicated reordering page.',
-                    implode(', ', $conflicts)
-                ));
+                throw new ApplicationException(Lang::get('backend::lang.lists.sortable_conflicts', [
+                    'conflicts' => implode(', ', $conflicts),
+                ]));
             }
 
             $widget->bindEvent('list.reorder', function ($ids, $orders) use ($model) {

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -790,12 +790,11 @@ class RelationController extends ControllerBehavior
                     !in_array(\Winter\Storm\Database\Traits\HasSortableRelations::class, class_uses_recursive($this->model))
                     || !$this->model->isSortableRelation($this->relationName)
                 ) {
-                    throw new ApplicationException(sprintf(
-                        'To use "sortable" on the "%s" relation, the model "%s" must use the %s trait and declare the relation in $sortableRelations.',
-                        $this->relationName,
-                        get_class($this->model),
-                        \Winter\Storm\Database\Traits\HasSortableRelations::class
-                    ));
+                    throw new ApplicationException(Lang::get('backend::lang.relation.sortable_requirements', [
+                        'relation' => $this->relationName,
+                        'model' => get_class($this->model),
+                        'trait' => \Winter\Storm\Database\Traits\HasSortableRelations::class,
+                    ]));
                 }
 
                 /*
@@ -810,11 +809,10 @@ class RelationController extends ControllerBehavior
                     'defaultSort'    => $this->getConfig('view[defaultSort]'),
                 ]));
                 if ($conflicts) {
-                    throw new ApplicationException(sprintf(
-                        'The "%s" relation cannot combine "sortable" with: %s. Drag-and-drop reordering requires the whole relation in a fixed order. Remove these options, or use the ReorderController for a dedicated reordering page.',
-                        $this->relationName,
-                        implode(', ', $conflicts)
-                    ));
+                    throw new ApplicationException(Lang::get('backend::lang.relation.sortable_conflicts', [
+                        'relation' => $this->relationName,
+                        'conflicts' => implode(', ', $conflicts),
+                    ]));
                 }
 
                 $config->sortable = true;

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -372,6 +372,8 @@ return [
         'delete_confirm' => 'Are you sure?',
         'link' => 'Link',
         'link_name' => 'Link :name',
+        'sortable_requirements' => 'To use "sortable" on the ":relation" relation, the model ":model" must use the :trait trait and declare the relation in $sortableRelations.',
+        'sortable_conflicts' => 'The ":relation" relation cannot combine "sortable" with: :conflicts. Drag-and-drop reordering requires the whole relation in a fixed order. Remove these options, or use the ReorderController for a dedicated reordering page.',
         'unlink' => 'Unlink',
         'unlink_name' => 'Unlink :name',
         'unlink_confirm' => 'Are you sure?',

--- a/modules/backend/lang/en/lang.php
+++ b/modules/backend/lang/en/lang.php
@@ -246,6 +246,8 @@ return [
         'delete_selected_success' => 'Deleted selected records.',
         'column_switch_true' => 'Yes',
         'column_switch_false' => 'No',
+        'sortable_requirements' => 'To use "sortable" on a list, the model ":model" must use the :trait trait.',
+        'sortable_conflicts' => 'A "sortable" list cannot also use: :conflicts. Drag-and-drop reordering requires the whole list in a fixed order. Remove these options, or use the ReorderController for a dedicated reordering page.',
     ],
     'fileupload' => [
         'attachment' => 'Attachment',


### PR DESCRIPTION
The last PR to add sortable lists/relations and was using fixed strings for the error messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation messages for sortable lists and relations.
  * Errors now provide clearer details about required configuration, conflicting options, model traits, and fixed ordering constraints.

* **Localization**
  * Added English language strings for sortable behavior and relation validation messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->