### PR TITLE
Fix vite:watch advertising an unreachable dev-server URL on IPv6 hosts

### DIFF
--- a/modules/system/console/asset/vite/ViteWatch.php
+++ b/modules/system/console/asset/vite/ViteWatch.php
@@ -21,6 +21,7 @@ class ViteWatch extends ViteCompile
         {--m|manifest= : Defines package.json to use for compile}
         {--s|silent : Enables silent mode, no output will be shown.}
         {--d|disable-tty : Disable tty mode}
+        {--host=localhost : Host the Vite dev server binds to and advertises in the hot file (use 0.0.0.0 for LAN/container access)}
         {--no-progress : Do not show mix progress}';
 
     /**
@@ -52,7 +53,12 @@ class ViteWatch extends ViteCompile
         $key = array_search('build', $command);
         unset($command[$key]);
 
+        // Bind the dev server to a concrete, reachable host and advertise it in
+        // the hot file. A bare `--host` binds all interfaces, which makes the
+        // Laravel Vite plugin write an unreachable `http://[::]:5173` on IPv6
+        // hosts. Default to `localhost`; pass `--host=0.0.0.0` for LAN access.
         $command[] = '--host';
+        $command[] = $this->option('host');
 
         return array_values($command);
     }


### PR DESCRIPTION
Fixes #1525.

### Problem

`vite:watch` appends a bare `--host` flag, binding the Vite dev server to all interfaces. On an IPv6-enabled host (e.g. macOS) the `laravel-vite-plugin` then resolves the dev-server URL to `[::]` and writes `http://[::]:5173` into `<package>/assets/dist/hot`. The backend emits asset/HMR URLs pointing at that address, which **a browser cannot connect to** — so the backend loads unstyled and HMR never engages. Because the forced `--host` is appended last, a user-supplied `--host localhost` in `viteArgs` is overridden, so there was no CLI-only workaround.

### Fix

Add a `--host` option (default `localhost`) and pass its value to Vite, so the hot file advertises a reachable URL out of the box:

```
php artisan vite:watch Winter.TailwindUI                 # binds localhost -> hot file: http://localhost:5173
php artisan vite:watch Winter.TailwindUI --host=0.0.0.0  # all interfaces, for LAN/container dev
```

### Behaviour change

The default bind changes from all-interfaces to `localhost`. LAN/Docker/Homestead workflows that relied on the dev server being reachable from other hosts opt back in with `--host=0.0.0.0`. Flagging this explicitly in case a different default is preferred (e.g. keeping all-interfaces and instead making the advertised URL reachable another way) — happy to adjust.

### Verified locally

- Before: `assets/dist/hot` → `http://[::]:5173` (unreachable)
- After (default): `assets/dist/hot` → `http://localhost:5173`; backend loads `@vite/client`, `app.js`, `app.css` from the dev server and HMR round-trips a source CSS edit live.

@jaxwilko tagging you for review since this touches the `--host` behaviour from the original vite command abstraction (c847c1a).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a host option to the Vite watch command, defaulting to `localhost`.
  * Supports binding the development server to `0.0.0.0` for LAN or container access.
  * The configured host is now advertised correctly for development connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->