### PR TITLE
Remove search widget and filters from conflicting options

### DIFF
--- a/modules/backend/behaviors/ListController.php
+++ b/modules/backend/behaviors/ListController.php
@@ -186,8 +186,6 @@ class ListController extends ControllerBehavior
              */
             $toolbar = $listConfig->toolbar ?? null;
             $conflicts = array_keys(array_filter([
-                'toolbar search' => is_array($toolbar) && !empty($toolbar['search']),
-                'filter'         => $listConfig->filter ?? null,
                 'recordsPerPage' => $listConfig->recordsPerPage ?? null,
                 'defaultSort'    => $listConfig->defaultSort ?? null,
             ]));

--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -804,8 +804,6 @@ class RelationController extends ControllerBehavior
                  * those combinations up front rather than silently producing a wrong order.
                  */
                 $conflicts = array_keys(array_filter([
-                    'showSearch'     => $this->getConfig('view[showSearch]'),
-                    'filter'         => $this->getConfig('view[filter]'),
                     'recordsPerPage' => $this->getConfig('view[recordsPerPage]'),
                     'defaultSort'    => $this->getConfig('view[defaultSort]'),
                 ]));


### PR DESCRIPTION
Search widget and filters should still be allowed when a list or a relation manager is set to sortable.

If the user wants to see all records for reordering, he can always clear the search box or remove the filters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sortable lists can now be configured with toolbar search and filtering.
  * Existing restrictions remain in place for pagination and custom sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->