### PR TITLE
Stop a nested form filling the model with its own fields

### DIFF
--- a/modules/backend/formwidgets/FieldSet.php
+++ b/modules/backend/formwidgets/FieldSet.php
@@ -48,16 +48,19 @@ class FieldSet extends FormWidgetBase
             $this->previewMode = true;
         }
 
+        $parentForm = $this->getParentForm();
+
         $config = $this->makeConfig(['fields' => $this->fields]);
         $config->model = $this->model;
         $config->data = $this->getLoadValue();
         $config->alias = $this->alias . $this->defaultAlias;
         // set arrayName from parent form to save fields to the model
-        $config->arrayName = $this->getParentForm()->arrayName;
-        // the fields are nested visually only; they resolve against the parent
-        // form's model and array name, exactly as if defined on the parent form
+        $config->arrayName = $parentForm->arrayName;
         $config->isNested = true;
-        $config->sharesParentScope = true;
+        // the fields are grouped visually only, so they resolve wherever the parent
+        // form's own fields resolve - on the model, unless the parent is itself a
+        // nested form that brought its own data scope (ie. a repeater item)
+        $config->sharesModelScope = !$parentForm->isNested || $parentForm->sharesModelScope;
 
         $widget = $this->formWidget = $this->makeWidget(Form::class, $config);
         $widget->previewMode = $this->previewMode;

--- a/modules/backend/formwidgets/FieldSet.php
+++ b/modules/backend/formwidgets/FieldSet.php
@@ -54,7 +54,10 @@ class FieldSet extends FormWidgetBase
         $config->alias = $this->alias . $this->defaultAlias;
         // set arrayName from parent form to save fields to the model
         $config->arrayName = $this->getParentForm()->arrayName;
+        // the fields are nested visually only; they resolve against the parent
+        // form's model and array name, exactly as if defined on the parent form
         $config->isNested = true;
+        $config->sharesParentScope = true;
 
         $widget = $this->formWidget = $this->makeWidget(Form::class, $config);
         $widget->previewMode = $this->previewMode;

--- a/modules/backend/tests/widgets/FormFieldSetScopeTest.php
+++ b/modules/backend/tests/widgets/FormFieldSetScopeTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Backend\Tests\Widgets
+{
+    use Backend\Classes\Controller;
+    use Backend\Classes\WidgetManager;
+    use Backend\FormWidgets\FieldSet;
+    use Backend\FormWidgets\NestedForm;
+    use Backend\Widgets\Form;
+    use System\Tests\Bootstrap\PluginTestCase;
+    use Winter\Storm\Database\Model;
+    use Winter\Storm\Database\Traits\Validation;
+
+    class FormFieldSetScopeTestModel extends Model
+    {
+        use Validation;
+
+        public $table = 'form_fieldset_scope_test';
+
+        public $rules = [
+            // Resolved as-is by a scope sharing form (fieldset)...
+            'nested_text' => 'required',
+            // ...and prefixed with the nested form's own scope by a regular nested form.
+            'meta.title' => 'required',
+        ];
+    }
+
+    /**
+     * Covers the data scope of the `fieldset` form widget's inner form.
+     *
+     * A fieldset nests fields visually only: its inner form reuses the parent form's
+     * model and arrayName, and its save data is merged back up as if the fields had
+     * been declared on the parent form. It is therefore flagged as sharing the parent's
+     * scope, while remaining flagged as nested so that code extending form widgets can
+     * still tell it apart from the form it is nested in.
+     */
+    class FormFieldSetScopeTest extends PluginTestCase
+    {
+        public function setUp(): void
+        {
+            parent::setUp();
+
+            // The backend module's form widgets are not auto-registered under PluginTestCase.
+            WidgetManager::instance()->registerFormWidget(FieldSet::class, 'fieldset');
+            WidgetManager::instance()->registerFormWidget(NestedForm::class, 'nestedform');
+        }
+
+        protected function makeForm(): Form
+        {
+            return new Form(new Controller, [
+                'model' => new FormFieldSetScopeTestModel,
+                'arrayName' => 'array',
+                'fields' => [
+                    'group' => [
+                        'type' => 'fieldset',
+                        'label' => 'Grouped Fields',
+                        'fields' => [
+                            'nested_text' => ['type' => 'text'],
+                            'nested_other' => ['type' => 'text'],
+                        ],
+                    ],
+                    'meta' => [
+                        'type' => 'nestedform',
+                        'form' => [
+                            'fields' => [
+                                'title' => ['type' => 'text'],
+                                'subtitle' => ['type' => 'text'],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+        }
+
+        public function testFieldSetInnerFormIsStillFlaggedAsNested()
+        {
+            // Extending code uses isNested to avoid injecting fields on the wrong Form
+            // widget instance; a fieldset shares its parent's model and controller, so
+            // the flag must stay set or those guards would no longer hold.
+            $this->assertTrue($this->getInnerForm('group', FieldSet::class)->isNested);
+        }
+
+        public function testFieldSetInnerFormSharesTheParentScope()
+        {
+            $this->assertTrue($this->getInnerForm('group', FieldSet::class)->sharesParentScope);
+        }
+
+        public function testFormsDoNotShareTheParentScopeByDefault()
+        {
+            $this->assertFalse($this->makeForm()->sharesParentScope);
+            $this->assertFalse($this->getInnerForm('meta', NestedForm::class)->sharesParentScope);
+        }
+
+        public function testFieldSetFieldsResolveRequiredAgainstTheModelAttribute()
+        {
+            $inner = $this->getInnerForm('group', FieldSet::class);
+            $inner->getFields();
+
+            // The rule is defined as "nested_text", not ".nested_text": a scope sharing
+            // form must not prefix the attribute name with its (inherited) arrayName.
+            $this->assertTrue($inner->getField('nested_text')->required);
+            $this->assertFalse($inner->getField('nested_other')->required);
+        }
+
+        public function testNestedFormFieldsStillResolveRequiredAgainstTheNestedAttribute()
+        {
+            $inner = $this->getInnerForm('meta', NestedForm::class);
+            $inner->getFields();
+
+            // A regular nested form owns its data scope, so the attribute name is still
+            // prefixed with it: the rule is defined as "meta.title".
+            $this->assertTrue($inner->getField('title')->required);
+            $this->assertFalse($inner->getField('subtitle')->required);
+        }
+
+        protected function getInnerForm(string $field, string $widgetClass): Form
+        {
+            $form = $this->makeForm();
+
+            // Defining the parent's fields builds and caches its nested form widgets.
+            $form->bindToController();
+
+            $widget = $form->getFormWidget($field);
+            $this->assertInstanceOf($widgetClass, $widget);
+
+            $inner = \Closure::bind(fn () => $this->formWidget, $widget, $widgetClass)();
+            $this->assertInstanceOf(Form::class, $inner);
+
+            return $inner;
+        }
+    }
+}

--- a/modules/backend/tests/widgets/FormFieldSetScopeTest.php
+++ b/modules/backend/tests/widgets/FormFieldSetScopeTest.php
@@ -6,6 +6,7 @@ namespace Backend\Tests\Widgets
     use Backend\Classes\WidgetManager;
     use Backend\FormWidgets\FieldSet;
     use Backend\FormWidgets\NestedForm;
+    use Backend\FormWidgets\Repeater;
     use Backend\Widgets\Form;
     use System\Tests\Bootstrap\PluginTestCase;
     use Winter\Storm\Database\Model;
@@ -17,22 +18,28 @@ namespace Backend\Tests\Widgets
 
         public $table = 'form_fieldset_scope_test';
 
+        protected $jsonable = ['items'];
+
         public $rules = [
-            // Resolved as-is by a scope sharing form (fieldset)...
+            // Resolved as-is by a form that brings no data scope of its own (fieldset)...
             'nested_text' => 'required',
-            // ...and prefixed with the nested form's own scope by a regular nested form.
+            // ...and prefixed with its own scope by a form that does.
             'meta.title' => 'required',
+            'items.*.title' => 'required',
         ];
     }
 
     /**
      * Covers the data scope of the `fieldset` form widget's inner form.
      *
-     * A fieldset nests fields visually only: its inner form reuses the parent form's
-     * model and arrayName, and its save data is merged back up as if the fields had
-     * been declared on the parent form. It is therefore flagged as sharing the parent's
-     * scope, while remaining flagged as nested so that code extending form widgets can
-     * still tell it apart from the form it is nested in.
+     * A fieldset groups fields visually only: its inner form reuses the parent form's
+     * model and arrayName, and its save data is merged back up as if the fields had been
+     * declared on the parent form. It is therefore flagged as sharing the model's scope,
+     * while remaining flagged as nested so that code extending form widgets can still
+     * tell it apart from the form it is nested in.
+     *
+     * The scope it inherits is only the model's when the parent form's own is: nested
+     * inside a repeater item, a fieldset's fields still belong to the repeater's data.
      */
     class FormFieldSetScopeTest extends PluginTestCase
     {
@@ -43,12 +50,16 @@ namespace Backend\Tests\Widgets
             // The backend module's form widgets are not auto-registered under PluginTestCase.
             WidgetManager::instance()->registerFormWidget(FieldSet::class, 'fieldset');
             WidgetManager::instance()->registerFormWidget(NestedForm::class, 'nestedform');
+            WidgetManager::instance()->registerFormWidget(Repeater::class, 'repeater');
         }
 
         protected function makeForm(): Form
         {
+            $model = new FormFieldSetScopeTestModel;
+            $model->items = [['title' => 'first']];
+
             return new Form(new Controller, [
-                'model' => new FormFieldSetScopeTestModel,
+                'model' => $model,
                 'arrayName' => 'array',
                 'fields' => [
                     'group' => [
@@ -68,6 +79,20 @@ namespace Backend\Tests\Widgets
                             ],
                         ],
                     ],
+                    'items' => [
+                        'type' => 'repeater',
+                        'form' => [
+                            'fields' => [
+                                'group' => [
+                                    'type' => 'fieldset',
+                                    'fields' => [
+                                        'title' => ['type' => 'text'],
+                                        'subtitle' => ['type' => 'text'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
                 ],
             ]);
         }
@@ -77,46 +102,76 @@ namespace Backend\Tests\Widgets
             // Extending code uses isNested to avoid injecting fields on the wrong Form
             // widget instance; a fieldset shares its parent's model and controller, so
             // the flag must stay set or those guards would no longer hold.
-            $this->assertTrue($this->getInnerForm('group', FieldSet::class)->isNested);
+            $this->assertTrue($this->getFieldSetForm()->isNested);
         }
 
-        public function testFieldSetInnerFormSharesTheParentScope()
+        public function testFieldSetInnerFormSharesTheModelScope()
         {
-            $this->assertTrue($this->getInnerForm('group', FieldSet::class)->sharesParentScope);
+            $this->assertTrue($this->getFieldSetForm()->sharesModelScope);
         }
 
-        public function testFormsDoNotShareTheParentScopeByDefault()
+        public function testFormsDoNotShareTheModelScopeByDefault()
         {
-            $this->assertFalse($this->makeForm()->sharesParentScope);
-            $this->assertFalse($this->getInnerForm('meta', NestedForm::class)->sharesParentScope);
+            $this->assertFalse($this->makeForm()->sharesModelScope);
+            $this->assertFalse($this->getInnerForm($this->makeForm(), 'meta', NestedForm::class)->sharesModelScope);
         }
 
         public function testFieldSetFieldsResolveRequiredAgainstTheModelAttribute()
         {
-            $inner = $this->getInnerForm('group', FieldSet::class);
+            $inner = $this->getFieldSetForm();
             $inner->getFields();
 
-            // The rule is defined as "nested_text", not ".nested_text": a scope sharing
-            // form must not prefix the attribute name with its (inherited) arrayName.
+            // The rule is defined as "nested_text", not ".nested_text": a fieldset brings
+            // no scope of its own, so there is nothing to prefix the attribute name with.
             $this->assertTrue($inner->getField('nested_text')->required);
             $this->assertFalse($inner->getField('nested_other')->required);
         }
 
         public function testNestedFormFieldsStillResolveRequiredAgainstTheNestedAttribute()
         {
-            $inner = $this->getInnerForm('meta', NestedForm::class);
+            $inner = $this->getInnerForm($this->makeForm(), 'meta', NestedForm::class);
             $inner->getFields();
 
-            // A regular nested form owns its data scope, so the attribute name is still
-            // prefixed with it: the rule is defined as "meta.title".
+            // A nested form owns its data scope, so the attribute name is still prefixed
+            // with it: the rule is defined as "meta.title".
             $this->assertTrue($inner->getField('title')->required);
             $this->assertFalse($inner->getField('subtitle')->required);
         }
 
-        protected function getInnerForm(string $field, string $widgetClass): Form
+        public function testFieldSetInsideARepeaterKeepsTheRepeaterItemScope()
+        {
+            $inner = $this->getInnerForm($this->getRepeaterItemForm(), 'group', FieldSet::class);
+            $inner->getFields();
+
+            // The fieldset inherits the repeater item's array name, so its fields belong
+            // to the repeater's data, not to the model's attributes. The rule is defined
+            // as "items.*.title" and the inherited scope must still be applied.
+            $this->assertFalse($inner->sharesModelScope);
+            $this->assertTrue($inner->getField('title')->required);
+            $this->assertFalse($inner->getField('subtitle')->required);
+        }
+
+        protected function getFieldSetForm(): Form
+        {
+            return $this->getInnerForm($this->makeForm(), 'group', FieldSet::class);
+        }
+
+        protected function getRepeaterItemForm(): Form
         {
             $form = $this->makeForm();
+            $form->bindToController();
 
+            $repeater = $form->getFormWidget('items');
+            $this->assertInstanceOf(Repeater::class, $repeater);
+
+            $itemForms = \Closure::bind(fn () => $this->formWidgets, $repeater, Repeater::class)();
+            $this->assertArrayHasKey(0, $itemForms);
+
+            return $itemForms[0];
+        }
+
+        protected function getInnerForm(Form $form, string $field, string $widgetClass): Form
+        {
             // Defining the parent's fields builds and caches its nested form widgets.
             $form->bindToController();
 

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -74,6 +74,15 @@ class Form extends WidgetBase
      */
     public $isNested = false;
 
+    /**
+     * @var bool Used to flag that this nested form shares the data scope of its parent
+     * form; ie. its fields resolve against the same model attributes and array name as
+     * if they had been defined on the parent form directly. Only relevant when
+     * $isNested is true. Used by the fieldset form widget, which nests fields visually
+     * without introducing a new data scope.
+     */
+    public $sharesParentScope = false;
+
     //
     // Object properties
     //
@@ -138,6 +147,7 @@ class Form extends WidgetBase
             'context',
             'arrayName',
             'isNested',
+            'sharesParentScope',
         ]);
 
         $this->widgetManager = WidgetManager::instance();
@@ -881,8 +891,9 @@ class Form extends WidgetBase
          * Check model if field is required
          */
         if ($field->required === null && $this->model && method_exists($this->model, 'isAttributeRequired')) {
-            // Check nested fields
-            if ($this->isNested) {
+            // Check nested fields, unless the nested form shares its parent's data
+            // scope, in which case the attribute name needs no prefixing
+            if ($this->isNested && !$this->sharesParentScope) {
                 // Get the current attribute level
                 $nameArray = HtmlHelper::nameToArray($this->arrayName);
                 unset($nameArray[0]);

--- a/modules/backend/widgets/Form.php
+++ b/modules/backend/widgets/Form.php
@@ -75,13 +75,14 @@ class Form extends WidgetBase
     public $isNested = false;
 
     /**
-     * @var bool Used to flag that this nested form shares the data scope of its parent
-     * form; ie. its fields resolve against the same model attributes and array name as
-     * if they had been defined on the parent form directly. Only relevant when
-     * $isNested is true. Used by the fieldset form widget, which nests fields visually
-     * without introducing a new data scope.
+     * @var bool Used to flag that this nested form introduces no data scope of its own,
+     * so that its fields resolve against the model's own attributes exactly as if they
+     * had been defined on the form it is nested in. Only meaningful when $isNested is
+     * true. Set by the fieldset form widget, which groups fields visually; a fieldset
+     * nested inside a repeater or nested form leaves this false, since the scope it
+     * inherits there is that form's data rather than the model's attributes.
      */
-    public $sharesParentScope = false;
+    public $sharesModelScope = false;
 
     //
     // Object properties
@@ -147,7 +148,7 @@ class Form extends WidgetBase
             'context',
             'arrayName',
             'isNested',
-            'sharesParentScope',
+            'sharesModelScope',
         ]);
 
         $this->widgetManager = WidgetManager::instance();
@@ -891,9 +892,8 @@ class Form extends WidgetBase
          * Check model if field is required
          */
         if ($field->required === null && $this->model && method_exists($this->model, 'isAttributeRequired')) {
-            // Check nested fields, unless the nested form shares its parent's data
-            // scope, in which case the attribute name needs no prefixing
-            if ($this->isNested && !$this->sharesParentScope) {
+            // Check nested fields
+            if ($this->isNested) {
                 // Get the current attribute level
                 $nameArray = HtmlHelper::nameToArray($this->arrayName);
                 unset($nameArray[0]);
@@ -905,8 +905,12 @@ class Form extends WidgetBase
                     }
                 }
 
-                // Recombine names for full attribute name in rules array
-                $attrName = implode('.', $nameArray) . ".{$attrName}";
+                // Recombine names for full attribute name in rules array. A nested form
+                // that introduces no data scope of its own (ie. the fieldset widget, which
+                // inherits its parent's array name) leaves nothing to prefix with.
+                if ($prefix = implode('.', $nameArray)) {
+                    $attrName = "{$prefix}.{$attrName}";
+                }
             }
 
             $field->required = $this->model->isAttributeRequired($attrName);


### PR DESCRIPTION
Builds on #1529 — that PR adds the `Form::$sharesModelScope` discriminator this one guards with, so the diff below includes it. Happy to rebase once #1529 lands, or to fold this into it if you'd rather have one PR.

### The problem

`Form::setFormValues()` fills the model as if the form were about to be saved, so the fields resolve against it:

```php
$this->prepareModelsToSave($this->model, $data);
```

A repeater item form and a nested form are handed the *parent* form's model to render against (`Repeater::makeItemFormWidget()`, `NestedForm::init()`), but their fields are keys of their own data scope, not attributes of that model. Filling it from there writes foreign values onto the record whenever an item field shares its name with a model attribute — and `type`, `name`, `title`, `status` are exactly the names repeater groups tend to use.

For a plain attribute it goes unnoticed, since nothing saves the model during a refresh. For a cast attribute it fails outright:

```yaml
# a model with an enum-cast `status`, and a repeater whose items have their own
status:
    type: text
items:
    type: repeater
    form:
        fields:
            status:
                type: balloon-selector
                options:
                    featured: Featured
                    plain: Plain
```

Refreshing the repeater (or switching/copying items, which is where we hit it) throws:

```
ValueError: "featured" is not a valid backing value for enum ...
```

The value never belonged to the model — it was only ever the item's.

### The fix

```php
if (!$this->isNested || $this->sharesModelScope) {
    $this->prepareModelsToSave($this->model, $data);
}
```

`isNested` is set in exactly three places in core: `Repeater`, `NestedForm` and `FieldSet`. The first two bring a data scope of their own and must not touch the model; a fieldset groups fields visually and its fields really are the model's attributes, which is what `$sharesModelScope` already flags. Top-level forms are unaffected, so `RelationController` and settings forms keep filling the model as before.

### Tests

`modules/backend/tests/widgets/FormNestedModelScopeTest.php` puts a field named `status` on the model, on a fieldset, on a nested form and in a repeater group, and asserts which of the four are allowed to reach the model's attribute. The two nested cases throw the `ValueError` above without the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fieldset fields now correctly use the parent model’s data scope when appropriate.
  - Nested forms and repeater items preserve their own data scopes, preventing values from being written to unrelated model attributes.
  - Required-field validation now resolves attribute paths correctly across fieldsets, nested forms, and repeater items.
  - Form value population now leaves parent model attributes unchanged when values belong to an independently scoped nested form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->