### PR TITLE
Add accessible names to datepicker and single fileupload widgets

### DIFF
--- a/modules/backend/formwidgets/datepicker/partials/_picker_date.php
+++ b/modules/backend/formwidgets/datepicker/partials/_picker_date.php
@@ -1,11 +1,16 @@
 <!-- Date -->
+<?php /* The field's <label for> targets the hidden data-locker input, leaving this
+        visible text box without an accessible name (WCAG 1.3.1 / 4.1.2). Name it directly. */ ?>
 <div class="input-with-icon right-align">
-    <i class="icon icon-calendar-o"></i>
+    <i class="icon icon-calendar-o" aria-hidden="true"></i>
     <input
         type="text"
         id="<?= $this->getId('date') ?>"
         class="form-control align-right"
         autocomplete="off"
+        <?php if ($field->label): ?>
+            aria-label="<?= e(trans($field->label)) ?>"
+        <?php endif ?>
         <?= $field->getAttributes() ?>
         data-datepicker />
 </div>

--- a/modules/backend/formwidgets/datepicker/partials/_picker_time.php
+++ b/modules/backend/formwidgets/datepicker/partials/_picker_time.php
@@ -1,11 +1,17 @@
 <!-- Time -->
+<?php /* Same as _picker_date.php — the field's <label for> targets the hidden data-locker
+        input, leaving this visible text box without an accessible name (WCAG 1.3.1 / 4.1.2).
+        "(time)" distinguishes it from the date box in datetime mode, where both share the label. */ ?>
 <div class="input-with-icon right-align">
-    <i class="icon icon-clock-o"></i>
+    <i class="icon icon-clock-o" aria-hidden="true"></i>
     <input
         type="text"
         id="<?= $this->getId('time') ?>"
         class="form-control align-right"
         autocomplete="off"
+        <?php if ($field->label): ?>
+            aria-label="<?= e(trans($field->label)) ?> (time)"
+        <?php endif ?>
         <?= $field->getAttributes() ?>
         data-timepicker />
 </div>

--- a/modules/backend/formwidgets/fileupload/partials/_file_single.php
+++ b/modules/backend/formwidgets/fileupload/partials/_file_single.php
@@ -16,8 +16,10 @@
 >
 
     <!-- Upload Button -->
+    <?php /* Core renders an icon-only button with no accessible name (WCAG 4.1.2). */ ?>
     <button type="button" class="btn btn-default upload-button">
-        <i class="<?= e($iconClass) ?>"></i>
+        <i class="<?= e($iconClass) ?>" aria-hidden="true"></i>
+        <span class="sr-only"><?= e(trans('backend::lang.fileupload.upload_file')) ?></span>
     </button>
 
     <!-- Existing file -->


### PR DESCRIPTION
Adds accessible names to two backend form-widget partials. These are **purely additive ARIA** changes — no markup structure, CSS class, or behaviour changes, so nothing else in the backend is affected.

### Changes

**Datepicker** (`_picker_date.php`, `_picker_time.php`)
- The field's `<label for>` targets the hidden `data-locker` input, leaving the *visible* date/time text boxes without an accessible name (WCAG 1.3.1 / 4.1.2). Add `aria-label` from the field label — the time box is suffixed `(time)` so it's distinguishable from the date box in datetime mode, where both share one label.
- `aria-hidden="true"` on the decorative calendar/clock icons.

**Single fileupload** (`_file_single.php`)
- The icon-only upload button had no accessible name (WCAG 4.1.2). Add an `sr-only` label (using the existing `backend::lang.fileupload.upload_file` string) and `aria-hidden="true"` on the icon.

### Notes
- `aria-label` is only emitted when the field has a label, so unlabelled fields are unchanged.
- `.sr-only` is already defined in `storm.css` (loaded on every backend page).
- Verified live in the backend: the datepicker inputs now expose `aria-label="<field label>"` / `"<field label> (time)"` and the icons are hidden from assistive tech.

Extracted from a downstream site's theme-level partial overrides so the fix lives upstream once and the override can be dropped. (Related follow-ups — native-select dropdown, balloon-selector keyboard support, heading semantics — were intentionally left out as they carry behaviour/UX changes unsuitable for core.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved screen reader support for date and time picker fields with accessible labels.
  * Marked decorative calendar and clock icons as hidden from assistive technologies.
  * Added an accessible name to the file upload button while keeping its visual appearance unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->