### PR TITLE
Harden per-item permission checks in the Settings controller

### DIFF
--- a/modules/system/controllers/Settings.php
+++ b/modules/system/controllers/Settings.php
@@ -238,6 +238,17 @@ class Settings extends Controller
             $item = $manager->findSettingItem($pluginOwner, $pluginCode);
         }
 
+        /*
+         * The manager drops items the user lacks permission for as it loads them, but that
+         * filtering is skipped when items are registered outside registerCallback() or when
+         * the item cache is warmed before authentication. This controller carries no
+         * $requiredPermissions of its own, so check the item here as well. Missing items and
+         * forbidden items are reported the same way, as the manager already does.
+         */
+        if ($item && !empty($item->permissions) && !$this->user?->hasAnyAccess((array) $item->permissions)) {
+            return false;
+        }
+
         return $item;
     }
 

--- a/modules/system/tests/controllers/SettingsSecurityTest.php
+++ b/modules/system/tests/controllers/SettingsSecurityTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace System\Tests\Controllers;
+
+use Backend\Models\User;
+use Backend\Models\UserRole;
+use System\Classes\SettingsManager;
+use System\Models\MailSetting;
+use System\Tests\Bootstrap\PluginTestCase;
+use Winter\Storm\Database\Model;
+use Winter\Storm\Support\Facades\Config;
+
+/**
+ * The Settings controller declares no $requiredPermissions, so a setting item's own
+ * `permissions` are the only thing protecting it. SettingsManager filters those items out as
+ * it loads them, but that filtering is skipped when items are registered directly on the
+ * manager instead of through registerCallback() -- loadItems() never runs, so nothing is
+ * filtered. findSettingItem() checks the item itself so the controller does not depend on the
+ * manager having taken that path.
+ */
+class SettingsSecurityTest extends PluginTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('cms.backendUri', 'backend');
+        Config::set('cms.enableCsrfProtection', false);
+
+        SettingsManager::forgetInstance();
+
+        // Settings models are cached both in a static instance map and in the query cache,
+        // and neither is reset between tests in the same process.
+        MailSetting::clearInternalCache();
+        \Cache::flush();
+    }
+
+    protected function makeUser(string $login, array $permissions): User
+    {
+        Model::unguard();
+        $role = UserRole::create([
+            'name' => $login,
+            'code' => $login,
+            'permissions' => $permissions,
+        ]);
+        $user = User::create([
+            'first_name' => ucfirst($login),
+            'last_name' => 'User',
+            'login' => $login,
+            'email' => "{$login}@test.test",
+            'password' => 'TestPassword1',
+            'password_confirmation' => 'TestPassword1',
+            'is_activated' => true,
+            'role_id' => $role->id,
+        ]);
+        Model::reguard();
+
+        return $user;
+    }
+
+    /** registerBackendSettings() is gated behind runningInBackend(), which is false here. */
+    protected function registerCoreSettingItems(): void
+    {
+        $provider = new \System\ServiceProvider($this->app);
+        $method = new \ReflectionMethod($provider, 'registerBackendSettings');
+        $method->setAccessible(true);
+        $method->invoke($provider);
+    }
+
+    /** Registered directly on the instance, so loadItems() -- and its filtering -- never runs. */
+    protected function registerUnfilteredSettingItem(): void
+    {
+        SettingsManager::instance()->registerSettingItems('Acme.Test', [
+            'protected' => [
+                'label' => 'Protected',
+                'class' => MailSetting::class,
+                'permissions' => ['system.manage_mail_settings'],
+            ],
+        ]);
+    }
+
+    protected function save(string $uri, string $address)
+    {
+        return $this->post('backend/system/settings/update/' . $uri, [
+            'MailSetting' => ['send_mode' => 'smtp', 'smtp_address' => $address],
+        ], [
+            'X-WINTER-REQUEST-HANDLER' => 'onSave',
+            'X-Requested-With' => 'XMLHttpRequest',
+        ]);
+    }
+
+    public function testAnUnfilteredItemIsRefusedWithoutItsPermission(): void
+    {
+        $this->registerUnfilteredSettingItem();
+        $this->actingAs($this->makeUser('peon', ['cms.manage_pages' => 1]));
+
+        $this->save('acme/test/protected', 'attacker.example.com');
+
+        MailSetting::clearInternalCache();
+        $this->assertNotEquals('attacker.example.com', MailSetting::instance()->smtp_address);
+    }
+
+    public function testAnUnfilteredItemIsServedToAUserHoldingItsPermission(): void
+    {
+        $this->registerUnfilteredSettingItem();
+        $this->actingAs($this->makeUser('mailadmin', ['system.manage_mail_settings' => 1]));
+
+        $response = $this->save('acme/test/protected', 'legit.example.com');
+
+        $this->assertEquals(200, $response->getStatusCode());
+        MailSetting::clearInternalCache();
+        $this->assertEquals('legit.example.com', MailSetting::instance()->smtp_address);
+    }
+
+    /** Nothing legitimate regressed on the normal registerCallback() path. */
+    public function testCoreMailSettingsStillSaveForAPermittedUser(): void
+    {
+        $this->registerCoreSettingItems();
+        $this->actingAs($this->makeUser('mailadmin2', ['system.manage_mail_settings' => 1]));
+
+        $response = $this->save('winter/system/mail_settings', 'legit.example.com');
+
+        $this->assertEquals(200, $response->getStatusCode());
+        MailSetting::clearInternalCache();
+        $this->assertEquals('legit.example.com', MailSetting::instance()->smtp_address);
+    }
+
+    public function testCoreMailSettingsAreRefusedForAnUnprivilegedUser(): void
+    {
+        $this->registerCoreSettingItems();
+        $this->actingAs($this->makeUser('peon2', ['cms.manage_pages' => 1]));
+
+        $this->save('winter/system/mail_settings', 'attacker.example.com');
+
+        MailSetting::clearInternalCache();
+        $this->assertNotEquals('attacker.example.com', MailSetting::instance()->smtp_address);
+    }
+}


### PR DESCRIPTION
`System\Controllers\Settings` declares no `$requiredPermissions`, so a setting item's own `permissions` are the only thing gating it. Those are enforced solely by `SettingsManager::loadItems()`, which filters the shared item cache that `findSettingItem()` reads — so the gate does hold on every path that ships today.

It fails open in two situations:

- `filterItemPermissions()` returns the list untouched when `$user` is null, so anything that warms the item cache before authentication caches the unfiltered set for the rest of the request.
- `registerSettingItems()` sets `$this->items = []` when it is falsy, so calling it directly on the manager rather than inside `registerCallback()` leaves `$this->items` non-null and `loadItems()` never runs — nothing is filtered at all.

Neither is reachable from core or from any first-party plugin I checked, so this is hardening rather than a fix for a live issue.

It came out of triaging GHSA-8ffc-66jg-44wc, which reported the Settings write path as writable by any backend user. That report did not reproduce — `loadItems()` reassigns `$this->items` with the filtered result, and `findSettingItem()` reads that same cache — but the controller shouldn't depend on the manager having taken that path.

## Changes

`findSettingItem()` now checks the item's own permissions, returning `false` for a forbidden item exactly as the manager already does for a missing one, so no new error shape is introduced. It covers `update()`, `update_onSave()`, `update_onTest()`, `update_onResetDefault()` and `formGetWidget()`, which all resolve their item through it.

## Tests

`modules/system/tests/controllers/SettingsSecurityTest.php`:

- a directly-registered item declaring a permission the user lacks is refused — fails without this change, where the item resolves and saves with HTTP 200
- the same item is still served to a user who does hold the permission
- core Mail Settings still save on the normal `registerCallback()` path for a permitted user
- core Mail Settings are still refused for an unprivileged user

The pre-existing `ViteCompileTest`, `MixCompileTest` and `ViewMakerTest` failures in `modules/system` are unrelated — they fail identically with this change reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
