### PR TITLE
Fix NestedForm falling back to the parent model when empty (#1522)

### DIFF
--- a/modules/backend/formwidgets/NestedForm.php
+++ b/modules/backend/formwidgets/NestedForm.php
@@ -48,7 +48,12 @@ class NestedForm extends FormWidgetBase
 
         $config = $this->makeConfig($this->form);
         $config->model = $this->model;
-        $config->data = $this->getLoadValue();
+        // Scope the nested form to its own value. When the field has no value yet,
+        // pass an empty array rather than null: a null data source makes the inner
+        // Form fall back to the parent model (Form::getModel()), which resolves
+        // sub-fields against the model's attributes and crashes when a sub-field
+        // name collides with a model attribute (e.g. a jsonable array). See #1522.
+        $config->data = $this->getLoadValue() ?: [];
         $config->alias = $this->alias . $this->defaultAlias;
         $config->arrayName = $this->getFieldName();
         $config->isNested = true;

--- a/modules/backend/tests/formwidgets/NestedFormScopingTest.php
+++ b/modules/backend/tests/formwidgets/NestedFormScopingTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Backend\Tests\FormWidgets
+{
+    use Backend\Classes\Controller;
+    use Backend\Classes\WidgetManager;
+    use Backend\FormWidgets\NestedForm;
+    use Backend\Widgets\Form;
+    use System\Tests\Bootstrap\PluginTestCase;
+    use Winter\Storm\Database\Model;
+
+    class NestedFormScopingTestModel extends Model
+    {
+        public $table = 'nested_form_scoping_test';
+
+        protected $jsonable = ['content'];
+
+        protected $fillable = ['content'];
+    }
+
+    /**
+     * Covers NestedForm data scoping.
+     *
+     * An empty nested form must scope its inner form to its own (empty) value rather
+     * than falling back to the parent model. When it fell back to the model, a
+     * sub-field whose name collided with a model attribute resolved the model's value
+     * — and rendering an array attribute as, say, a textarea threw
+     * "Array to string conversion".
+     *
+     * @see https://github.com/wintercms/winter/issues/1522
+     */
+    class NestedFormScopingTest extends PluginTestCase
+    {
+        public function setUp(): void
+        {
+            parent::setUp();
+
+            // The nestedform alias is not auto-registered under PluginTestCase.
+            WidgetManager::instance()->registerFormWidget(NestedForm::class, 'nestedform');
+        }
+
+        protected function makeForm(Model $model): Form
+        {
+            return new Form(new Controller, [
+                'model' => $model,
+                'arrayName' => 'array',
+                'fields' => [
+                    'meta' => [
+                        'type' => 'nestedform',
+                        'form' => [
+                            'fields' => [
+                                // "content" deliberately collides with the model attribute.
+                                'content' => ['type' => 'textarea'],
+                                'title' => ['type' => 'text'],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+        }
+
+        public function testEmptyNestedFormDoesNotResolveSubFieldsFromParentModel()
+        {
+            $model = new NestedFormScopingTestModel;
+            // A jsonable array attribute on the model root, sharing a name with a nested
+            // sub-field, while the nested form itself has no value.
+            $model->content = [['data' => ['deep' => 'value']]];
+
+            $inner = $this->getInnerForm($this->makeForm($model));
+            $inner->getFields();
+
+            $contentField = $inner->getField('content');
+            $this->assertNotNull($contentField);
+
+            // The sub-field must be scoped to the empty nested value, NOT the model's
+            // root array.
+            $this->assertNotSame($model->content, $contentField->value);
+            $this->assertEmpty($contentField->value);
+        }
+
+        public function testPopulatedNestedFormStillResolvesItsOwnValues()
+        {
+            $model = new NestedFormScopingTestModel;
+            $model->content = [['data' => ['deep' => 'value']]]; // model root (should be ignored)
+            $model->meta = ['content' => 'nested content', 'title' => 'nested title'];
+
+            $inner = $this->getInnerForm($this->makeForm($model));
+            $inner->getFields();
+
+            // The nested value wins over the colliding model attribute.
+            $this->assertSame('nested content', $inner->getField('content')->value);
+            $this->assertSame('nested title', $inner->getField('title')->value);
+        }
+
+        protected function getInnerForm(Form $form): Form
+        {
+            // Defining the parent's fields builds and caches its nested form widget.
+            $form->bindToController();
+
+            $nested = $form->getFormWidget('meta');
+            $this->assertInstanceOf(NestedForm::class, $nested);
+
+            $inner = \Closure::bind(fn () => $this->formWidget, $nested, NestedForm::class)();
+            $this->assertInstanceOf(Form::class, $inner);
+
+            return $inner;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #1522.

A `nestedform` field whose sub-field name collides with a model attribute crashes the whole form with `ErrorException: Array to string conversion` when the nested form has no value — most visibly when the model attribute is a `$jsonable` array.

## Root cause

`NestedForm::init()` passed the field's load value straight to the inner `Form`'s `data`:

```php
$config->data = $this->getLoadValue();
```

When the field has no value, `getLoadValue()` returns `null`. `Form::getModel()` then does:

```php
$this->data = isset($this->data) ? (object) $this->data : $this->model;
```

`isset()` is `false` for `null`, so the inner form falls back to the **parent model** as its data source. Sub-fields then resolve their values from the model's attributes *by name*, so a sub-field named e.g. `content` picks up `$model->content` — and rendering an array value as a textarea throws `Array to string conversion`, taking down the form.

## Fix

Scope the nested form to its own value; pass an empty array instead of `null` so it never reaches the parent model:

```php
$config->data = $this->getLoadValue() ?: [];
```

## Tests

Adds `modules/backend/tests/formwidgets/NestedFormScopingTest.php`:

- **`testEmptyNestedFormDoesNotResolveSubFieldsFromParentModel`** — an empty nested form with a `content` sub-field, on a model whose root `content` is a jsonable array, must resolve the sub-field to empty (not the model's array). Fails without the fix ("two arrays are not identical"), passes with it.
- **`testPopulatedNestedFormStillResolvesItsOwnValues`** — a populated nested form still resolves its own values (the nested value wins over the colliding model attribute).

Full `modules/backend/tests/widgets` + `modules/backend/tests/formwidgets` suites pass (85 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed empty nested forms incorrectly resolving fields from the parent record.
  * Prevented crashes when nested field names overlap with parent model attributes.
  * Preserved correct value handling for populated nested forms.

* **Tests**
  * Added coverage for empty and populated nested form field scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->