### PR TITLE
Harden phpcs utilities: escape filenames instead of only spaces

### DIFF
--- a/.github/workflows/utilities/phpcs-pr
+++ b/.github/workflows/utilities/phpcs-pr
@@ -16,18 +16,18 @@ if (empty($argv[1])) {
 $fileList = shell_exec('git diff --name-only --diff-filter=ACMR origin/' . $argv[1] . ' HEAD');
 $files = array_filter(explode("\n", $fileList));
 
-foreach ($files as &$file) {
-    if (strpos($file, ' ') !== false) {
-        $file = str_replace(' ', '\\ ', $file);
-    }
-}
-
 // no changes found in diff, early exit
 if (!count($files)) {
     fwrite(STDOUT, "\e[0;32mFound no changed files.\e[0m");
     fwrite(STDOUT, "\n");
     exit(0);
 }
+
+// Prefix each path with ./ so a filename beginning with '-' cannot be parsed
+// as a PHPCS option, then escape it for safe shell usage.
+$files = array_map(function ($file) {
+    return escapeshellarg('./' . $file);
+}, $files);
 
 // Run all changed files through the PHPCS code sniffer and generate a CSV report
 $csv = shell_exec('phpcs --colors -nq --report="csv" --extensions="php" ' . implode(' ', $files));

--- a/.github/workflows/utilities/phpcs-push
+++ b/.github/workflows/utilities/phpcs-push
@@ -16,18 +16,18 @@ if (empty($argv[1])) {
 $fileList = shell_exec('git show --name-only --pretty="" --diff-filter=ACMR ' . $argv[1]);
 $files = array_filter(explode("\n", $fileList));
 
-foreach ($files as &$file) {
-    if (strpos($file, ' ') !== false) {
-        $file = str_replace(' ', '\\ ', $file);
-    }
-}
-
 // no changes found in diff, early exit
 if (!count($files)) {
     fwrite(STDOUT, "\e[0;32mFound no changed files.\e[0m");
     fwrite(STDOUT, "\n");
     exit(0);
 }
+
+// Prefix each path with ./ so a filename beginning with '-' cannot be parsed
+// as a PHPCS option, then escape it for safe shell usage.
+$files = array_map(function ($file) {
+    return escapeshellarg('./' . $file);
+}, $files);
 
 // Run all changed files through the PHPCS code sniffer and generate a CSV report
 $csv = shell_exec('phpcs --colors -nq --report="csv" --extensions="php" ' . implode(' ', $files));
@@ -69,7 +69,7 @@ fwrite(STDERR, "\e[0;31mFound "
         ? '1 issue'
         : count($lines) . ' issues')
     . " with code quality.\e[0m");
-fwrite(STDERR,  "\n");
+fwrite(STDERR, "\n");
 
 foreach ($files as $file => $errors) {
     fwrite(STDERR, "\n");
@@ -84,4 +84,3 @@ foreach ($files as $file => $errors) {
     }
 }
 exit(1);
-


### PR DESCRIPTION
## What
The `phpcs-pr`/`phpcs-push` helpers in `.github/workflows/utilities/` built the PHPCS command by concatenating changed filenames with only *spaces* backslash-escaped. Any other shell metacharacter in a crafted filename could therefore be interpreted by the shell (`shell_exec`).

## Change
Pass each path through `escapeshellarg()` when assembling the command, and drop the now-redundant manual space-escaping loop. The existing empty-diff early-exit is unchanged.

These helpers are copied into Storm and many plugins; this fixes the canonical source. (The same change has been synced to Storm and the Winter plugins that carry a copy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated code-quality checks when no files have changed.
  * Improved handling of file paths containing spaces, special characters, or leading hyphens.
  * Prevented file names from being misinterpreted as command-line options during validation.
  * Streamlined pull request and push validation workflows by avoiding unnecessary processing when there are no changed files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->