### PR TITLE
Let fieldset form widget fields resolve against the parent form's scope

### DIFF
--- a/modules/backend/formwidgets/FieldSet.php
+++ b/modules/backend/formwidgets/FieldSet.php
@@ -48,16 +48,19 @@ class FieldSet extends FormWidgetBase
             $this->previewMode = true;
         }
 
+        $parentForm = $this->getParentForm();
+
         $config = $this->makeConfig(['fields' => $this->fields]);
         $config->model = $this->model;
         $config->data = $this->getLoadValue();
         $config->alias = $this->alias . $this->defaultAlias;
         // set arrayName from parent form to save fields to the model
-        $config->arrayName = $this->getParentForm()->arrayName;
-        // the fields are nested visually only; they resolve against the parent
-        // form's model and array name, exactly as if defined on the parent form
+        $config->arrayName = $parentForm->arrayName;
         $config->isNested = true;
-        $config->sharesParentScope = true;
+        // the fields are grouped visually only, so they resolve wherever the parent
+        // form's own fields resolve - on the model, unless the parent is itself a
+        // nested form that brought its own data scope (ie. a repeater item)
+        $config->sharesModelScope = !$parentForm->isNested || $parentForm->sharesModelScope;
 
         $widget = $this->formWidget = $this->makeWidget(Form::class, $config);
         $widget->previewMode = $this->previewMode;

--- a/modules/backend/formwidgets/FieldSet.php
+++ b/modules/backend/formwidgets/FieldSet.php
@@ -54,7 +54,10 @@ class FieldSet extends FormWidgetBase
         $config->alias = $this->alias . $this->defaultAlias;
         // set arrayName from parent form to save fields to the model
         $config->arrayName = $this->getParentForm()->arrayName;
+        // the fields are nested visually only; they resolve against the parent
+        // form's model and array name, exactly as if defined on the parent form
         $config->isNested = true;
+        $config->sharesParentScope = true;
 
         $widget = $this->formWidget = $this->makeWidget(Form::class, $config);
         $widget->previewMode = $this->previewMode;

--- a/modules/backend/tests/widgets/FormFieldSetScopeTest.php
+++ b/modules/backend/tests/widgets/FormFieldSetScopeTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Backend\Tests\Widgets
+{
+    use Backend\Classes\Controller;
+    use Backend\Classes\WidgetManager;
+    use Backend\FormWidgets\FieldSet;
+    use Backend\FormWidgets\NestedForm;
+    use Backend\Widgets\Form;
+    use System\Tests\Bootstrap\PluginTestCase;
+    use Winter\Storm\Database\Model;
+    use Winter\Storm\Database\Traits\Validation;
+
+    class FormFieldSetScopeTestModel extends Model
+    {
+        use Validation;
+
+        public $table = 'form_fieldset_scope_test';
+
+        public $rules = [
+            // Resolved as-is by a scope sharing form (fieldset)...
+            'nested_text' => 'required',
+            // ...and prefixed with the nested form's own scope by a regular nested form.
+            'meta.title' => 'required',
+        ];
+    }
+
+    /**
+     * Covers the data scope of the `fieldset` form widget's inner form.
+     *
+     * A fieldset nests fields visually only: its inner form reuses the parent form's
+     * model and arrayName, and its save data is merged back up as if the fields had
+     * been declared on the parent form. It is therefore flagged as sharing the parent's
+     * scope, while remaining flagged as nested so that code extending form widgets can
+     * still tell it apart from the form it is nested in.
+     */
+    class FormFieldSetScopeTest extends PluginTestCase
+    {
+        public function setUp(): void
+        {
+            parent::setUp();
+
+            // The backend module's form widgets are not auto-registered under PluginTestCase.
+            WidgetManager::instance()->registerFormWidget(FieldSet::class, 'fieldset');
+            WidgetManager::instance()->registerFormWidget(NestedForm::class, 'nestedform');
+        }
+
+        protected function makeForm(): Form
+        {
+            return new Form(new Controller, [
+                'model' => new FormFieldSetScopeTestModel,
+                'arrayName' => 'array',
+                'fields' => [
+                    'group' => [
+                        'type' => 'fieldset',
+                        'label' => 'Grouped Fields',
+                        'fields' => [
+                            'nested_text' => ['type' => 'text'],
+                            'nested_other' => ['type' => 'text'],
+                        ],
+                    ],
+                    'meta' => [
+                        'type' => 'nestedform',
+                        'form' => [
+                            'fields' => [
+                                'title' => ['type' => 'text'],
+                                'subtitle' => ['type' => 'text'],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+        }
+
+        public function testFieldSetInnerFormIsStillFlaggedAsNested()
+        {
+            // Extending code uses isNested to avoid injecting fields on the wrong Form
+            // widget instance; a fieldset shares its parent's model and controller, so
+            // the flag must stay set or those guards would no longer hold.
+            $this->assertTrue($this->getInnerForm('group', FieldSet::class)->isNested);
+        }
+
+        public function testFieldSetInnerFormSharesTheParentScope()
+        {
+            $this->assertTrue($this->getInnerForm('group', FieldSet::class)->sharesParentScope);
+        }
+
+        public function testFormsDoNotShareTheParentScopeByDefault()
+        {
+            $this->assertFalse($this->makeForm()->sharesParentScope);
+            $this->assertFalse($this->getInnerForm('meta', NestedForm::class)->sharesParentScope);
+        }
+
+        public function testFieldSetFieldsResolveRequiredAgainstTheModelAttribute()
+        {
+            $inner = $this->getInnerForm('group', FieldSet::class);
+            $inner->getFields();
+
+            // The rule is defined as "nested_text", not ".nested_text": a scope sharing
+            // form must not prefix the attribute name with its (inherited) arrayName.
+            $this->assertTrue($inner->getField('nested_text')->required);
+            $this->assertFalse($inner->getField('nested_other')->required);
+        }
+
+        public function testNestedFormFieldsStillResolveRequiredAgainstTheNestedAttribute()
+        {
+            $inner = $this->getInnerForm('meta', NestedForm::class);
+            $inner->getFields();
+
+            // A regular nested form owns its data scope, so the attribute name is still
+            // prefixed with it: the rule is defined as "meta.title".
+            $this->assertTrue($inner->getField('title')->required);
+            $this->assertFalse($inner->getField('subtitle')->required);
+        }
+
+        protected function getInnerForm(string $field, string $widgetClass): Form
+        {
+            $form = $this->makeForm();
+
+            // Defining the parent's fields builds and caches its nested form widgets.
+            $form->bindToController();
+
+            $widget = $form->getFormWidget($field);
+            $this->assertInstanceOf($widgetClass, $widget);
+
+            $inner = \Closure::bind(fn () => $this->formWidget, $widget, $widgetClass)();
+            $this->assertInstanceOf(Form::class, $inner);
+
+            return $inner;
+        }
+    }
+}

--- a/modules/backend/tests/widgets/FormFieldSetScopeTest.php
+++ b/modules/backend/tests/widgets/FormFieldSetScopeTest.php
@@ -6,6 +6,7 @@ namespace Backend\Tests\Widgets
     use Backend\Classes\WidgetManager;
     use Backend\FormWidgets\FieldSet;
     use Backend\FormWidgets\NestedForm;
+    use Backend\FormWidgets\Repeater;
     use Backend\Widgets\Form;
     use System\Tests\Bootstrap\PluginTestCase;
     use Winter\Storm\Database\Model;
@@ -17,22 +18,28 @@ namespace Backend\Tests\Widgets
 
         public $table = 'form_fieldset_scope_test';
 
+        protected $jsonable = ['items'];
+
         public $rules = [
-            // Resolved as-is by a scope sharing form (fieldset)...
+            // Resolved as-is by a form that brings no data scope of its own (fieldset)...
             'nested_text' => 'required',
-            // ...and prefixed with the nested form's own scope by a regular nested form.
+            // ...and prefixed with its own scope by a form that does.
             'meta.title' => 'required',
+            'items.*.title' => 'required',
         ];
     }
 
     /**
      * Covers the data scope of the `fieldset` form widget's inner form.
      *
-     * A fieldset nests fields visually only: its inner form reuses the parent form's
-     * model and arrayName, and its save data is merged back up as if the fields had
-     * been declared on the parent form. It is therefore flagged as sharing the parent's
-     * scope, while remaining flagged as nested so that code extending form widgets can
-     * still tell it apart from the form it is nested in.
+     * A fieldset groups fields visually only: its inner form reuses the parent form's
+     * model and arrayName, and its save data is merged back up as if the fields had been
+     * declared on the parent form. It is therefore flagged as sharing the model's scope,
+     * while remaining flagged as nested so that code extending form widgets can still
+     * tell it apart from the form it is nested in.
+     *
+     * The scope it inherits is only the model's when the parent form's own is: nested
+     * inside a repeater item, a fieldset's fields still belong to the repeater's data.
      */
     class FormFieldSetScopeTest extends PluginTestCase
     {
@@ -43,12 +50,16 @@ namespace Backend\Tests\Widgets
             // The backend module's form widgets are not auto-registered under PluginTestCase.
             WidgetManager::instance()->registerFormWidget(FieldSet::class, 'fieldset');
             WidgetManager::instance()->registerFormWidget(NestedForm::class, 'nestedform');
+            WidgetManager::instance()->registerFormWidget(Repeater::class, 'repeater');
         }
 
         protected function makeForm(): Form
         {
+            $model = new FormFieldSetScopeTestModel;
+            $model->items = [['title' => 'first']];
+
             return new Form(new Controller, [
-                'model' => new FormFieldSetScopeTestModel,
+                'model' => $model,
                 'arrayName' => 'array',
                 'fields' => [
                     'group' => [
@@ -68,6 +79,20 @@ namespace Backend\Tests\Widgets
                             ],
                         ],
                     ],
+                    'items' => [
+                        'type' => 'repeater',
+                        'form' => [
+                            'fields' => [
+                                'group' => [
+                                    'type' => 'fieldset',
+                                    'fields' => [
+                                        'title' => ['type' => 'text'],
+                                        'subtitle' => ['type' => 'text'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
                 ],
             ]);
         }
@@ -77,46 +102,76 @@ namespace Backend\Tests\Widgets
             // Extending code uses isNested to avoid injecting fields on the wrong Form
             // widget instance; a fieldset shares its parent's model and controller, so
             // the flag must stay set or those guards would no longer hold.
-            $this->assertTrue($this->getInnerForm('group', FieldSet::class)->isNested);
+            $this->assertTrue($this->getFieldSetForm()->isNested);
         }
 
-        public function testFieldSetInnerFormSharesTheParentScope()
+        public function testFieldSetInnerFormSharesTheModelScope()
         {
-            $this->assertTrue($this->getInnerForm('group', FieldSet::class)->sharesParentScope);
+            $this->assertTrue($this->getFieldSetForm()->sharesModelScope);
         }
 
-        public function testFormsDoNotShareTheParentScopeByDefault()
+        public function testFormsDoNotShareTheModelScopeByDefault()
         {
-            $this->assertFalse($this->makeForm()->sharesParentScope);
-            $this->assertFalse($this->getInnerForm('meta', NestedForm::class)->sharesParentScope);
+            $this->assertFalse($this->makeForm()->sharesModelScope);
+            $this->assertFalse($this->getInnerForm($this->makeForm(), 'meta', NestedForm::class)->sharesModelScope);
         }
 
         public function testFieldSetFieldsResolveRequiredAgainstTheModelAttribute()
         {
-            $inner = $this->getInnerForm('group', FieldSet::class);
+            $inner = $this->getFieldSetForm();
             $inner->getFields();
 
-            // The rule is defined as "nested_text", not ".nested_text": a scope sharing
-            // form must not prefix the attribute name with its (inherited) arrayName.
+            // The rule is defined as "nested_text", not ".nested_text": a fieldset brings
+            // no scope of its own, so there is nothing to prefix the attribute name with.
             $this->assertTrue($inner->getField('nested_text')->required);
             $this->assertFalse($inner->getField('nested_other')->required);
         }
 
         public function testNestedFormFieldsStillResolveRequiredAgainstTheNestedAttribute()
         {
-            $inner = $this->getInnerForm('meta', NestedForm::class);
+            $inner = $this->getInnerForm($this->makeForm(), 'meta', NestedForm::class);
             $inner->getFields();
 
-            // A regular nested form owns its data scope, so the attribute name is still
-            // prefixed with it: the rule is defined as "meta.title".
+            // A nested form owns its data scope, so the attribute name is still prefixed
+            // with it: the rule is defined as "meta.title".
             $this->assertTrue($inner->getField('title')->required);
             $this->assertFalse($inner->getField('subtitle')->required);
         }
 
-        protected function getInnerForm(string $field, string $widgetClass): Form
+        public function testFieldSetInsideARepeaterKeepsTheRepeaterItemScope()
+        {
+            $inner = $this->getInnerForm($this->getRepeaterItemForm(), 'group', FieldSet::class);
+            $inner->getFields();
+
+            // The fieldset inherits the repeater item's array name, so its fields belong
+            // to the repeater's data, not to the model's attributes. The rule is defined
+            // as "items.*.title" and the inherited scope must still be applied.
+            $this->assertFalse($inner->sharesModelScope);
+            $this->assertTrue($inner->getField('title')->required);
+            $this->assertFalse($inner->getField('subtitle')->required);
+        }
+
+        protected function getFieldSetForm(): Form
+        {
+            return $this->getInnerForm($this->makeForm(), 'group', FieldSet::class);
+        }
+
+        protected function getRepeaterItemForm(): Form
         {
             $form = $this->makeForm();
+            $form->bindToController();
 
+            $repeater = $form->getFormWidget('items');
+            $this->assertInstanceOf(Repeater::class, $repeater);
+
+            $itemForms = \Closure::bind(fn () => $this->formWidgets, $repeater, Repeater::class)();
+            $this->assertArrayHasKey(0, $itemForms);
+
+            return $itemForms[0];
+        }
+
+        protected function getInnerForm(Form $form, string $field, string $widgetClass): Form
+        {
             // Defining the parent's fields builds and caches its nested form widgets.
             $form->bindToController();
 

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -74,6 +74,15 @@ class Form extends WidgetBase
      */
     public $isNested = false;
 
+    /**
+     * @var bool Used to flag that this nested form shares the data scope of its parent
+     * form; ie. its fields resolve against the same model attributes and array name as
+     * if they had been defined on the parent form directly. Only relevant when
+     * $isNested is true. Used by the fieldset form widget, which nests fields visually
+     * without introducing a new data scope.
+     */
+    public $sharesParentScope = false;
+
     //
     // Object properties
     //
@@ -138,6 +147,7 @@ class Form extends WidgetBase
             'context',
             'arrayName',
             'isNested',
+            'sharesParentScope',
         ]);
 
         $this->widgetManager = WidgetManager::instance();
@@ -881,8 +891,9 @@ class Form extends WidgetBase
          * Check model if field is required
          */
         if ($field->required === null && $this->model && method_exists($this->model, 'isAttributeRequired')) {
-            // Check nested fields
-            if ($this->isNested) {
+            // Check nested fields, unless the nested form shares its parent's data
+            // scope, in which case the attribute name needs no prefixing
+            if ($this->isNested && !$this->sharesParentScope) {
                 // Get the current attribute level
                 $nameArray = HtmlHelper::nameToArray($this->arrayName);
                 unset($nameArray[0]);

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -75,13 +75,14 @@ class Form extends WidgetBase
     public $isNested = false;
 
     /**
-     * @var bool Used to flag that this nested form shares the data scope of its parent
-     * form; ie. its fields resolve against the same model attributes and array name as
-     * if they had been defined on the parent form directly. Only relevant when
-     * $isNested is true. Used by the fieldset form widget, which nests fields visually
-     * without introducing a new data scope.
+     * @var bool Used to flag that this nested form introduces no data scope of its own,
+     * so that its fields resolve against the model's own attributes exactly as if they
+     * had been defined on the form it is nested in. Only meaningful when $isNested is
+     * true. Set by the fieldset form widget, which groups fields visually; a fieldset
+     * nested inside a repeater or nested form leaves this false, since the scope it
+     * inherits there is that form's data rather than the model's attributes.
      */
-    public $sharesParentScope = false;
+    public $sharesModelScope = false;
 
     //
     // Object properties
@@ -147,7 +148,7 @@ class Form extends WidgetBase
             'context',
             'arrayName',
             'isNested',
-            'sharesParentScope',
+            'sharesModelScope',
         ]);
 
         $this->widgetManager = WidgetManager::instance();
@@ -891,9 +892,8 @@ class Form extends WidgetBase
          * Check model if field is required
          */
         if ($field->required === null && $this->model && method_exists($this->model, 'isAttributeRequired')) {
-            // Check nested fields, unless the nested form shares its parent's data
-            // scope, in which case the attribute name needs no prefixing
-            if ($this->isNested && !$this->sharesParentScope) {
+            // Check nested fields
+            if ($this->isNested) {
                 // Get the current attribute level
                 $nameArray = HtmlHelper::nameToArray($this->arrayName);
                 unset($nameArray[0]);
@@ -905,8 +905,12 @@ class Form extends WidgetBase
                     }
                 }
 
-                // Recombine names for full attribute name in rules array
-                $attrName = implode('.', $nameArray) . ".{$attrName}";
+                // Recombine names for full attribute name in rules array. A nested form
+                // that introduces no data scope of its own (ie. the fieldset widget, which
+                // inherits its parent's array name) leaves nothing to prefix with.
+                if ($prefix = implode('.', $nameArray)) {
+                    $attrName = "{$prefix}.{$attrName}";
+                }
             }
 
             $field->required = $this->model->isAttributeRequired($attrName);


### PR DESCRIPTION
> **Companion PR:** wintercms/wn-translate-plugin#121 — the plugin side of this change.

Alternative to #1528, addressing @LukeTowers' [concern](https://github.com/wintercms/winter/pull/1528#pullrequestreview-5016615689) there that dropping `isNested` breaks extensions which use it to avoid injecting fields on the wrong Form widget instance. Opened at his invitation.

### The problem

`isNested` currently carries two meanings:

1. **"this Form widget is a child of another Form widget"** — what extension guards use it for. `LukeTowers.EasyAudit`, `Winter.Pages` and `Winter.TailwindUI` all pair it with a `model instanceof` / controller check.
2. **"this form's data scope differs from the model's attributes"** — what the docblock describes ("a good indicator to expect that the form model and dataset values will differ"), and what core and `Winter.Translate` use it for.

For `repeater` and `nestedform` both hold. For `fieldset` only the first does: it reuses the parent form's model *and* its `arrayName`, and merges its `getSaveData()` straight back up, so its fields are model attributes exactly as if they had been declared on the parent form.

Conflating the two breaks two things:

- **`Winter.Translate` skips the form.** Translatable attributes grouped inside a fieldset never get their `ml*` widget. This is what #1528 set out to fix.
- **Required-detection is wrong.** `makeFormField()` prefixes the attribute name for nested forms. With the fieldset's inherited `arrayName` that yields `isAttributeRequired('.website_name')` for a parent `arrayName` of `Settings` — a name that can never match a rule — so `required` is silently never auto-detected from model rules for fieldset fields.

Dropping the flag as #1528 does fixes both, but a fieldset's inner form shares the parent's model *and* controller, so those three plugins would then inject a duplicate Activity Log tab / Preview tab / brand fields inside the fieldset.

### The change

Two parts, which turned out to be independent:

1. **Required-detection.** The prefixing itself is correct whenever there is a prefix to apply; it only breaks when a fieldset inherits a bare parent `arrayName` and there is nothing left after dropping the root. Guarding the empty prefix fixes the top level case and leaves every genuinely nested form untouched — including a fieldset inside a repeater item, which inherits `items[0]` and must keep resolving `items.*.field`.
2. **A flag for extensions.** `Form::$sharesModelScope` answers whether a nested form's fields resolve against the model's own attributes. `FieldSet` derives it from the form it is nested in, so it is `true` at the top level and `false` inside a repeater or nested form, whose data it actually holds. Core does not read it — like `isNested`, it exists for extending code; `Winter.Translate` is the first consumer.

`isNested` stays `true` on the fieldset's inner form throughout.

### Backwards compatibility

No break. `isNested` remains `true` on the fieldset's inner form, so every existing guard — in core, in first-party plugins and in third-party code — behaves exactly as it does today. The new property defaults to `false`, so `repeater`, `nestedform` and any custom nested form are unaffected.

### Tests

`modules/backend/tests/widgets/FormFieldSetScopeTest.php` covers both halves of the change. Each test was confirmed to discriminate by running it against `develop`:

| Test | Against `develop` | Against #1528 |
| --- | --- | --- |
| inner form is still flagged as nested | passes | **fails** |
| inner form shares the model scope | **fails** | **fails** |
| forms do not share the model scope by default | **fails** | **fails** |
| fieldset fields resolve `required` against the model attribute | **fails** | passes |
| nested form fields still resolve `required` against the nested attribute | passes | passes |
| fieldset inside a repeater keeps the repeater item scope | **fails** | passes |

The first row is the regression @LukeTowers raised, the fourth is the required-detection bug, and the last is the repeater case @coderabbitai caught on the first revision of this PR. Full core suite green with the change: 800 tests, 2993 assertions, 0 failures.

### Manual verification

Tested on a settings model with 22 translatable attributes, all of them inside `type: fieldset` groups, with a companion change in `Winter.Translate` (wintercms/wn-translate-plugin#121) that checks the new flag:

- with this change, all 22 render as `ml*` widgets inside the fieldset;
- with `Winter.Translate`'s original `$widget->isNested` guard restored, 0 — confirming the inner form still reports `isNested === true`, so nothing that relies on that flag is affected.

The attribute-name computation was confirmed separately: for a parent `arrayName` of `Settings`, the nested branch produces `'.website_name'`, and `'Post[options]'` produces `'options.website_name'` — correct for a real nested form, wrong for a fieldset.

### Related

- Supersedes #1528 (same goal, without the BC break) — @mjauvin, happy to close this in favour of yours if you'd rather carry it.
- Plugin side: wintercms/wn-translate-plugin#121 (merge-safe in either order; without this PR its `property_exists()` check is `false` and behaviour is unchanged).
- Docs note for `Form::$sharesModelScope` to follow if you want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation handling for fields inside fieldsets, nested forms, and repeater items.
  * Required-field validation now correctly resolves model attributes and nested field paths.
  * Fixed data-scope inheritance for fieldsets, including fieldsets nested within repeater items.
* **Tests**
  * Added coverage for nested form and fieldset validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->