### PR TITLE
Resolve nested relations against the innermost ancestor

### DIFF
--- a/modules/backend/behaviors/RelationController.php
+++ b/modules/backend/behaviors/RelationController.php
@@ -536,8 +536,13 @@ class RelationController extends ControllerBehavior
      *  a) AMBIENT - the nesting stack is non-empty, meaning a manage
      *     form is actively rendering right now (see
      *     relationMakePartial()) and this field is nested directly
-     *     under whatever's on top of it. $model is trusted as-is - it's
-     *     the widget's own bound model.
+     *     under whatever's on top of it. $model canNOT be trusted
+     *     here: initRelation() is reached as
+     *     relationRender() -> validateField() -> initRelation($this->model),
+     *     and $this->model is the record of the ENCLOSING relation,
+     *     not of the manage form actually rendering. Those coincide at
+     *     one level of nesting and diverge at two, so the parent is
+     *     walked from the root exactly as in (b).
      *  b) RECONSTRUCTED - $field is already a bracket path (e.g.
      *     "items[5][taxes]"), walked from the root to find the actual
      *     model. This is the common case for anything other than an
@@ -574,7 +579,9 @@ class RelationController extends ControllerBehavior
 
         if ($ambientPath !== null) {
             $this->nestedField = $ambientPath . '[' . $field . ']';
-            return [$model, $field, true];
+            [$hops] = $this->parseBracketField($this->nestedField);
+
+            return [$this->resolveModelForHops($this->rootModel, $hops), $field, true];
         }
 
         if (strpos($field, '[') !== false) {

--- a/modules/backend/tests/behaviors/RelationControllerNestedTest.php
+++ b/modules/backend/tests/behaviors/RelationControllerNestedTest.php
@@ -919,6 +919,57 @@ class RelationControllerNestedTest extends PluginTestCase
     }
 
     /**
+     * Two levels of ambient nesting - an Item's manage form rendering
+     * a sub-item's manage form, which itself renders a relation field.
+     *
+     * The model RelationManager hands initRelation() is always
+     * $this->model, i.e. the record of the ENCLOSING relation. At one
+     * level of nesting that IS the parent, so trusting it works. At
+     * two it is the grandparent, and trusting it resolves the leaf
+     * relation against the wrong ancestor - in the real world a
+     * BadMethodCallException, since the grandparent's class usually
+     * has no such relation at all.
+     */
+    public function testAmbientFieldTwoLevelsDeepResolvesInnermostAncestorNotEnclosingRecord()
+    {
+        $order = RelationTestOrder::create(['name' => 'Order 1']);
+        $itemA = RelationTestItem::create(['order_id' => $order->id, 'name' => 'Item A']);
+        $subItem = RelationTestItem::create(['parent_item_id' => $itemA->id, 'name' => 'Sub A1']);
+
+        $controller = $this->makeController($order);
+        $behavior = $controller->asExtension(RelationController::class);
+        $controller->initRelation($order, 'items');
+
+        // Item A's manage form is rendering; its sub-items field
+        // resolves ambiently against it.
+        $this->pushNestingStack($behavior, "items[{$itemA->id}]");
+        $controller->initRelation($itemA, 'items');
+
+        // The sub-item's own manage form is now rendering INSIDE Item
+        // A's, and a relation field within it resolves ambiently.
+        $this->pushNestingStack($behavior, "items[{$itemA->id}][items][{$subItem->id}]");
+
+        // Item A, not the sub-item: exactly what
+        // validateField() -> initRelation($this->model) passes here.
+        $controller->initRelation($itemA, 'taxes');
+
+        $this->popNestingStack($behavior);
+        $this->popNestingStack($behavior);
+
+        $this->assertEquals(
+            "items[{$itemA->id}][items][{$subItem->id}][taxes]",
+            $this->readProtectedProperty($behavior, 'nestedField'),
+            'Two levels of ambient nesting should qualify the field against the whole stack path'
+        );
+
+        $this->assertEquals(
+            $subItem->id,
+            $this->readProtectedProperty($behavior, 'model')->id,
+            'A field nested two levels deep must resolve against the innermost ancestor, not the enclosing record'
+        );
+    }
+
+    /**
      * Narrower test for relationMakePartial() specifically - confirms
      * it actually pushes before rendering and pops after, regardless
      * of whether the render call inside it succeeds (it has its own


### PR DESCRIPTION
Targets the `nested-relation-controller` branch, not `develop` — a follow-up to #1499 ([details in this comment](https://github.com/wintercms/winter/pull/1499#issuecomment-5427115730)).

## Problem

`resolveNestedContext()`'s ambient branch trusts the model passed to `initRelation()` as the relation's parent, per its docblock ("`$model` is trusted as-is - it's the widget's own bound model"). That model is `$this->model`, set from the **enclosing** relation, because the call arrives as `relationRender() → validateField() → initRelation($this->model)`.

At one level of nesting the enclosing record *is* the parent, so it works. At two it is the grandparent, and the leaf relation resolves against the wrong model:

```
BadMethodCallException: Call to undefined method Aic\Account\Models\Closet::closet()

#6 RelationController.php(450): Model->__call('closet', Array)
#7 RelationController.php(304): RelationController->initRelation(Object(Closet), 'closet')
#8 RelationController.php(931): RelationController->validateField('closet')
#9 RelationController->relationRender('closet')
```

Reproduced on a real three-level config (`Order → closets → paslatten → closet`), where the paslat form's own partial contains a single `$this->relationRender('closet')` — `closet` being a relation on `Paslatten`, not on `Closet`.

## Fix

Walk the ambient path's hops from the root, exactly as the reconstructed branch two lines below already does:

```diff
 if ($ambientPath !== null) {
     $this->nestedField = $ambientPath . '[' . $field . ']';
-    return [$model, $field, true];
+    [$hops] = $this->parseBracketField($this->nestedField);
+
+    return [$this->resolveModelForHops($this->rootModel, $hops), $field, true];
 }
```

Both cases now share one resolution mechanism, and the ambient path gains `resolveModelForHops()`'s `$relation->find($id)` parent check at every depth rather than only on reconstructed paths. The docblock is corrected to match.

## Tests

Adds `testAmbientFieldTwoLevelsDeepResolvesInnermostAncestorNotEnclosingRecord`, built on the branch's existing self-referencing `Item → items → Item` fixture. It fails without the change (resolves Item A instead of the sub-item) and passes with it.

- The branch's 22 existing nested tests pass unmodified — depth 2 resolves to the same model either way, which is also why the suite did not catch this.
- Full `modules/backend` suite run with and without the change, failures diffed: the only delta is the new test flipping to pass. (43 pre-existing errors in `UserTest`/`UserAuthorizationTest` in my environment, unrelated.)
- Verified in a browser afterwards: closet A's paslat renders closet A, closet B's renders closet B. Two-level create, update, delete and in-place list refresh all still behave.
