### PR TITLE
Fix unreachable numberrange case in the filter widget

### DIFF
--- a/modules/backend/widgets/Filter.php
+++ b/modules/backend/widgets/Filter.php
@@ -153,29 +153,26 @@ class Filter extends WidgetBase
                 if ($step = array_get($scope->config, 'step')) {
                     $params['step'] = is_numeric($step) ? $step : null;
                 }
-                // no break, these paramaters apply to both of the following cases
 
-            case 'number':
-                if (is_numeric($scope->value)) {
-                    $params['number'] = $scope->value;
+                // The parameters above apply to both types, the ones below do not
+                if ($scope->type === 'numberrange') {
+                    if (
+                        $scope->value
+                        && (is_array($scope->value) && count($scope->value) === 2)
+                        && (isset($scope->value[0]) || isset($scope->value[1]))
+                    ) {
+                        $min = $scope->value[0];
+                        $max = $scope->value[1];
+
+                        $params['minStr'] = $min ?? '-∞';
+                        $params['min'] = $min ?? null;
+
+                        $params['maxStr'] = $max ?? '∞';
+                        $params['max'] = $max ?? null;
+                    }
                 }
-
-                break;
-
-            case 'numberrange':
-                if (
-                    $scope->value
-                    && (is_array($scope->value) && count($scope->value) === 2)
-                    && (isset($scope->value[0]) || isset($scope->value[1]))
-                ) {
-                    $min = $scope->value[0];
-                    $max = $scope->value[1];
-
-                    $params['minStr'] = $min ?? '-∞';
-                    $params['min'] = $min ?? null;
-
-                    $params['maxStr'] = $max ?? '∞';
-                    $params['max'] = $max ?? null;
+                elseif (is_numeric($scope->value)) {
+                    $params['number'] = $scope->value;
                 }
 
                 break;


### PR DESCRIPTION
`renderScopeElement` repeats `case 'number'` and `case 'numberrange'` inside one switch: once as a pair at the top of the shared min/max/step block, and once each below it. PHP jumps to the first label that matches, so the two lower ones are never entered on their own. A `numberrange` scope enters at the top pair, runs the shared block, falls through into the `case 'number'` body and breaks there, so `minStr`, `min`, `maxStr` and `max` never reach the partial and the range inputs render without their values.

The `// no break` comment shows the intent was a fallthrough into a per-type block, which is what a switch cannot do when the label is already above. I turned the two lower cases into a branch on `$scope->type` inside the shared block, so the shared parameters still apply to both and each type keeps its own half.

`number` scopes behave the same before and after: they used to reach that body by fallthrough, now they reach it through the `elseif`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering for numeric values.
  * Numeric filters now use the entered number correctly, while numeric range filters continue to support minimum and maximum values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->