### PR TITLE
Read record navigation keys without the list's display columns

### DIFF
--- a/modules/backend/behaviors/FormController.php
+++ b/modules/backend/behaviors/FormController.php
@@ -687,11 +687,11 @@ class FormController extends ControllerBehavior
      * Resolves the position of the current record within the controller's list
      * and the neighboring record keys used for previous/next navigation.
      *
-     * The sibling set comes from the ListController's prepared query, so it
+     * The sibling set comes from the ListController's list widget, so it
      * reflects the active filters, search and sorting exactly as the user left
-     * the list. Ordered keys are read with a single portable `pluck` and the
-     * position is resolved in PHP — no driver-specific SQL — so it behaves
-     * identically across every database Winter supports.
+     * the list. Ordered keys are read with a single portable, key-only query
+     * and the position is resolved in PHP — no driver-specific SQL — so it
+     * behaves identically across every database Winter supports.
      *
      * @param \Winter\Storm\Database\Model|null $model
      * @return array{previous: mixed, next: mixed, current: int|null, total: int}|null
@@ -717,9 +717,7 @@ class FormController extends ControllerBehavior
             return null;
         }
 
-        $keys = $listWidget->prepareQuery()->pluck($model->getQualifiedKeyName())->all();
-
-        return static::resolveRecordPosition($keys, $model->getKey());
+        return static::resolveRecordPosition($listWidget->getRecordKeys(), $model->getKey());
     }
 
     /**

--- a/modules/backend/tests/widgets/ListsTest.php
+++ b/modules/backend/tests/widgets/ListsTest.php
@@ -2,6 +2,7 @@
 
 namespace Backend\Tests\Widgets;
 
+use Db;
 use System\Tests\Bootstrap\PluginTestCase;
 use Winter\Storm\Exception\ApplicationException;
 use Backend\Tests\Fixtures\Models\UserFixture;
@@ -118,6 +119,60 @@ class ListsTest extends PluginTestCase
 
         $this->assertNotNull($list->getColumn('id'));
         $this->assertNotNull($list->getColumn('email'));
+    }
+
+    public function testRecordKeysAreReadWithoutTheDisplayColumns()
+    {
+        $this->actingAs((new UserFixture)->asSuperUser());
+
+        $sql = $this->recordKeysQuery(['column' => 'id', 'direction' => 'desc']);
+        $key = Db::connection()->getQueryGrammar()->wrap((new User)->getQualifiedKeyName());
+
+        $this->assertStringStartsWith('select ' . $key . ' from', $sql);
+        $this->assertStringNotContainsString('groups_count', $sql);
+    }
+
+    public function testRecordKeysKeepTheDisplayColumnsTheSortResolvesAgainst()
+    {
+        $this->actingAs((new UserFixture)->asSuperUser());
+
+        $sql = $this->recordKeysQuery(['column' => 'groups', 'direction' => 'desc']);
+
+        $this->assertStringContainsString('groups_count', $sql);
+    }
+
+    /**
+     * Returns the SQL of the query Lists::getRecordKeys() runs for the given sort.
+     */
+    protected function recordKeysQuery(array $defaultSort): string
+    {
+        $list = new Lists(null, [
+            'model' => new User,
+            'arrayName' => 'array',
+            'defaultSort' => $defaultSort,
+            'columns' => [
+                'id' => [
+                    'type' => 'text',
+                    'label' => 'ID',
+                    'sortable' => true
+                ],
+                'groups' => [
+                    'label' => 'Groups',
+                    'relation' => 'groups',
+                    'useRelationCount' => true,
+                    'sortable' => true
+                ]
+            ]
+        ]);
+
+        $sql = '';
+        Db::listen(function ($query) use (&$sql) {
+            $sql = $query->sql;
+        });
+
+        $list->getRecordKeys();
+
+        return $sql;
     }
 
     protected function restrictedListsFixture(bool $singlePermission = false)

--- a/modules/backend/widgets/Lists.php
+++ b/modules/backend/widgets/Lists.php
@@ -734,6 +734,51 @@ class Lists extends WidgetBase
     }
 
     /**
+     * Returns the primary key of every record in the list, in the list's current
+     * order, honouring the active search, filters and sorting.
+     *
+     * Only the key is read: `prepareQuery()` selects every visible column, so on
+     * a list carrying `useRelationCount` or custom `select:` columns each row
+     * would evaluate a correlated subquery whose value is then thrown away. The
+     * select list is reduced to the key unless the active sort resolves against
+     * one of its aliases, since ORDER BY relies on those being selected.
+     *
+     * @return array<int, mixed>
+     */
+    public function getRecordKeys(): array
+    {
+        $query = $this->prepareQuery();
+        $keyName = $this->model->getQualifiedKeyName();
+
+        if (!$this->sortsBySelectedExpression()) {
+            $baseQuery = $query->getQuery();
+            $baseQuery->columns = [$keyName];
+
+            // The select bindings belong to the expressions just discarded.
+            $baseQuery->bindings['select'] = [];
+        }
+
+        return $query->pluck($keyName)->all();
+    }
+
+    /**
+     * Determines whether the active sort refers to a column that exists only as
+     * an alias in the select list, which is the case for columns using
+     * `select:` or `useRelationCount`, as well as related columns sorted by
+     * `valueFrom`.
+     */
+    protected function sortsBySelectedExpression(): bool
+    {
+        if ($this->showTree || !($sortColumn = $this->getSortColumn())) {
+            return false;
+        }
+
+        $column = array_get($this->allColumns, $sortColumn);
+
+        return $column && (isset($column->sqlSelect) || isset($column->relation));
+    }
+
+    /**
      * Calculate the totals for the summable columns
      */
     protected function calculateTotalSums(array $columns): array


### PR DESCRIPTION
`FormController::formGetRecordNavigation()` reads the sibling key set from the list's display query:

```php
$keys = $listWidget->prepareQuery()->pluck($model->getQualifiedKeyName())->all();
```

`prepareQuery()` selects `<table>.*` plus one correlated subquery for every `useRelationCount` column and every custom `select:` column, and `Query\Builder::pluck()` only supplies a column list when none is set (`onceWithColumns()` keeps an existing `$columns`). Every one of those expressions is therefore evaluated for every row in the list, and every value is then discarded — the navigation needs nothing but the keys.

On a production backend whose user list carries ten `useRelationCount` columns over 67k users, that is ~670k correlated `count(*)` executions plus a full-row fetch of the table, on every `update`/`preview` page load. Measured against a copy of that database:

| query the navigation runs | cost |
| --- | --- |
| `select users.*, <10 count subqueries> from users order by name desc` | **6,725 ms** + ~37 MB of rows |
| `select users.id from users order by name desc` | **234 ms** |

TTFB for `winter/user/users/preview/<id>` was 17-31 s, and identical for every record — the cost is the size of the list, not the record. Every other page in that backend, including a form page carrying eight relation widgets, renders in 0.4-3.2 s.

### Fix

`Lists::getRecordKeys()` returns the ordered keys with the select list reduced to the key column, and `FormController` calls that instead of plucking from the display query.

Those selects can only be dropped when the active sort does not resolve against one of their aliases: `useRelationCount` columns sort by `<relation>_count` and `select:` columns sort by the column alias, and both have to stay selected for `ORDER BY` to resolve. Lists sorted that way keep the full select list and behave exactly as before. The select bindings are cleared along with the expressions they belong to.

Nothing else changes — same order, same search, same filters, same position math.

### Testing

`ListsTest` covers both branches: the select list is reduced to the key when the sort does not need the display columns, and preserved when it does. Forcing the old behaviour fails the first test with the full display query, so it holds the regression.

Verified end to end on the affected site as well: the navigation now issues `select users.id from users order by name desc`, and still reports the correct position.

Introduced in #1510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Record navigation now consistently follows the active list order when moving between records.
  - List ordering based on related-record counts remains accurate during navigation.

- **Performance**
  - Record navigation retrieves only the data needed to identify records when possible, reducing unnecessary list-query work and improving responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->